### PR TITLE
Deprecate FailLoginAttemptValidator and add FailLoginAttemptValidationHandler

### DIFF
--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -79,6 +79,10 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.governance</groupId>
             <artifactId>org.wso2.carbon.identity.recovery</artifactId>
         </dependency>
@@ -154,6 +158,8 @@
                             org.wso2.carbon.identity.application.common.model;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.util;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.core.model;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.recovery.*;
                             version="${identity.governance.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaComponent.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaComponent.java
@@ -21,12 +21,14 @@ package org.wso2.carbon.identity.captcha.internal;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.ComponentContext;
+import org.wso2.carbon.identity.application.authentication.framework.AuthenticationDataPublisher;
 import org.wso2.carbon.identity.captcha.connector.CaptchaConnector;
 import org.wso2.carbon.identity.captcha.connector.recaptcha.PasswordRecoveryReCaptchaConnector;
 import org.wso2.carbon.identity.captcha.connector.recaptcha.SSOLoginReCaptchaConfig;
 import org.wso2.carbon.identity.captcha.connector.recaptcha.SelfSignUpReCaptchaConnector;
 import org.wso2.carbon.identity.captcha.connector.recaptcha.UsernameRecoveryReCaptchaConnector;
 import org.wso2.carbon.identity.captcha.util.CaptchaUtil;
+import org.wso2.carbon.identity.captcha.validator.FailLoginAttemptValidationHandler;
 import org.wso2.carbon.identity.captcha.validator.FailLoginAttemptValidator;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
