### PR TITLE
Fix to ensure connections are closed when updating password through the recovery process

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/store/JDBCRecoveryDataStore.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/store/JDBCRecoveryDataStore.java
@@ -167,6 +167,7 @@ public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
             throw Utils.handleServerException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_UNEXPECTED, null, e);
         } finally {
             IdentityDatabaseUtil.closeStatement(prepStmt);
+            IdentityDatabaseUtil.closeConnection(connection);
         }
     }
 


### PR DESCRIPTION
When a user updates their password using the notification email there is an issue exhibited that exhausts the connection pool. 

This fix will ensure that the connections are closed correctly once the SQL has been run. The other methods in the same class are all correct and the same methods are now present in the update password functionality as well.