### PR TITLE
Add / to the claim values to avoid conflicts with user store domain

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/username/NotificationUsernameRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/username/NotificationUsernameRecoveryManager.java
@@ -39,6 +39,7 @@ import org.wso2.carbon.identity.recovery.model.UserClaim;
 import org.wso2.carbon.identity.recovery.util.Utils;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.claim.Claim;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
@@ -54,6 +55,7 @@ import java.util.List;
 public class NotificationUsernameRecoveryManager {
 
     private static final Log log = LogFactory.getLog(NotificationUsernameRecoveryManager.class);
+    private static final String FORWARD_SLASH = "/";
 
     private static NotificationUsernameRecoveryManager instance = new NotificationUsernameRecoveryManager();
 
@@ -292,6 +294,17 @@ public class NotificationUsernameRecoveryManager {
         }
         try {
             if (userStoreManager != null) {
+                if (StringUtils.isNotBlank(value) && value.contains(FORWARD_SLASH)) {
+                    String extractedDomain = IdentityUtil.extractDomainFromName(value);
+                    UserStoreManager secondaryUserStoreManager = userStoreManager.
+                            getSecondaryUserStoreManager(extractedDomain);
+                    /* Some claims (Eg:- Birth date) can have "/" in claim values. But in user store level we are
+                      trying to extract the claim value and find the user store domain. Hence we are adding an extra
+                      "/" to the claim value to avoid such issues.*/
+                    if (secondaryUserStoreManager == null) {
+                        value = FORWARD_SLASH + value;
+                    }
+                }
                 userList = userStoreManager.getUserList(claim, value, null);
             }
             return userList;


### PR DESCRIPTION
### Proposed changes in this pull request
Resolves https://github.com/wso2/product-is/issues/6546

Having date format as "dd/mm/yr" is giving an issue. The root cause is whenever a claim value has "/" we are extracting that claim value and take the first part as the user store domain[1]. That causes the issue.

With this PR we are going to fix the issue by adding an extra "/" to the claim value from governance level. So that when we tried to extract the domain from kernel-level, we will get an empty value for domain since it is empty it will not be taken as a user store domain[2].

[1] https://github.com/wso2-support/carbon4-kernel/blob/support-4.4.35/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java#L1345-L1348
[2] https://github.com/wso2-support/carbon4-kernel/blob/support-4.4.35/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java#L1352

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
