### PR TITLE
Fix wso2/product-is#3210: Account failed attempt count does not reset if secondary user store domain name is in lowercase

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
@@ -670,7 +670,7 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
                     .RealmConfig.PROPERTY_DOMAIN_NAME);
 
             if (userDomain != null) {
-                if (userDomain.equals(userStoreDomain)) {
+                if (userDomain.equalsIgnoreCase(userStoreDomain)) {
                     isExists = true;
                 }
             } else if (IdentityUtil.getPrimaryDomainName().equalsIgnoreCase(userStoreDomain)) {


### PR DESCRIPTION
### Proposed changes in this pull request


- Fixing account failed attempt count does not reset if secondary user store domain name is in lowercase by ignoring the case while user store domain match

### When should this PR be merged

- Immediate


### Follow up actions

- None