### PR TITLE
Fix empty purposes scenario while adding user consent

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -586,6 +586,16 @@ public class UserSelfRegistrationManager {
         }
         // There should be a one receipt
         ReceiptServiceInput receiptServiceInput = receiptInput.getServices().get(0);
+
+        // Handle the scenario, where all the purposes are having optional PII attributes and then the user register
+        // without giving consent to any of the purposes.
+        if (receiptServiceInput.getPurposes().isEmpty()) {
+            if (log.isDebugEnabled()) {
+                log.debug("Consent does not contain any purposes. Hence not adding consent");
+            }
+            return;
+        }
+
         receiptServiceInput.setTenantDomain(tenantDomain);
         try {
             setIDPData(tenantDomain, receiptServiceInput);


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes https://github.com/wso2/product-is/issues/4837. 
- In a scenario where all the purposes are having optional PII attributes and then the user self-register without giving consent to any of them.
- Avoid adding the consent with empty purposes, in the above scenario.
 
### When should this PR be merged

- ASAP

#### Documentation

- N/A
