### PR TITLE
Add null check to retrievedChallengeQuestions array

### DIFF
--- a/components/org.wso2.carbon.identity.recovery.ui/src/main/resources/web/recovery-mgt/challenges-mgt-finish-ajaxprocessor.jsp
+++ b/components/org.wso2.carbon.identity.recovery.ui/src/main/resources/web/recovery-mgt/challenges-mgt-finish-ajaxprocessor.jsp
@@ -31,6 +31,7 @@
 <%@ page import="org.wso2.carbon.utils.ServerConstants" %>
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.Arrays" %>
+<%@ page import="java.util.Collections" %>
 <%@ page import="java.util.List" %>
 
 <%
@@ -82,8 +83,11 @@
 
 
         ChallengeQuestion[] retrievedChallengeQuestions = proxy.getChallengeQuestionsForTenant(tenantDomain);
-        retrievedQuestions = Arrays.asList(retrievedChallengeQuestions);
-
+        if (retrievedChallengeQuestions != null) {
+            retrievedQuestions = Arrays.asList(retrievedChallengeQuestions);
+        } else {
+            retrievedQuestions = Collections.emptyList();
+        }
 
         if (removeSetId != null && removeSetId.trim().length() > 0) {
             for (ChallengeQuestion challengeQuestion : retrievedQuestions) {


### PR DESCRIPTION
### Proposed changes in this pull request

This PR is to fix https://github.com/wso2/product-is/issues/3939

The fix will be checking for situations where retrievedChallengeQuestions array is null and will use an emptyList in such situation