@@ -91,8 +93,12 @@ public class CaptchaComponent {
             captchaConnector.init(CaptchaDataHolder.getInstance().getIdentityGovernanceService());
             CaptchaDataHolder.getInstance().addCaptchaConnector(captchaConnector);
 
+            AuthenticationDataPublisher failedLoginAttemptValidator = new FailLoginAttemptValidator();
+            context.getBundleContext().registerService(AuthenticationDataPublisher.class, failedLoginAttemptValidator
+                    , null);
+
             context.getBundleContext().registerService(AbstractEventHandler.class.getName(),
-                    new FailLoginAttemptValidator(), null);
+                    new FailLoginAttemptValidationHandler(), null);
 
             if (log.isDebugEnabled()) {
                 log.debug("Captcha Component is activated");

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/validator/FailLoginAttemptValidationHandler.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/validator/FailLoginAttemptValidationHandler.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.captcha.validator;
+
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.base.IdentityRuntimeException;
+import org.wso2.carbon.identity.captcha.exception.CaptchaException;
+import org.wso2.carbon.identity.captcha.util.CaptchaConstants;
+import org.wso2.carbon.identity.captcha.util.CaptchaUtil;
+import org.wso2.carbon.identity.core.bean.context.MessageContext;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
+
+import java.util.Map;
+
+/**
+ * Validate no of failed login attempts against the no configured and engage captcha
+ */
+public class FailLoginAttemptValidationHandler extends AbstractEventHandler {
+
+    private static Log log = LogFactory.getLog(FailLoginAttemptValidationHandler.class);
+
+    @Override
+    public String getName() {
+
+        return "failLoginAttemptValidator";
+    }
+
+    @Override
+    public boolean canHandle(MessageContext messageContext) throws IdentityRuntimeException {
+
+        return super.canHandle(messageContext) && isFailLoginAttemptValidatorEnabled();
+    }
+
+    @Override
+    public void handleEvent(Event event) throws IdentityEventException {
+
+        if (canHandleEvent(event)) {
+
+            AuthenticationContext context = (AuthenticationContext) event.getEventProperties().get
+                    (IdentityEventConstants.EventProperty.CONTEXT);
+            Map<String, Object> unmodifiableParamMap = (Map<String, Object>) event.getEventProperties()
+                    .get(IdentityEventConstants.EventProperty.PARAMS);
+            String eventName = event.getEventName();
+
+            if (log.isDebugEnabled()) {
+                log.debug(this.getName() + " received event : " + eventName);
+            }
+
+            if (IdentityEventConstants.EventName.AUTHENTICATION_STEP_FAILURE.name().equals(eventName)) {
+
+                handleAuthenticationStepFailure(context, unmodifiableParamMap);
+            }
+        }
+    }
+
+    /**
+     * Handles 'AUTHENTICATION_STEP_FAILURE' event and validates no of failed login attempts of the user and
+     * enables captcha.
+     *
+     * @param authenticationContext authentication context {@link AuthenticationContext}
+     * @param map                   event property parameter map
+     */
+    protected void handleAuthenticationStepFailure(AuthenticationContext authenticationContext, Map<String, Object>
+            map) {
+
+        String currentAuthenticator = authenticationContext.getCurrentAuthenticator();
+        if (StringUtils.isBlank(currentAuthenticator) && MapUtils.isNotEmpty(map)) {
+            currentAuthenticator = (String) map.get(FrameworkConstants.AUTHENTICATOR);
+        }
+        if ("BasicAuthenticator".equals(currentAuthenticator) && MapUtils.isNotEmpty(map) && map.get
+                (FrameworkConstants.AnalyticsAttributes.USER) != null) {
+
+            if (map.get(FrameworkConstants.AnalyticsAttributes.USER) instanceof User) {
+                User failedUser = (User) map.get(FrameworkConstants.AnalyticsAttributes.USER);
+                String username = getDomainQualifiedUsername(failedUser);
+
+                if (log.isDebugEnabled()) {
+                    log.debug("Evaluating failed login attempts for user: " + username + " authenticated from: " +
+                            currentAuthenticator);
+                }
+
+                try {
+                    if (CaptchaUtil.isMaximumFailedLoginAttemptsReached(username, failedUser.getTenantDomain())) {
+                        CaptchaConstants.setEnableSecurityMechanism("enable");
+                        if (log.isDebugEnabled()) {
+                            log.debug("User: " + username + " reached maximum no of failed login attempts. Enabling " +
+                                    "captcha for user.");
+                        }
+                    }
+                } catch (CaptchaException e) {
+                    log.error("Failed to evaluate max failed login attempts of the user: " + username, e);
+                }
+            }
+        }
+    }
+
+    private boolean isFailLoginAttemptValidatorEnabled() throws IdentityRuntimeException {
+
+        if (this.configs.getModuleProperties() != null) {
+            String handlerEnabled = this.configs.getModuleProperties().getProperty(CaptchaConstants
+                    .FAIL_LOGIN_ATTEMPT_VALIDATOR_ENABLED);
+            return Boolean.parseBoolean(handlerEnabled);
+        }
+
+        return false;
+    }
+
+    private boolean canHandleEvent(Event event) {
+
+        return event != null && event.getEventProperties().get(IdentityEventConstants.EventProperty.CONTEXT) instanceof
+                AuthenticationContext && event.getEventProperties().get(IdentityEventConstants.EventProperty.PARAMS)
+                instanceof Map;
+    }
+
+    private String getDomainQualifiedUsername(User user) {
+
+        String username = user.getUserName();
+        if (!StringUtils.isBlank(user.getUserStoreDomain()) &&
+                !IdentityUtil.getPrimaryDomainName().equals(user.getUserStoreDomain())) {
+            username = UserCoreUtil.addDomainToName(username, user.getUserStoreDomain());
+        }
+
+        return username;
+    }
+}


### PR DESCRIPTION
Resolves wso2/product-is#4660

### Proposed changes in this pull request

With respect to #3090, AuthenticationDataPublisher implementations are deprecated and use of AbstractEventHanlders are encouraged to act as event handlers for authentication events.

Yet this has changed the existing SPI of the FailLoginAttemptValidator.
This fix deprecates the existing implementation and introduce the new implementation that implements an event hander, preserving backward compatibility.

Also avoids the engagement of the deprecated implementation by default. 
If that needs to be engaged need to follow steps below.
- Add below config in identity.xml under `<EventListeners>`
```
<EventListener type="org.wso2.carbon.identity.core.handler.AbstractIdentityMessageHandler"
                       name="org.wso2.carbon.identity.captcha.validator.FailLoginAttemptValidator"
                       orderId="10" enable="true"/>
```
- Disable the new handler from identity-event.properties
```
module.name.16=failLoginAttemptValidator
failLoginAttemptValidator.subscription.1=AUTHENTICATION_STEP_FAILURE
failLoginAttemptValidator.enable=false
```
### When should this PR be merged

ASAP

### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
