### PR TITLE
Fix self registration rest API throws 500 when username is not valid to the regex defined in user-mgt.xml

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -133,7 +133,8 @@ public class IdentityRecoveryConstants {
         ERROR_CODE_ADD_USER_CONSENT("20042", "Error while adding consent for user %s."),
         ERROR_CODE_PUBLISH_EVENT("20043", "Error while publishing event %s."),
         ERROR_CODE_CALLBACK_URL_NOT_VALID("20044", "Configured callback URL does not match with the provided callback"
-                + " URL: %s in the request.");
+                + " URL: %s in the request."),
+        ERROR_CODE_USERNAME_POLICY_VIOLATED("20045", "Provided username '%s' violates the policy.");
 
 
         private final String code;

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -189,6 +189,10 @@ public class UserSelfRegistrationManager {
                         password, userRoles, claimsMap, null);
 
             } catch (UserStoreException e) {
+                if (StringUtils.isNotEmpty(e.getMessage()) && e.getMessage().contains("31301")) {
+                    throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.
+                            ERROR_CODE_USERNAME_POLICY_VIOLATED, user.getUserName(), e);
+                }
                 Throwable cause = e;
 
                 while (cause != null) {


### PR DESCRIPTION

### Proposed changes in this pull request
self registration rest API throws 500 when username is not valid to the regex defined in user-mgt.xml

### When should this PR be merged
Immediately

### Follow up actions
None

