### PR TITLE
Introduce generic api to validate confirmation codes in…

### DIFF
--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/gen/java/org/wso2/carbon/identity/recovery/endpoint/ValidateCodeApi.java
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/gen/java/org/wso2/carbon/identity/recovery/endpoint/ValidateCodeApi.java
@@ -1,0 +1,46 @@
+package org.wso2.carbon.identity.recovery.endpoint;
+
+import org.wso2.carbon.identity.recovery.endpoint.dto.*;
+import org.wso2.carbon.identity.recovery.endpoint.ValidateCodeApiService;
+import org.wso2.carbon.identity.recovery.endpoint.factories.ValidateCodeApiServiceFactory;
+
+import io.swagger.annotations.ApiParam;
+
+import org.wso2.carbon.identity.recovery.endpoint.dto.ErrorDTO;
+import org.wso2.carbon.identity.recovery.endpoint.dto.CodeValidationRequestDTO;
+
+import java.util.List;
+
+import java.io.InputStream;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.*;
+
+@Path("/validate-code")
+@Consumes({ "application/json" })
+@Produces({ "application/json" })
+@io.swagger.annotations.Api(value = "/validate-code", description = "the validate-code API")
+public class ValidateCodeApi  {
+
+   private final ValidateCodeApiService delegate = ValidateCodeApiServiceFactory.getValidateCodeApi();
+
+    @POST
+    
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Validate Confirmation Code\n", notes = "This API is used to validate confirmation codes sent in account recovery scenarios and self signup.Need to put confirmation \"code\" and recovery \"step\" as parameters.\n", response = void.class)
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 202, message = "Accepted"),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Bad Request"),
+        
+        @io.swagger.annotations.ApiResponse(code = 500, message = "Server Error") })
+
+    public Response validateCodePost(@ApiParam(value = "code, recovery step and optianal parameters. For recovery steps you can use values from \"UPDATE_PASSWORD\",\"CONFIRM_SIGN_UP\",\"VALIDATE_CHALLENGE_QUESTION\", \"VALIDATE_ALL_CHALLENGE_QUESTION\" four categories according to the recovery scenario you want to validate the code." ,required=true ) CodeValidationRequestDTO codeValidationRequest)
+    {
+    return delegate.validateCodePost(codeValidationRequest);
+    }
+}
+

--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/gen/java/org/wso2/carbon/identity/recovery/endpoint/ValidateCodeApiService.java
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/gen/java/org/wso2/carbon/identity/recovery/endpoint/ValidateCodeApiService.java
@@ -1,0 +1,19 @@
+package org.wso2.carbon.identity.recovery.endpoint;
+
+import org.wso2.carbon.identity.recovery.endpoint.*;
+import org.wso2.carbon.identity.recovery.endpoint.dto.*;
+
+import org.wso2.carbon.identity.recovery.endpoint.dto.ErrorDTO;
+import org.wso2.carbon.identity.recovery.endpoint.dto.CodeValidationRequestDTO;
+
+import java.util.List;
+
+import java.io.InputStream;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+
+import javax.ws.rs.core.Response;
+
+public abstract class ValidateCodeApiService {
+    public abstract Response validateCodePost(CodeValidationRequestDTO codeValidationRequest);
+}
+

