### PR TITLE
Fix failed to commit and rollback the connection while throw sql exception

### DIFF
--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/jdbc/JDBCNotificationReceiversRetrieval.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/jdbc/JDBCNotificationReceiversRetrieval.java
@@ -123,8 +123,9 @@ public class JDBCNotificationReceiversRetrieval implements NotificationReceivers
                     users.add(receiver);
                 }
             }
-
+            dbConnection.commit();
         } catch (SQLException e) {
+            DatabaseUtil.rollBack(dbConnection);
             if (log.isDebugEnabled()) {
                 log.debug("Using sql : " + sqlStmt);
             }

--- a/components/org.wso2.carbon.identity.password.history/src/main/java/org/wso2/carbon/identity/password/history/store/Impl/DefaultPasswordHistoryDataStore.java
+++ b/components/org.wso2.carbon.identity.password.history/src/main/java/org/wso2/carbon/identity/password/history/store/Impl/DefaultPasswordHistoryDataStore.java
@@ -133,6 +133,7 @@ public class DefaultPasswordHistoryDataStore implements PasswordHistoryDataStore
             connection.commit();
 
         } catch (SQLException e) {
+            IdentityDatabaseUtil.rollBack(connection);
             throw new IdentityPasswordHistoryException("Error while removing password history date from user :" +
                     user.getUserName(), e);
         } finally {
@@ -173,6 +174,7 @@ public class DefaultPasswordHistoryDataStore implements PasswordHistoryDataStore
             }
 
         } catch (SQLException e) {
+            IdentityDatabaseUtil.rollBack(connection);
             throw new IdentityPasswordHistoryException("Error while validating password history", e);
         } finally {
             IdentityDatabaseUtil.closeStatement(prepStmt);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/store/JDBCRecoveryDataStore.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/store/JDBCRecoveryDataStore.java
@@ -52,6 +52,7 @@ public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
         Connection connection = IdentityDatabaseUtil.getDBConnection();
         PreparedStatement prepStmt = null;
         try {
+            connection.setAutoCommit(false);
             prepStmt = connection.prepareStatement(IdentityRecoveryConstants.SQLQueries.STORE_RECOVERY_DATA);
             prepStmt.setString(1, recoveryDataDO.getUser().getUserName());
             prepStmt.setString(2, recoveryDataDO.getUser().getUserStoreDomain().toUpperCase());
@@ -62,9 +63,9 @@ public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
             prepStmt.setTimestamp(7, new Timestamp(new Date().getTime()));
             prepStmt.setString(8, recoveryDataDO.getRemainingSetIds());
             prepStmt.execute();
-            connection.setAutoCommit(false);
             connection.commit();
         } catch (SQLException e) {
+            IdentityDatabaseUtil.rollBack(connection);
             throw Utils.handleServerException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_STORING_RECOVERY_DATA, null, e);
         } finally {
             IdentityDatabaseUtil.closeStatement(prepStmt);


### PR DESCRIPTION


### Proposed changes in this pull request

When we use the JDBC transaction by applying connection.commit() to commit the SQL statements and make sure SQL statements within a transaction block are all executed successfully. if either one of the SQL statement within the transaction block is failed, abort and rollback everything within the transaction block.
In the identity-governance, there are some places use the JDBC transaction but did not properly commit and rollback the connection.

Issue: https://github.com/wso2/product-is/issues/5433