--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/gen/java/org/wso2/carbon/identity/recovery/endpoint/dto/CodeValidationRequestDTO.java
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/gen/java/org/wso2/carbon/identity/recovery/endpoint/dto/CodeValidationRequestDTO.java
@@ -1,0 +1,78 @@
+package org.wso2.carbon.identity.recovery.endpoint.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.recovery.endpoint.dto.PropertyDTO;
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.constraints.NotNull;
+
+
+
+
+
+@ApiModel(description = "")
+public class CodeValidationRequestDTO  {
+  
+  
+  
+  private String code = null;
+  
+  
+  private String step = null;
+  
+  
+  private List<PropertyDTO> properties = new ArrayList<PropertyDTO>();
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("code")
+  public String getCode() {
+    return code;
+  }
+  public void setCode(String code) {
+    this.code = code;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("step")
+  public String getStep() {
+    return step;
+  }
+  public void setStep(String step) {
+    this.step = step;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("properties")
+  public List<PropertyDTO> getProperties() {
+    return properties;
+  }
+  public void setProperties(List<PropertyDTO> properties) {
+    this.properties = properties;
+  }
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class CodeValidationRequestDTO {\n");
+    
+    sb.append("  code: ").append(code).append("\n");
+    sb.append("  step: ").append(step).append("\n");
+    sb.append("  properties: ").append(properties).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/gen/java/org/wso2/carbon/identity/recovery/endpoint/factories/ValidateCodeApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/gen/java/org/wso2/carbon/identity/recovery/endpoint/factories/ValidateCodeApiServiceFactory.java
@@ -1,0 +1,14 @@
+package org.wso2.carbon.identity.recovery.endpoint.factories;
+
+import org.wso2.carbon.identity.recovery.endpoint.ValidateCodeApiService;
+import org.wso2.carbon.identity.recovery.endpoint.impl.ValidateCodeApiServiceImpl;
+
+public class ValidateCodeApiServiceFactory {
+
+   private final static ValidateCodeApiService service = new ValidateCodeApiServiceImpl();
+
+   public static ValidateCodeApiService getValidateCodeApi()
+   {
+      return service;
+   }
+}

--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/ValidateCodeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/ValidateCodeApiServiceImpl.java
@@ -1,0 +1,44 @@
+package org.wso2.carbon.identity.recovery.endpoint.impl;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
+import org.wso2.carbon.identity.recovery.endpoint.Constants;
+import org.wso2.carbon.identity.recovery.endpoint.Utils.RecoveryUtil;
+import org.wso2.carbon.identity.recovery.endpoint.ValidateCodeApiService;
+import org.wso2.carbon.identity.recovery.endpoint.dto.CodeValidationRequestDTO;
+import org.wso2.carbon.identity.recovery.password.NotificationPasswordRecoveryManager;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Implementation class of password reset confirmation code validation api.
+ */
+public class ValidateCodeApiServiceImpl extends ValidateCodeApiService {
+
+    private static final Log LOG = LogFactory.getLog(ValidateCodeApiServiceImpl.class);
+
+    @Override
+    public Response validateCodePost(CodeValidationRequestDTO codeValidationRequestDTO) {
+
+        try {
+            NotificationPasswordRecoveryManager notificationPasswordRecoveryManager = RecoveryUtil
+                    .getNotificationBasedPwdRecoveryManager();
+            notificationPasswordRecoveryManager.validateConfirmationCode(codeValidationRequestDTO.getCode()
+                    , codeValidationRequestDTO.getStep());
+        } catch (IdentityRecoveryClientException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Client Error while validating the confirmation code ", e);
+            }
+            RecoveryUtil.handleBadRequest(e.getMessage(), e.getErrorCode());
+        } catch (IdentityRecoveryException e) {
+            RecoveryUtil.handleInternalServerError(Constants.SERVER_ERROR, e.getErrorCode(), LOG, e);
+        } catch (Throwable throwable) {
+            RecoveryUtil.handleInternalServerError(Constants.SERVER_ERROR, IdentityRecoveryConstants
+                    .ErrorMessages.ERROR_CODE_UNEXPECTED.getCode(), LOG, throwable);
+        }
+        return Response.accepted().build();
+    }
+}

--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/main/resources/api.identity.recovery.yaml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/main/resources/api.identity.recovery.yaml
@@ -152,7 +152,44 @@ paths:
       tags:
         - Password Recovery
         - Notification
-             
+
+  /validate-code:
+    post:
+      description: |
+        This API is used to validate confirmation codes sent in account recovery scenarios and self signup.Need to put confirmation "code" and recovery "step" as parameters.
+      x-wso2-request: |
+        curl -k -v -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{ "code": "84325529-8aa7-4851-8751-5980a7f2d9f7","step": "UPDATE_PASSWORD","properties": []}' "https://localhost:9443/api/identity/recovery/v0.9/validate-code"
+
+      x-wso2-response: |
+        "HTTP/1.1 202 Accepted"
+
+      summary: |
+        Validate Confirmation Code
+
+      # This are the post parameters:
+      parameters:
+        -
+          name: CodeValidationRequest
+          in: body
+          description:  code, recovery step and optianal parameters. For recovery steps you can use values from "UPDATE_PASSWORD","CONFIRM_SIGN_UP","VALIDATE_CHALLENGE_QUESTION", "VALIDATE_ALL_CHALLENGE_QUESTION" four categories according to the recovery scenario you want to validate the code.
+          required: true
+          schema:
+            $ref: '#/definitions/CodeValidationRequest'
+      responses:
+        202:
+          description: Accepted
+        400:
+          description: Bad Request
+          schema:
+             $ref: '#/definitions/Error'
+
+        500:
+          description: Server Error
+          schema:
+             $ref: '#/definitions/Error'
+      tags:
+        - Password Recovery
+
 
    # Endpoint uses to initiate password reset with security questions
   /security-question:
@@ -592,4 +629,21 @@ definitions:
       value: 
         type: string
 #-----------------------------------------------------        
+
+#-----------------------------------------------------
+# The CodeValidationRequest  object
+#-----------------------------------------------------
+  CodeValidationRequest:
+    type: object
+    properties:
+      code:
+        type: string
+      step:
+        type: string
+      properties:
+        type: array
+        items:
+          $ref: '#/definitions/Property'
+#-----------------------------------------------------
+
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/main/webapp/WEB-INF/beans.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/main/webapp/WEB-INF/beans.xml
@@ -14,7 +14,7 @@
             <bean class="org.wso2.carbon.identity.recovery.endpoint.SecurityQuestionsApi"/>
             <bean class="org.wso2.carbon.identity.recovery.endpoint.SetPasswordApi"/>
             <bean class="org.wso2.carbon.identity.recovery.endpoint.ValidateAnswerApi"/>
-            
+            <bean class="org.wso2.carbon.identity.recovery.endpoint.ValidateCodeApi"/>
         </jaxrs:serviceBeans>
         <jaxrs:providers>
             <bean class="com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider"/>

--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/test/java/org/wso2/carbon/identity/recovery/endpoint/ValidateCodeApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/test/java/org/wso2/carbon/identity/recovery/endpoint/ValidateCodeApiServiceImplTest.java
@@ -1,0 +1,82 @@
+/*
+ *
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.wso2.carbon.identity.recovery.endpoint;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.IObjectFactory;
+import org.testng.annotations.ObjectFactory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.recovery.endpoint.Utils.RecoveryUtil;
+import org.wso2.carbon.identity.recovery.endpoint.dto.CodeValidationRequestDTO;
+import org.wso2.carbon.identity.recovery.endpoint.dto.PropertyDTO;
+import org.wso2.carbon.identity.recovery.endpoint.impl.ValidateCodeApiServiceImpl;
+import org.wso2.carbon.identity.recovery.password.NotificationPasswordRecoveryManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.testng.Assert.*;
+
+/**
+ * This class covers unit tests for ValidateCodeApiServiceImpl.java
+ */
+@PrepareForTest({RecoveryUtil.class})
+public class ValidateCodeApiServiceImplTest {
+
+    @Mock
+    NotificationPasswordRecoveryManager notificationPasswordRecoveryManager;
+
+    @InjectMocks
+    ValidateCodeApiServiceImpl validateCodeApiService;
+
+    @Test
+    public void testValidateCodePost() throws Exception {
+        mockStatic(RecoveryUtil.class);
+        when(RecoveryUtil.getNotificationBasedPwdRecoveryManager()).thenReturn(notificationPasswordRecoveryManager);
+        assertEquals(validateCodeApiService.validateCodePost(buildCodeValidationRequestDTO()).getStatus(), 202);
+    }
+
+    private CodeValidationRequestDTO buildCodeValidationRequestDTO() {
+
+        CodeValidationRequestDTO codeValidationRequestDTO = new CodeValidationRequestDTO();
+        codeValidationRequestDTO.setCode("DummyCode");
+        codeValidationRequestDTO.setStep("DummyStep");
+        codeValidationRequestDTO.setProperties(buildPropertyListDTO());
+        return codeValidationRequestDTO;
+    }
+
+    private List<PropertyDTO> buildPropertyListDTO() {
+
+        PropertyDTO propertyDTO = new PropertyDTO();
+        propertyDTO.setKey("DummyPropertyKey");
+        propertyDTO.setValue("Dummy property value");
+        List<PropertyDTO> propertyDTOList = new ArrayList<>();
+        propertyDTOList.add(propertyDTO);
+        return propertyDTOList;
+    }
+
+    @ObjectFactory
+    public IObjectFactory getObjectFactory() {
+
+        return new org.powermock.modules.testng.PowerMockObjectFactory();
+    }
+}

--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/test/resources/testng.xml
@@ -24,6 +24,7 @@
             <class name="org.wso2.carbon.identity.recovery.endpoint.SecurityQuestionApiServiceImplTest"/>
             <class name="org.wso2.carbon.identity.recovery.endpoint.ValidateAnswerApiServiceImplTest"/>
             <class name="org.wso2.carbon.identity.recovery.endpoint.RecoverPasswordApiServiceImplTest"/>
+            <class name="org.wso2.carbon.identity.recovery.endpoint.ValidateCodeApiServiceImplTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
… account recovery flows

### Proposed changes in this pull request

Currently there is no specific api to validate the confirmation codes received during password recovery flows and self signup.
validation happens along with some other operations (ex:update password, register user)
There is no separate api to validate only the received confirmation codes.
This new api will intake the confirmation code and the recovery step 
recovery steps:
("UPDATE_PASSWORD","CONFIRM_SIGN_UP","VALIDATE_CHALLENGE_QUESTION", "VALIDATE_ALL_CHALLENGE_QUESTION")

Following classes are auto generated class using the swagger api plugin
ValidateCodeApi.java
ValidateCodeApiService.java
CodeValidationRequestDTO.java
ValidateCodeApiServiceFactory.java

Added unit test case.

-

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
