### PR TITLE
Support multiple notification channels for user self registration

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceUtil.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceUtil.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
 import org.wso2.carbon.identity.governance.internal.IdentityMgtServiceDataHolder;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.user.api.UserStoreManager;
@@ -129,4 +130,18 @@ public class IdentityGovernanceUtil {
         return domainNameProperty;
     }
 
+    /**
+     * Reads configurations from the identity.xml and returns the default notification channel.
+     *
+     * @return Default channel for sending notifications
+     */
+    public static String getDefaultNotificationChannel() {
+
+        String defaultNotificationChannel = IdentityUtil
+                .getProperty(IdentityMgtConstants.NotificationChannelConstants.DEFAULT_NOTIFICATION_CHANNEL);
+        if (StringUtils.isEmpty(defaultNotificationChannel)) {
+            return NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        }
+        return defaultNotificationChannel;
+    }
 }

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityMgtConstants.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityMgtConstants.java
@@ -23,10 +23,14 @@ public class IdentityMgtConstants {
 
     private IdentityMgtConstants(){}
 
+    public static final String USER_IDENTITY_CLAIMS = "UserIdentityClaims";
+
     public class PropertyConfig {
 
         private PropertyConfig(){}
 
+        // Enable notification channel resolver.
+        public static final String RESOLVE_NOTIFICATION_CHANNELS = "Notification.ResolveNotificationChannels.Enable";
         public static final String CONFIG_FILE_NAME = "identity-mgt.properties";
         public static final String ACCOUNT_LOCK_ENABLE = "Account.Lock.Enable";
         public static final String AUTH_POLICY_ENABLE = "Authentication.Policy.Enable";
@@ -77,6 +81,52 @@ public class IdentityMgtConstants {
         public static final String FAIL_LOGIN_ATTEMPTS = "http://wso2.org/claims/identity/failedLoginAttempts";
         public static final String UNLOCKING_TIME = "http://wso2.org/claims/identity/unlockTime";
         public static final String ACCOUNT_LOCK = "http://wso2.org/claims/identity/accountLocked";
+        public static final String PREFERED_CHANNEL_CLAIM = "http://wso2.org/claims/identity/preferredChannel";
+
+    }
+
+    public class NotificationChannelConstants {
+
+        private NotificationChannelConstants() {
+        }
+
+        public static final String DEFAULT_NOTIFICATION_CHANNEL = "Notification.DefaultNotificationChannel";
+    }
+
+    public enum ErrorMessages {
+
+        ERROR_CODE_DEFAULT_BAD_REQUEST("NCM-400", "Bad Request"),
+        ERROR_CODE_DEFAULT_SERVER_ERROR("NCM-500", "Internal Server Error"),
+        ERROR_CODE_DEFAULT_UNEXPECTED_ERROR("NCM-500", "Unexpected Error"),
+
+        // NCM - notification Channel Manager.
+        ERROR_CODE_UNSUPPORTED_PREFERRED_CHANNEL("NCM-10001","Channel not supported"),
+        ERROR_CODE_NO_CLAIM_MATCHED_FOR_PREFERRED_CHANNEL("NCM-10002",
+                "No claim matched for preferred channel"),
+        ERROR_CODE_NO_NOTIFICATION_CHANNELS("NCM-10003","User has no notification channels"),
+        ERROR_CODE_BAD_REQUEST("NCM-10004", "Bad Request"),
+        ERROR_CODE_SERVER_ERROR("NCM-15001", "Server Error");
+
+        private final String code;
+        private final String message;
+
+        ErrorMessages(String code, String message) {
+            this.code = code;
+            this.message = message;
+        }
+
+        public String getCode() {
+            return code;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        @Override
+        public String toString() {
+            return code + " - " + message;
+        }
 
     }
 }

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/exceptions/notiification/NotificationChannelManagerClientException.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/exceptions/notiification/NotificationChannelManagerClientException.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.governance.exceptions.notiification;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
+
+/**
+ * Exception class that represents exceptions thrown upon resolving communication channels due to client request errors.
+ */
+public class NotificationChannelManagerClientException extends NotificationChannelManagerException {
+
+    /**
+     * Constructs a new exception with the specified detail message.
+     *
+     * @param message The detail message
+     */
+    public NotificationChannelManagerClientException(String message) {
+        super(message);
+        this.setErrorCode(getDefaultErrorCode());
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message The detail message
+     * @param cause   The cause
+     */
+    public NotificationChannelManagerClientException(String message, Throwable cause) {
+        super(message, cause);
+        this.setErrorCode(getDefaultErrorCode());
+    }
+
+    /**
+     * Constructs a new exception with an error code and a detail message.
+     *
+     * @param errorCode The error code
+     * @param message   The detail message.
+     */
+    public NotificationChannelManagerClientException(String errorCode, String message) {
+        super(errorCode, message);
+        this.setErrorCode(errorCode);
+    }
+
+    /**
+     * Constructs a new exception with an error code, detail message and throwable.
+     *
+     * @param errorCode The error code
+     * @param message   The detail message
+     * @param throwable Throwable
+     */
+    public NotificationChannelManagerClientException(String errorCode, String message, Throwable throwable) {
+        super(errorCode, message, throwable);
+        this.setErrorCode(errorCode);
+    }
+
+    /**
+     * Get the default error code of the exception.
+     *
+     * @return Error description
+     */
+    private String getDefaultErrorCode() {
+
+        String errorCode = super.getErrorCode();
+        if (StringUtils.isEmpty(errorCode)) {
+            errorCode = IdentityMgtConstants.ErrorMessages.ERROR_CODE_DEFAULT_BAD_REQUEST.getCode();
+        }
+        return errorCode;
+    }
+}

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/exceptions/notiification/NotificationChannelManagerException.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/exceptions/notiification/NotificationChannelManagerException.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.governance.exceptions.notiification;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
+
+/**
+ * Exception class that represents exceptions thrown upon resolving notification channels of a user.
+ */
+public class NotificationChannelManagerException extends IdentityException {
+
+    private static final long serialVersionUID = 1700318648018222420L;
+
+    /**
+     * Constructs a new exception with the specified detail message.
+     *
+     * @param message The detail message
+     */
+    public NotificationChannelManagerException(String message) {
+        super(message);
+        this.setErrorCode(getDefaultErrorCode());
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message The detail message
+     * @param cause   The cause
+     */
+    public NotificationChannelManagerException(String message, Throwable cause) {
+        super(message, cause);
+        this.setErrorCode(getDefaultErrorCode());
+    }
+
+    /**
+     * Constructs a new exception with an error code and a detail message.
+     *
+     * @param errorCode The error code
+     * @param message   The detail message
+     */
+    public NotificationChannelManagerException(String errorCode, String message) {
+        super(errorCode, message);
+        this.setErrorCode(errorCode);
+    }
+
+    /**
+     * Constructs a new exception with an error code, detail message and throwable.
+     *
+     * @param errorCode The error code
+     * @param message   The detail message
+     * @param throwable Throwable
+     */
+    public NotificationChannelManagerException(String errorCode, String message, Throwable throwable) {
+        super(errorCode, message, throwable);
+        this.setErrorCode(errorCode);
+    }
+
+    /**
+     * Get the default error code of the exception.
+     *
+     * @return Error description
+     */
+    private String getDefaultErrorCode() {
+
+        String errorCode = super.getErrorCode();
+        if (StringUtils.isEmpty(errorCode)) {
+            errorCode = IdentityMgtConstants.ErrorMessages.ERROR_CODE_DEFAULT_UNEXPECTED_ERROR.getCode();
+        }
+        return errorCode;
+    }
+}

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/exceptions/notiification/NotificationChannelManagerServerException.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/exceptions/notiification/NotificationChannelManagerServerException.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.governance.exceptions.notiification;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
+
+/**
+ * Exception class that represents exceptions thrown upon server errors while resolving the notification channel.
+ */
+public class NotificationChannelManagerServerException extends NotificationChannelManagerException {
+
+    /**
+     * Constructs a new exception with the specified detail message.
+     *
+     * @param message The detail message
+     */
+    public NotificationChannelManagerServerException(String message) {
+        super(message);
+        this.setErrorCode(getDefaultErrorCode());
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message The detail message
+     * @param cause   The cause
+     */
+    public NotificationChannelManagerServerException(String message, Throwable cause) {
+        super(message, cause);
+        this.setErrorCode(getDefaultErrorCode());
+    }
+
+    /**
+     * Constructs a new exception with an error code and a detail message.
+     *
+     * @param errorCode The error code
+     * @param message   The detail message.
+     */
+    public NotificationChannelManagerServerException(String errorCode, String message) {
+        super(errorCode, message);
+        this.setErrorCode(errorCode);
+    }
+
+    /**
+     * Constructs a new exception with an error code, detail message and throwable.
+     *
+     * @param errorCode The error code
+     * @param message   The detail message
+     * @param throwable Throwable
+     */
+    public NotificationChannelManagerServerException(String errorCode, String message, Throwable throwable) {
+        super(errorCode, message, throwable);
+        this.setErrorCode(errorCode);
+    }
+
+    /**
+     * Get the default error code of the exception.
+     *
+     * @return Error description
+     */
+    private String getDefaultErrorCode() {
+
+        String errorCode = super.getErrorCode();
+        if (StringUtils.isEmpty(errorCode)) {
+            errorCode = IdentityMgtConstants.ErrorMessages.ERROR_CODE_DEFAULT_SERVER_ERROR.getCode();
+        }
+        return errorCode;
+    }
+}

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/internal/IdentityMgtServiceComponent.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/internal/IdentityMgtServiceComponent.java
@@ -31,6 +31,8 @@ import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceServiceImpl;
 import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
+import org.wso2.carbon.identity.governance.internal.service.impl.notification.DefaultNotificationChannelManager;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannelManager;
 import org.wso2.carbon.identity.governance.listener.IdentityMgtEventListener;
 import org.wso2.carbon.identity.governance.listener.IdentityStoreEventListener;
 import org.wso2.carbon.idp.mgt.IdpManager;
@@ -58,6 +60,10 @@ public class IdentityMgtServiceComponent {
             context.getBundleContext().registerService(IdentityGovernanceService.class, identityGovernanceService,
                     null);
             IdentityMgtServiceDataHolder.getInstance().setIdentityGovernanceService(identityGovernanceService);
+            DefaultNotificationChannelManager defaultNotificationChannelManager =
+                    new DefaultNotificationChannelManager();
+            context.getBundleContext()
+                    .registerService(NotificationChannelManager.class.getName(), defaultNotificationChannelManager, null);
 
             if (log.isDebugEnabled()) {
                 log.debug("Identity Management Listener is enabled");

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/internal/service/impl/notification/DefaultNotificationChannelManager.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/internal/service/impl/notification/DefaultNotificationChannelManager.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.governance.internal.service.impl.notification;
+
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.governance.IdentityGovernanceUtil;
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
+import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationChannelManagerException;
+import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationChannelManagerClientException;
+import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationChannelManagerServerException;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+
+import org.wso2.carbon.identity.governance.internal.IdentityMgtServiceDataHolder;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannelManager;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.api.UserRealm;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+/**
+ * Class contains the implementation of the NotificationChannelManager.
+ */
+public class DefaultNotificationChannelManager implements NotificationChannelManager {
+
+    private static final Log log = LogFactory.getLog(DefaultNotificationChannelManager.class);
+    private ArrayList<NotificationChannels> channels = new ArrayList<>();
+
+    public DefaultNotificationChannelManager() {
+
+        this.channels.add(NotificationChannels.EMAIL_CHANNEL);
+        this.channels.add(NotificationChannels.SMS_CHANNEL);
+    }
+
+    /**
+     * Validate whether the user specified notification channel type is supported by the server or not.
+     *
+     * @param preferredChannel Type of the user preferred notification channel
+     * @return True if the preferred channel is supported
+     */
+    @Override
+    public boolean isSupportedChannel(String preferredChannel) {
+
+        // Server supported notification channels.
+        for (NotificationChannels channel : channels) {
+
+            // If preferred channel is in the channel list, the preferred channel is supported by the server to send
+            // notifications.
+            if (channel.getChannelType().equalsIgnoreCase(preferredChannel)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Given preferred channel : " + preferredChannel + " is supported by the server");
+                }
+                return true;
+            }
+        }
+        // Given preferred channel is not supported by the server.
+        if (log.isDebugEnabled()) {
+            log.debug("Given preferred channel : " + preferredChannel + " is not supported by the server");
+        }
+        return false;
+    }
+
+    /**
+     * Resolve a communication channels to send notifications according to a map of claims available to the user.
+     *
+     * @param username        Username
+     * @param tenantDomain    Tenant domain of the user
+     * @param userstoreDomain Userstore domain of the user
+     * @param claimsMap       Map of the user claims with claim uri as the key and claim value as the value of the map.
+     * @return Communication channel
+     * @throws NotificationChannelManagerException Error while resolving the channel
+     */
+    @Override
+    public String resolveCommunicationChannel(String username, String tenantDomain, String userstoreDomain,
+            Map<String, String> claimsMap) throws NotificationChannelManagerException {
+
+        boolean isChannelResolvingEnabled = Boolean.parseBoolean(
+                IdentityUtil.getProperty(IdentityMgtConstants.PropertyConfig.RESOLVE_NOTIFICATION_CHANNELS));
+
+        // If channel resolving logic is not enabled, return the server default notification channel.
+        if (!isChannelResolvingEnabled) {
+            return IdentityGovernanceUtil.getDefaultNotificationChannel();
+        }
+        String preferredChannel = claimsMap.get(IdentityMgtConstants.Claim.PREFERED_CHANNEL_CLAIM);
+        if (StringUtils.isNotEmpty(preferredChannel)) {
+            if (isSupportedChannel(preferredChannel)) {
+                if (validatePreferredChannelWithValuesInClaimMap(preferredChannel, claimsMap)) {
+                    return preferredChannel;
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("No value in the matching claim for preferred channel : " + preferredChannel);
+                    }
+                    throw new NotificationChannelManagerClientException(
+                            IdentityMgtConstants.ErrorMessages.ERROR_CODE_NO_CLAIM_MATCHED_FOR_PREFERRED_CHANNEL
+                                    .getCode(),
+                            IdentityMgtConstants.ErrorMessages.ERROR_CODE_NO_CLAIM_MATCHED_FOR_PREFERRED_CHANNEL
+                                    .getMessage());
+                }
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("Given preferred channel : " + preferredChannel + " is not supported by the server");
+                }
+                throw new NotificationChannelManagerClientException(
+                        IdentityMgtConstants.ErrorMessages.ERROR_CODE_UNSUPPORTED_PREFERRED_CHANNEL.getCode(),
+                        IdentityMgtConstants.ErrorMessages.ERROR_CODE_UNSUPPORTED_PREFERRED_CHANNEL.getMessage());
+            }
+        } else {
+            preferredChannel = resolveCommunicationChannel(channels, claimsMap);
+        }
+        return preferredChannel;
+    }
+
+    /**
+     * Resolve a communication channels to send notifications according to the available claims of the user.
+     *
+     * @param username        Username of the user
+     * @param tenantDomain    Tenant domain of the user
+     * @param userstoreDomain Userstore domain of the user
+     * @return Communication channel
+     * @throws NotificationChannelManagerException Error while resolving the channel
+     */
+    @Override
+    public String resolveCommunicationChannel(String username, String tenantDomain, String userstoreDomain)
+            throws NotificationChannelManagerException {
+
+        boolean isChannelResolvingEnabled = Boolean.parseBoolean(
+                IdentityUtil.getProperty(IdentityMgtConstants.PropertyConfig.RESOLVE_NOTIFICATION_CHANNELS));
+
+        // If channel resolving logic is not enabled, return the server default notification channel.
+        if (!isChannelResolvingEnabled) {
+            return IdentityGovernanceUtil.getDefaultNotificationChannel();
+        }
+        Map<String, String> claimMap = buildChannelClaimsMap(username,tenantDomain);
+
+        // If there are no values for channel related claims.
+        if (MapUtils.isEmpty(claimMap)) {
+            if (log.isDebugEnabled()) {
+                String error = String.format("No notification channel for user : %1$s with domain : %2$s.",
+                        userstoreDomain + CarbonConstants.DOMAIN_SEPARATOR + username, tenantDomain);
+                log.debug(error);
+            }
+            throw new NotificationChannelManagerClientException(
+                    IdentityMgtConstants.ErrorMessages.ERROR_CODE_NO_NOTIFICATION_CHANNELS.getCode(),
+                    IdentityMgtConstants.ErrorMessages.ERROR_CODE_NO_NOTIFICATION_CHANNELS.getMessage());
+        }
+        String preferredChannel = claimMap.get(IdentityMgtConstants.Claim.PREFERED_CHANNEL_CLAIM);
+
+        // If the user has already specified a channel, then no need to evaluate the claims for a notification channel.
+        if (StringUtils.isNotEmpty(preferredChannel)) {
+            // Check whether the preferred channel has claims values.
+            if (validatePreferredChannelWithValuesInClaimMap(preferredChannel, claimMap)) {
+                return preferredChannel;
+            }
+            throw new NotificationChannelManagerClientException(
+                    IdentityMgtConstants.ErrorMessages.ERROR_CODE_NO_CLAIM_MATCHED_FOR_PREFERRED_CHANNEL.getCode(),
+                    IdentityMgtConstants.ErrorMessages.ERROR_CODE_NO_CLAIM_MATCHED_FOR_PREFERRED_CHANNEL.getMessage());
+        }
+        return resolveCommunicationChannel(this.channels, claimMap);
+    }
+
+    /**
+     * Checks whether the preferred communication channel matches the given channel values.
+     *
+     * @param claimsMap User's claims
+     * @return True of preferred channel has a value in the claims map.
+     */
+    private boolean validatePreferredChannelWithValuesInClaimMap(String preferredChannel, Map<String, String> claimsMap)
+            throws NotificationChannelManagerClientException {
+
+        // Get the notification channel which matches the given channel type
+        NotificationChannels channel = NotificationChannels.getNotificationChannel(preferredChannel);
+        return StringUtils.isNotEmpty(claimsMap.get(channel.getClaimUri()));
+    }
+
+    /**
+     * Get a notification channel for the given set of claims which are belong to a user.
+     *
+     * @param channels  notification channels
+     * @param claimsMap Claims
+     * @return notification channel
+     */
+    private String resolveCommunicationChannel(ArrayList<NotificationChannels> channels,
+            Map<String, String> claimsMap) {
+
+        ArrayList<String> availableChannels = new ArrayList<>();
+        for (NotificationChannels channel : channels) {
+
+            // Checks whether there is a value value for given communication channel url.
+            String value = claimsMap.get(channel.getClaimUri());
+            if (StringUtils.isNotEmpty(value)) {
+
+                // Add the channel type as a available channel.
+                availableChannels.add(channel.getChannelType());
+            }
+        }
+        if (!availableChannels.isEmpty()) {
+            if (availableChannels.size() > 1) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Multiple notification channels available for the user");
+                }
+                return resolveMultipleAvailableChannels(availableChannels);
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("Single notification channel is available : " + availableChannels.get(0));
+                }
+                return availableChannels.get(0);
+            }
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Resolve a communication channel when multiple channels are available for the user.
+     *
+     * @param availableChannels Available channels for the user
+     * @return Resolved notification channel
+     */
+    private String resolveMultipleAvailableChannels(ArrayList<String> availableChannels) {
+
+        // Get server default configurations.
+        String serverDefaultChannel = IdentityGovernanceUtil.getDefaultNotificationChannel();
+
+        // Check whether the server default communication channel is available for the user.
+        if (availableChannels.contains(serverDefaultChannel)) {
+            if (log.isDebugEnabled()) {
+                log.debug("User has multiple communication channels. Using server default configuration : "
+                        + serverDefaultChannel + " channel as the communication channel");
+            }
+            return serverDefaultChannel;
+        }
+
+        // Reaching this point will imply that user does not have server default channel in his/her available
+        // channel list. Therefore, sending the first channel as in the list as preferred channel.
+        String availableChannel = availableChannels.get(0);
+        if (log.isDebugEnabled()) {
+            String message = String.format("User does not have server default channel : %1$s. Therefore,"
+                    + "communication channel is set to : %2$s", serverDefaultChannel, availableChannel);
+            log.debug(message);
+        }
+        return availableChannel;
+    }
+
+    /**
+     * Create a claims list related to notification channels using the notification channel objects.
+     *
+     * @param channels Notification channel objects
+     * @return List of claims associated with the notification channels
+     */
+    private ArrayList<String> getChannelsClaimList(ArrayList<NotificationChannels> channels) {
+
+        ArrayList<String> claimList = new ArrayList<>();
+        for (NotificationChannels channel : channels) {
+            claimList.add(channel.getClaimUri());
+        }
+        return claimList;
+    }
+
+    /**
+     * Build the user claims map with notification channel information.
+     *
+     * @param username     Username
+     * @param tenantDomain Tenant domain
+     * @return User claims map with notification channel information
+     * @throws NotificationChannelManagerServerException Error while getting user claims
+     */
+    private Map<String, String> buildChannelClaimsMap(String username, String tenantDomain)
+            throws NotificationChannelManagerServerException {
+
+        ArrayList<String> claimUrls = getChannelsClaimList(this.channels);
+        claimUrls.add(IdentityMgtConstants.Claim.PREFERED_CHANNEL_CLAIM);
+        UserStoreManager userStoreManager = getUserstoreManager(username, tenantDomain);
+        Map<String, String> claimValues;
+        try {
+            claimValues = userStoreManager.getUserClaimValues(username, claimUrls.toArray(new String[0]), null);
+        } catch (UserStoreException exception) {
+
+            // This error will occur due to unavailability of identity claims.
+            // Retrieving email address and mobile claims for user.
+            String[] channelClaims = new String[] {
+                    NotificationChannels.SMS_CHANNEL.getClaimUri(), NotificationChannels.EMAIL_CHANNEL.getClaimUri()
+            };
+            try {
+                claimValues = userStoreManager.getUserClaimValues(username, channelClaims, null);
+            } catch (UserStoreException e) {
+                throw new NotificationChannelManagerServerException(
+                        IdentityMgtConstants.ErrorMessages.ERROR_CODE_DEFAULT_SERVER_ERROR.getCode(),
+                        IdentityMgtConstants.ErrorMessages.ERROR_CODE_DEFAULT_SERVER_ERROR.getMessage(), e);
+            }
+        }
+        return claimValues;
+    }
+
+    /**
+     * Get the UserStoreManager
+     *
+     * @param username     Username
+     * @param tenantDomain Tenant domain
+     * @return UserStoreManager
+     * @throws NotificationChannelManagerServerException Error getting UserStoreManager
+     */
+    private UserStoreManager getUserstoreManager(String username, String tenantDomain)
+            throws NotificationChannelManagerServerException {
+
+        try {
+            int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+            RealmService realmService = IdentityMgtServiceDataHolder.getInstance().getRealmService();
+            UserRealm userRealm = realmService.getTenantUserRealm(tenantId);
+            if (userRealm != null) {
+                return userRealm.getUserStoreManager();
+            } else {
+                if (log.isDebugEnabled()) {
+                    String error = String
+                            .format("User Realm returned NULL for user : %1$s with in " + "domain : %2$s", username,
+                                    tenantDomain);
+                    log.debug(error);
+                }
+                throw new NotificationChannelManagerServerException(
+                        IdentityMgtConstants.ErrorMessages.ERROR_CODE_DEFAULT_SERVER_ERROR.getCode(),
+                        IdentityMgtConstants.ErrorMessages.ERROR_CODE_DEFAULT_SERVER_ERROR.getMessage());
+            }
+        } catch (UserStoreException e) {
+            throw new NotificationChannelManagerServerException(
+                    IdentityMgtConstants.ErrorMessages.ERROR_CODE_DEFAULT_SERVER_ERROR.getCode(),
+                    IdentityMgtConstants.ErrorMessages.ERROR_CODE_DEFAULT_SERVER_ERROR.getMessage(), e);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/notification/NotificationChannelManager.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/notification/NotificationChannelManager.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.governance.service.notification;
+
+import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationChannelManagerException;
+
+import java.util.Map;
+
+/**
+ * Service Interface for resolving notification channel.
+ */
+public interface NotificationChannelManager {
+
+    /**
+     * Validate whether the user specified notification channel type is supported by the server or not.
+     *
+     * @param preferredChannel Type of the user preferred notification channel
+     * @return True if the preferred channel is supported
+     */
+    boolean isSupportedChannel(String preferredChannel);
+
+    /**
+     * Resolve a communication channels to send notifications according to the available claims of the user.
+     *
+     * @param username        Username of the user
+     * @param tenantDomain    Tenant domain of the user
+     * @param userstoreDomain Userstore domain of the user
+     * @return Communication channel
+     * @throws NotificationChannelManagerException Error while resolving the channel
+     */
+    String resolveCommunicationChannel(String username, String tenantDomain, String userstoreDomain)
+            throws NotificationChannelManagerException;
+
+    /**
+     * Resolve a communication channels to send notifications according to a map of claims available to the user.
+     *
+     * @param username        Username of the user
+     * @param tenantDomain    Tenant domain of the user
+     * @param userstoreDomain Userstore domain of the user
+     * @param claimsMap       Map of the user claims with claim uri as the key and claim value as the value of the ma.
+     * @return Communication channel
+     * @throws NotificationChannelManagerException Error while resolving the channel
+     */
+    String resolveCommunicationChannel(String username, String tenantDomain, String userstoreDomain,
+            Map<String, String> claimsMap) throws NotificationChannelManagerException;
+
+}

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/notification/NotificationChannels.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/notification/NotificationChannels.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.governance.service.notification;
+
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
+import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationChannelManagerClientException;
+
+/**
+ * Enum contains the supported notification channels by the identity server.
+ */
+public enum NotificationChannels {
+
+    EMAIL_CHANNEL("EMAIL", "http://wso2.org/claims/emailaddress",
+            "http://wso2.org/claims/identity/emailVerified"),
+    SMS_CHANNEL("SMS", "http://wso2.org/claims/mobile",
+            "http://wso2.org/claims/identity/phoneVerified");
+
+    // Type of the channel. Eg: EMAIL or SMS.
+    private String channelType;
+
+    // Verification claim url of the channel.
+    private String verifiedClaimUrl;
+
+    // Claim url of the channel.
+    private String claimUrl;
+
+    /**
+     * Get claim url of the channel.
+     *
+     * @return Claim url of the channel
+     */
+    public String getClaimUri() {
+        return claimUrl;
+    }
+
+
+    /**
+     * Get claim url of the channel.
+     *
+     * @return Claim url of the channel
+     */
+    public String getVerifiedClaimUrl() {
+        return verifiedClaimUrl;
+    }
+
+    /**
+     * Get channel type/name of the channel.
+     *
+     * @return Claim url of the channel
+     */
+    public String getChannelType() {
+        return channelType;
+    }
+
+    NotificationChannels(String type, String claimUrl, String verifiedClaimUrl) {
+
+        this.channelType = type;
+        this.claimUrl = claimUrl;
+        this.verifiedClaimUrl = verifiedClaimUrl;
+    }
+
+    /**
+     * Get NotificationChannels enum which matches the channel type.
+     *
+     * @param channelType Type of the channel
+     * @return NotificationChannel which matches the given channel type
+     */
+    public static NotificationChannels getNotificationChannel(String channelType)
+            throws NotificationChannelManagerClientException {
+
+        if (EMAIL_CHANNEL.getChannelType().equals(channelType)) {
+            return EMAIL_CHANNEL;
+        } else if (SMS_CHANNEL.getChannelType().equals(channelType)) {
+            return SMS_CHANNEL;
+        } else {
+            throw new NotificationChannelManagerClientException(
+                    IdentityMgtConstants.ErrorMessages.ERROR_CODE_NO_NOTIFICATION_CHANNELS.getCode(),
+                    IdentityMgtConstants.ErrorMessages.ERROR_CODE_NO_NOTIFICATION_CHANNELS.getMessage());
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStore.java
@@ -101,10 +101,9 @@ public class InMemoryIdentityDataStore extends UserIdentityDataStore {
                 if (cache != null) {
                     UserIdentityClaim cachedUserIdentityDTO = cache.get(key);
                     if (cachedUserIdentityDTO != null) {
-                        cachedUserIdentityDTO.getUserIdentityDataMap().putAll(userIdentityDTO.getUserIdentityDataMap());
-                    } else {
-                        cache.put(key, userIdentityDTO);
+                        userIdentityDTO.getUserIdentityDataMap().putAll(cachedUserIdentityDTO.getUserIdentityDataMap());
                     }
+                    cache.put(key, userIdentityDTO);
                 }
             }
         } catch (UserStoreException e) {

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStore.java
@@ -99,7 +99,12 @@ public class InMemoryIdentityDataStore extends UserIdentityDataStore {
 
                 Cache<String, UserIdentityClaim> cache = getCache();
                 if (cache != null) {
-                    cache.put(key, userIdentityDTO);
+                    UserIdentityClaim cachedUserIdentityDTO = cache.get(key);
+                    if (cachedUserIdentityDTO != null) {
+                        cachedUserIdentityDTO.getUserIdentityDataMap().putAll(userIdentityDTO.getUserIdentityDataMap());
+                    } else {
+                        cache.put(key, userIdentityDTO);
+                    }
                 }
             }
         } catch (UserStoreException e) {

--- a/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/internal/service/impl/notification/DefaultNotificationChannelManagerTest.java
+++ b/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/internal/service/impl/notification/DefaultNotificationChannelManagerTest.java
@@ -1,0 +1,485 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.identity.governance.internal.service.impl.notification;
+
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.testng.Assert.*;
+
+import org.apache.commons.lang.StringUtils;
+import org.mockito.InjectMocks;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.IObjectFactory;
+import org.testng.annotations.*;
+
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.governance.IdentityGovernanceUtil;
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
+import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationChannelManagerException;
+import org.wso2.carbon.identity.governance.internal.IdentityMgtServiceDataHolder;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
+
+import java.util.HashMap;
+
+/**
+ * Class contains test cases for DefaultNotificationChannelManager.
+ */
+
+@PrepareForTest({ IdentityUtil.class, IdentityTenantUtil.class, IdentityGovernanceUtil.class,
+                  IdentityMgtServiceDataHolder.class })
+
+public class DefaultNotificationChannelManagerTest {
+
+    /**
+     * DefaultNotificationChannelManager instance.
+     */
+    @InjectMocks
+    private DefaultNotificationChannelManager defaultNotificationChannelManager;
+
+    /**
+     * Claims map with channel related attributes.
+     */
+    private HashMap<String, String> channelClaims;
+
+    @Mock
+    UserStoreManager userStoreManager;
+
+    @Mock
+    RealmService realmService;
+
+    @Mock
+    UserRealm userRealm;
+
+    @Mock
+    IdentityMgtServiceDataHolder identityMgtServiceDataHolder;
+
+    @ObjectFactory
+    public IObjectFactory getObjectFactory() {
+
+        return new org.powermock.modules.testng.PowerMockObjectFactory();
+    }
+
+    private static final String SUCCESSFUL_CHANNEL_RESOLVE = "Successful channel resolve";
+    private static final String ERROR_IN_CHANNEL_RESOLVE = "Error while resolving the channel";
+    private static final String CHANNEL_RESOLVING_NOT_ENABLED = "Channel resolving not enabled";
+
+    /**
+     * Initializing variables.
+     */
+    @BeforeTest
+    public void setup() {
+
+        defaultNotificationChannelManager = new DefaultNotificationChannelManager();
+
+        // Get the claims map with the corresponding channel claims and values.
+        channelClaims = getDefaultClaimsMap(new String[] {
+                NotificationChannels.EMAIL_CHANNEL.getClaimUri(), NotificationChannels.SMS_CHANNEL.getClaimUri()
+        }, new String[] { "test@wso2.com", "1234567890" });
+    }
+
+    /**
+     * Testing for supported notification channels
+     */
+    @Test
+    public void testIsSupportedChannel() {
+
+        // SMS notification channel.
+        boolean isSupportedChannel1 = defaultNotificationChannelManager.isSupportedChannel("SMS");
+        assertTrue(isSupportedChannel1);
+
+        // EMAIL notification channel.
+        boolean isSupportedChannel2 = defaultNotificationChannelManager.isSupportedChannel("EMAIL");
+        assertTrue(isSupportedChannel2);
+
+        // Unsupported channel notification channel.
+        boolean isSupportedChannel3 = defaultNotificationChannelManager.isSupportedChannel("CALL");
+        assertFalse(isSupportedChannel3);
+
+        // Case sensitivity test.
+        boolean isSupportedChannel4 = defaultNotificationChannelManager.isSupportedChannel("email");
+        assertTrue(isSupportedChannel4);
+    }
+
+    /**
+     * Test resolve notification channel for the user by resolving the channel claims in the request.
+     *
+     * @param channelClaims              Channel claims
+     * @param defaultNotificationChannel Default notification channel
+     * @param expectedChannel            Expected resolved channel
+     * @param scenario                   Channel resolving scenario.
+     * @param scenarioType               Channel resolving scenario type
+     * @param expectedErrorCode          Expected error
+     * @throws NotificationChannelManagerException Error while resolving the channel
+     */
+    @Test(dataProvider = "channelClaimsForChannelResolveUsingUserClaimsMap")
+    public void testResolveCommunicationChannel(HashMap<String, String> channelClaims,
+            String defaultNotificationChannel, String expectedChannel, String scenario, String scenarioType,
+            String expectedErrorCode) throws NotificationChannelManagerException {
+
+        // Test Meta data.
+        String testUser = "testUser";
+        String testTenantDomain = "testTenantDomain";
+        String testUserstoreDomain = "testTenantDomain";
+
+        // Convert the empty strings to null objects, since null objects cannot be passed as method arguments.
+        if (StringUtils.isEmpty(expectedChannel)) {
+            expectedChannel = null;
+        }
+        if (SUCCESSFUL_CHANNEL_RESOLVE.equals(scenarioType)) {
+
+            // Mock configurations.
+            mockSelfRegistrationConfigurations(defaultNotificationChannel, true);
+            String resolvedChannel = defaultNotificationChannelManager
+                    .resolveCommunicationChannel(testUser, testTenantDomain, testUserstoreDomain, channelClaims);
+            assertEquals(resolvedChannel, expectedChannel, scenario);
+        } else if (ERROR_IN_CHANNEL_RESOLVE.equals(scenarioType)) {
+            try {
+                // Mock configurations.
+                mockSelfRegistrationConfigurations(defaultNotificationChannel, true);
+                String resolvedChannel = defaultNotificationChannelManager
+                        .resolveCommunicationChannel(testUser, testTenantDomain, testUserstoreDomain, channelClaims);
+                assertEquals(resolvedChannel, expectedChannel, scenario);
+            } catch (NotificationChannelManagerException e) {
+                assertEquals(e.getErrorCode(), expectedErrorCode, scenario);
+            }
+        } else if (CHANNEL_RESOLVING_NOT_ENABLED.equals(scenarioType)) {
+
+            // Mock configurations.
+            mockSelfRegistrationConfigurations(defaultNotificationChannel, false);
+            String resolvedChannel = defaultNotificationChannelManager
+                    .resolveCommunicationChannel(testUser, testTenantDomain, testUserstoreDomain, channelClaims);
+            assertEquals(resolvedChannel, expectedChannel, scenario);
+        }
+    }
+
+    /**
+     * Test resolving notification channel using the user.
+     *
+     * @param channelClaims              Channel claims
+     * @param defaultNotificationChannel Default notification channel
+     * @param expectedChannel            Expected resolved channel
+     * @param scenario                   Channel resolving scenario.
+     * @param scenarioType               Channel resolving scenario type
+     * @param expectedErrorCode          Expected error
+     * @throws NotificationChannelManagerException Error while resolving the channel
+     */
+    @Test(dataProvider = "channelClaimsForChannelResolveUsingUser")
+    public void testResolveCommunicationChannelWithUsername(HashMap<String, String> channelClaims,
+            String defaultNotificationChannel, String expectedChannel, String scenario, String scenarioType,
+            String expectedErrorCode) throws Exception {
+
+        // Meta Data
+        String testUser = "testUser";
+        String testTenantDomain = "testTenantDomain";
+        String testUserstoreDomain = "testTenantDomain";
+
+        // Mock classes and configurations.
+        mockUserstoreManager(channelClaims);
+        mockSelfRegistrationConfigurations(defaultNotificationChannel, true);
+
+        // Convert the empty strings to null objects, since null objects cannot be passed as method arguments.
+        if (StringUtils.isEmpty(expectedChannel)) {
+            expectedChannel = null;
+        }
+        if (SUCCESSFUL_CHANNEL_RESOLVE.equals(scenarioType)) {
+            String resolvedChannel = defaultNotificationChannelManager
+                    .resolveCommunicationChannel(testUser, testTenantDomain, testUserstoreDomain);
+            assertEquals(resolvedChannel, expectedChannel, scenario);
+        } else if (ERROR_IN_CHANNEL_RESOLVE.equals(scenarioType)) {
+            try {
+                String resolvedChannel = defaultNotificationChannelManager
+                        .resolveCommunicationChannel(testUser, testTenantDomain, testUserstoreDomain);
+                assertEquals(resolvedChannel, expectedChannel, scenario);
+            } catch (NotificationChannelManagerException e) {
+                assertEquals(e.getErrorCode(), expectedErrorCode, scenario);
+            }
+        } else if (CHANNEL_RESOLVING_NOT_ENABLED.equals(scenarioType)){
+            mockSelfRegistrationConfigurations(defaultNotificationChannel, false);
+            String resolvedChannel = defaultNotificationChannelManager
+                    .resolveCommunicationChannel(testUser, testTenantDomain, testUserstoreDomain);
+            assertEquals(resolvedChannel, expectedChannel, scenario);
+        }
+    }
+
+    /**
+     * Mock self registration configurations.
+     *
+     * @param defaultNotificationChannel Default notification channel
+     * @param enableResolving            Enable channel resolving
+     */
+    private void mockSelfRegistrationConfigurations(String defaultNotificationChannel, boolean enableResolving) {
+
+        mockStatic(IdentityUtil.class);
+        when(IdentityUtil.getProperty(IdentityMgtConstants.NotificationChannelConstants.DEFAULT_NOTIFICATION_CHANNEL))
+                .thenReturn(defaultNotificationChannel);
+        when(IdentityUtil.getProperty(IdentityMgtConstants.PropertyConfig.RESOLVE_NOTIFICATION_CHANNELS))
+                .thenReturn(Boolean.toString(enableResolving));
+    }
+
+    /**
+     * Mock userstore manager to get user claims.
+     *
+     * @param claimsMap User claims
+     * @throws Exception Error while mocking Userstoremanager
+     */
+    private void mockUserstoreManager(HashMap<String, String> claimsMap) throws Exception {
+
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getTenantId(Matchers.anyString())).thenReturn(-1234);
+
+        mockStatic(IdentityMgtServiceDataHolder.class);
+        when(IdentityMgtServiceDataHolder.getInstance()).thenReturn(identityMgtServiceDataHolder);
+        when(identityMgtServiceDataHolder.getRealmService()).thenReturn(realmService);
+        when(realmService.getTenantUserRealm(Matchers.anyInt())).thenReturn(userRealm);
+        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+        when(userStoreManager
+                .getUserClaimValues(Matchers.anyString(), Matchers.any(String[].class), Matchers.anyString()))
+                .thenReturn(claimsMap);
+
+    }
+
+    /**
+     * Method to create a claims map.
+     * NOTE: the length of both arguments needs to be the same.
+     *
+     * @param keys   Key set
+     * @param values Values
+     * @return Map of claims
+     */
+    private HashMap<String, String> getDefaultClaimsMap(String[] keys, String[] values) {
+
+        HashMap<String, String> channelClaims = new HashMap<>();
+        for (int counter = 0; counter < keys.length; counter++) {
+            channelClaims.put(keys[counter], values[counter]);
+        }
+        return channelClaims;
+    }
+
+    /**
+     * Contains user data related to the channels to resolve the notification channel using user claims in the request.
+     *
+     * @return Object[][]
+     */
+    @DataProvider(name = "channelClaimsForChannelResolveUsingUserClaimsMap")
+    private Object[][] buildChannelClaimSet1() {
+
+        // Preferred Channel EMAIL with email claim values.
+        HashMap<String, String> channelClaimsMap1 = new HashMap<>(channelClaims);
+        channelClaimsMap1.put(IdentityMgtConstants.Claim.PREFERED_CHANNEL_CLAIM,
+                NotificationChannels.EMAIL_CHANNEL.getChannelType());
+        String defaultChannel1 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String expectedChannel1 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String message1 = "SCENARIO: User specified the Preferred Channel as EMAIL and has email claim values : ";
+
+        // Preferred Channel SMS with SMS claim values.
+        HashMap<String, String> channelClaimsMap2 = new HashMap<>(channelClaims);
+        channelClaimsMap2.put(IdentityMgtConstants.Claim.PREFERED_CHANNEL_CLAIM,
+                NotificationChannels.SMS_CHANNEL.getChannelType());
+        String defaultChannel2 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String expectedChannel2 = NotificationChannels.SMS_CHANNEL.getChannelType();
+        String message2 = "SCENARIO: User specified the Preferred Channel as SMS and has mobile claim values : ";
+
+        // User has not specified a preferred channel, but have values for email claim.
+        HashMap<String, String> channelClaimsMap3 = new HashMap<>(channelClaims);
+        channelClaimsMap3.remove(NotificationChannels.SMS_CHANNEL.getClaimUri());
+        String defaultChannel3 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String expectedChannel3 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String message3 = "SCENARIO: User has no preferred channel, has email claims only : ";
+
+        // User has not specified a preferred channel, but have values for mobile claim.
+        HashMap<String, String> channelClaimsMap4 = new HashMap<>(channelClaims);
+        channelClaimsMap4.remove(NotificationChannels.EMAIL_CHANNEL.getClaimUri());
+        String defaultChannel4 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String expectedChannel4 = NotificationChannels.SMS_CHANNEL.getChannelType();
+        String message4 = "SCENARIO: User has no preferred channel, has mobile claims only : ";
+
+        // User has not specified a preferred channel, but provided both email and mobile values.
+        // Default notification channel in EMAIL.
+        HashMap<String, String> channelClaimsMap5 = new HashMap<>(channelClaims);
+        String defaultChannel5 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String expectedChannel5 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String message5 = "SCENARIO: User has both email and mobile claims. Default channel EMAIL : ";
+
+        // User has not specified a preferred channel, but provided both email and mobile values.
+        // Default notification channel in SMS.
+        HashMap<String, String> channelClaimsMap6 = new HashMap<>(channelClaims);
+        String defaultChannel6 = NotificationChannels.SMS_CHANNEL.getChannelType();
+        String expectedChannel6 = NotificationChannels.SMS_CHANNEL.getChannelType();
+        String message6 = "SCENARIO: User has both email and mobile claims. Default channel SMS : ";
+
+        // User has not specified a preferred channel or notification channels.
+        HashMap<String, String> channelClaimsMap7 = new HashMap<>();
+        String defaultChannel7 = NotificationChannels.SMS_CHANNEL.getChannelType();
+        String message7 = "SCENARIO: User has not specified any notification channels : ";
+
+        /* ERROR SCENARIOS */
+        // No claim values for the preferred channel.
+        HashMap<String, String> channelClaimsMap8 = new HashMap<>();
+        channelClaimsMap8.put(IdentityMgtConstants.Claim.PREFERED_CHANNEL_CLAIM,
+                NotificationChannels.EMAIL_CHANNEL.getChannelType());
+        String defaultChannel8 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String message8 = "SCENARIO: User specified the Preferred Channel as EMAIL, but no email claim values : ";
+        String expectedErrorCode8 = IdentityMgtConstants.ErrorMessages.
+                ERROR_CODE_NO_CLAIM_MATCHED_FOR_PREFERRED_CHANNEL.getCode();
+
+        // Invalid notification channel as the preferred notification channel.
+        HashMap<String, String> channelClaimsMap9 = new HashMap<>(channelClaims);
+        channelClaimsMap9.put(IdentityMgtConstants.Claim.PREFERED_CHANNEL_CLAIM, "new notification channel");
+        String defaultChannel9 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String message9 = "SCENARIO: User specified an invalid notification channel type : ";
+        String expectedErrorCode9 = IdentityMgtConstants.ErrorMessages.
+                ERROR_CODE_UNSUPPORTED_PREFERRED_CHANNEL.getCode();
+
+        /* CHANNEL RESOLVING CONFIG NOT ENABLED */
+        // Default notification channel in EMAIL.
+        HashMap<String, String> channelClaimsMap10 = new HashMap<>(channelClaims);
+        String defaultChannel10 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String expectedChannel10 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String message10 = "SCENARIO: Configs not enabled. Default Channel " + defaultChannel10 + " : ";
+
+        // Default notification channel in SMS.
+        HashMap<String, String> channelClaimsMap11 = new HashMap<>(channelClaims);
+        String defaultChannel11 = NotificationChannels.SMS_CHANNEL.getChannelType();
+        String expectedChannel11 = NotificationChannels.SMS_CHANNEL.getChannelType();
+        String message11 = "SCENARIO: Configs not enabled. Default Channel " + defaultChannel11 + " : ";
+
+        return new Object[][] {
+                { channelClaimsMap1, defaultChannel1, expectedChannel1, message1, SUCCESSFUL_CHANNEL_RESOLVE, null },
+                { channelClaimsMap2, defaultChannel2, expectedChannel2, message2, SUCCESSFUL_CHANNEL_RESOLVE, null },
+                { channelClaimsMap3, defaultChannel3, expectedChannel3, message3, SUCCESSFUL_CHANNEL_RESOLVE, null },
+                { channelClaimsMap4, defaultChannel4, expectedChannel4, message4, SUCCESSFUL_CHANNEL_RESOLVE, null },
+                { channelClaimsMap5, defaultChannel5, expectedChannel5, message5, SUCCESSFUL_CHANNEL_RESOLVE, null },
+                { channelClaimsMap6, defaultChannel6, expectedChannel6, message6, SUCCESSFUL_CHANNEL_RESOLVE, null },
+                { channelClaimsMap7, defaultChannel7, StringUtils.EMPTY, message7, SUCCESSFUL_CHANNEL_RESOLVE, null },
+                { channelClaimsMap8, defaultChannel8, StringUtils.EMPTY, message8, ERROR_IN_CHANNEL_RESOLVE,
+                  expectedErrorCode8 },
+                { channelClaimsMap9, defaultChannel9, StringUtils.EMPTY, message9, ERROR_IN_CHANNEL_RESOLVE,
+                  expectedErrorCode9 },
+                { channelClaimsMap10, defaultChannel10, expectedChannel10, message10, CHANNEL_RESOLVING_NOT_ENABLED,
+                  null },
+                { channelClaimsMap11, defaultChannel11, expectedChannel11, message11, CHANNEL_RESOLVING_NOT_ENABLED,
+                  null }
+        };
+
+    }
+
+    /**
+     * Contains user data related to the channels to resolve the notification channel using username in the request.
+     *
+     * @return Object[][]
+     */
+    @DataProvider(name = "channelClaimsForChannelResolveUsingUser")
+    private Object[][] buildChannelClaimSet2() {
+
+        // Preferred Channel EMAIL with email claim values.
+        HashMap<String, String> channelClaimsMap1 = new HashMap<>(channelClaims);
+        channelClaimsMap1.put(IdentityMgtConstants.Claim.PREFERED_CHANNEL_CLAIM,
+                NotificationChannels.EMAIL_CHANNEL.getChannelType());
+        String defaultChannel1 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String expectedChannel1 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String message1 = "SCENARIO: User specified the Preferred Channel as EMAIL and has email claim values : ";
+
+        // Preferred Channel SMS with SMS claim values.
+        HashMap<String, String> channelClaimsMap2 = new HashMap<>(channelClaims);
+        channelClaimsMap2.put(IdentityMgtConstants.Claim.PREFERED_CHANNEL_CLAIM,
+                NotificationChannels.SMS_CHANNEL.getChannelType());
+        String defaultChannel2 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String expectedChannel2 = NotificationChannels.SMS_CHANNEL.getChannelType();
+        String message2 = "SCENARIO: User specified the Preferred Channel as SMS and has mobile claim values : ";
+
+        // User has not specified a preferred channel, but have values for email claim.
+        HashMap<String, String> channelClaimsMap3 = new HashMap<>(channelClaims);
+        channelClaimsMap3.remove(NotificationChannels.SMS_CHANNEL.getClaimUri());
+        String defaultChannel3 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String expectedChannel3 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String message3 = "SCENARIO: User has no preferred channel, has email claims only : ";
+
+        // User has not specified a preferred channel, but have values for mobile claim.
+        HashMap<String, String> channelClaimsMap4 = new HashMap<>(channelClaims);
+        channelClaimsMap4.remove(NotificationChannels.EMAIL_CHANNEL.getClaimUri());
+        String defaultChannel4 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String expectedChannel4 = NotificationChannels.SMS_CHANNEL.getChannelType();
+        String message4 = "SCENARIO: User has no preferred channel, has mobile claims only : ";
+
+        // User has not specified a preferred channel, but provided both email and mobile values.
+        // Default notification channel in EMAIL.
+        HashMap<String, String> channelClaimsMap5 = new HashMap<>(channelClaims);
+        String defaultChannel5 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String expectedChannel5 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String message5 = "SCENARIO: User has both email and mobile claims. Default channel EMAIL : ";
+
+        // User has not specified a preferred channel, but provided both email and mobile values.
+        // Default notification channel in SMS.
+        HashMap<String, String> channelClaimsMap6 = new HashMap<>(channelClaims);
+        String defaultChannel6 = NotificationChannels.SMS_CHANNEL.getChannelType();
+        String expectedChannel6 = NotificationChannels.SMS_CHANNEL.getChannelType();
+        String message6 = "SCENARIO: User has both email and mobile claims. Default channel SMS : ";
+
+        /* ERROR SCENARIOS */
+        // Preferred channel as EMAIL but no claims for email channel.
+        HashMap<String, String> channelClaimsMap7 = new HashMap<>(channelClaims);
+        channelClaimsMap7.remove(NotificationChannels.EMAIL_CHANNEL.getClaimUri());
+        channelClaimsMap7.put(IdentityMgtConstants.Claim.PREFERED_CHANNEL_CLAIM,
+                NotificationChannels.EMAIL_CHANNEL.getChannelType());
+        String defaultChannel7 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String message7 = "SCENARIO: User specified the Preferred Channel as EMAIL, but no email claim values : ";
+        String expectedErrorCode7 =
+                IdentityMgtConstants.ErrorMessages.ERROR_CODE_NO_CLAIM_MATCHED_FOR_PREFERRED_CHANNEL.getCode();
+
+        // User has no channel claims.
+        HashMap<String, String> channelClaimsMap8 = new HashMap<>();
+        String defaultChannel8 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String message8 = "SCENARIO: User no channel claims : ";
+        String expectedErrorCode8 =
+                IdentityMgtConstants.ErrorMessages.ERROR_CODE_NO_NOTIFICATION_CHANNELS.getCode();
+
+        /* CHANNEL RESOLVING CONFIG NOT ENABLED */
+        // Default notification channel in EMAIL.
+        HashMap<String, String> channelClaimsMap9 = new HashMap<>(channelClaims);
+        String defaultChannel9 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String expectedChannel9 = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        String message9 = "SCENARIO: Configs not enabled. Default Channel " + defaultChannel9 + " : ";
+
+        // Default notification channel in SMS.
+        HashMap<String, String> channelClaimsMap10 = new HashMap<>(channelClaims);
+        String defaultChannel10 = NotificationChannels.SMS_CHANNEL.getChannelType();
+        String expectedChannel10 = NotificationChannels.SMS_CHANNEL.getChannelType();
+        String message10 = "SCENARIO: Configs not enabled. Default Channel " + defaultChannel10 + " : ";
+
+        return new Object[][] {
+                { channelClaimsMap1, defaultChannel1, expectedChannel1, message1, SUCCESSFUL_CHANNEL_RESOLVE, null },
+                { channelClaimsMap2, defaultChannel2, expectedChannel2, message2, SUCCESSFUL_CHANNEL_RESOLVE, null },
+                { channelClaimsMap3, defaultChannel3, expectedChannel3, message3, SUCCESSFUL_CHANNEL_RESOLVE, null },
+                { channelClaimsMap4, defaultChannel4, expectedChannel4, message4, SUCCESSFUL_CHANNEL_RESOLVE, null },
+                { channelClaimsMap5, defaultChannel5, expectedChannel5, message5, SUCCESSFUL_CHANNEL_RESOLVE, null },
+                { channelClaimsMap6, defaultChannel6, expectedChannel6, message6, SUCCESSFUL_CHANNEL_RESOLVE, null },
+                { channelClaimsMap7, defaultChannel7, StringUtils.EMPTY, message7, ERROR_IN_CHANNEL_RESOLVE,
+                  expectedErrorCode7 },
+                { channelClaimsMap8, defaultChannel8, StringUtils.EMPTY, message8, ERROR_IN_CHANNEL_RESOLVE,
+                  expectedErrorCode8 },
+                { channelClaimsMap9, defaultChannel9, expectedChannel9, message9, CHANNEL_RESOLVING_NOT_ENABLED,
+                  null },
+                { channelClaimsMap10, defaultChannel10, expectedChannel10, message10, CHANNEL_RESOLVING_NOT_ENABLED,
+                  null }
+        };
+    }
+}

--- a/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListenerTest.java
+++ b/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListenerTest.java
@@ -154,11 +154,13 @@ public class IdentityMgtEventListenerTest {
         claimSet1.put("http://wso2.org/claims/email", "example1@wso2.com");
         claimSet1.put("http://wso2.org/claims/username", "john");
         claimSet1.put("http://wso2.org/claims/identity/accountLocked", "true");
+        claimSet1.put("http://wso2.org/claims/identity/preferredChannel","EMAIL");
 
         Map<String, String> claimSet2 = new HashMap<>();
         claimSet2.put("http://wso2.org/claims/identity/oidc", "oidc");
         claimSet2.put("http://wso2.org/claims/email", "example@wso2.com");
         claimSet2.put("http://wso2.org/claims/identity/accountLocked", "false");
+        claimSet2.put("http://wso2.org/claims/identity/preferredChannel","EMAIL");
 
         return new Object[][]{
                 {"admin", claimSet1, "myProfile"},
@@ -190,11 +192,13 @@ public class IdentityMgtEventListenerTest {
         claimSet1.put("http://wso2.org/claims/email", "example@wso2.com");
         claimSet1.put("http://wso2.org/claims/username", "john");
         claimSet1.put("http://wso2.org/claims/identity/accountLocked", "true");
+        claimSet1.put("http://wso2.org/claims/identity/preferredChannel","EMAIL");
 
         Map<String, String> claimSet2 = new HashMap<>();
         claimSet2.put("http://wso2.org/claims/identity/oidc", "oidc");
         claimSet2.put("http://wso2.org/claims/email", "john@wso2.com");
         claimSet2.put("http://wso2.org/claims/identity/accountLocked", "false");
+        claimSet1.put("http://wso2.org/claims/identity/preferredChannel","EMAIL");
 
         return new Object[][]{
                 {"admin", new String("admin"), roleList, claimSet1, "muProfile"},

--- a/components/org.wso2.carbon.identity.governance/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.governance/src/test/resources/testng.xml
@@ -25,6 +25,7 @@
         <classes>
             <class name="org.wso2.carbon.identity.governance.listener.IdentityMgtEventListenerTest"></class>
             <class name="org.wso2.carbon.identity.governance.listener.IdentityStoreEventListenerTest"></class>
+            <class name="org.wso2.carbon.identity.governance.internal.service.impl.notification.DefaultNotificationChannelManagerTest"/>
         </classes>
     </test>
 </suite>

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -262,7 +262,8 @@ public class IdentityRecoveryConstants {
 
     public static class ConnectorConfig {
 
-        public static final String REGISTER_WITH_VERIFIED_CHANNELS = "SelfRegistration.RegisterWithVerifiedChannels";
+        public static final String SKIP_ACCOUNT_LOCK_ON_VERIFIED_PREFERRED_CHANNEL =
+                "SelfRegistration.SkipAccountLockOnVerifiedPreferredChannel";
         public static final String NOTIFICATION_INTERNALLY_MANAGE = "Recovery.Notification.InternallyManage";
         public static final String NOTIFY_USER_EXISTENCE = "Recovery.NotifyUserExistence";
         public static final String NOTIFICATION_SEND_RECOVERY_NOTIFICATION_SUCCESS = "Recovery.NotifySuccess";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -57,6 +57,7 @@ public class IdentityRecoveryConstants {
             "http://wso2.org/claims/identity/failedLoginLockoutCount";
     public static final String VERIFY_EMAIL_CLIAM = "http://wso2.org/claims/identity/verifyEmail";
     public static final String EMAIL_VERIFIED_CLAIM = "http://wso2.org/claims/identity/emailVerified";
+    public static final String MOBILE_VERIFIED_CLAIM = "http://wso2.org/claims/identity/phoneVerified";
     public static final String ASK_PASSWORD_CLAIM = "http://wso2.org/claims/identity/askPassword";
     public static final String ADMIN_FORCED_PASSWORD_RESET_CLAIM = "http://wso2.org/claims/identity/adminForcedPasswordReset";
     public static final String OTP_PASSWORD_CLAIM = "http://wso2.org/claims/oneTimePassword";
@@ -70,9 +71,15 @@ public class IdentityRecoveryConstants {
 
     public static final String PASSWORD_RESET_FAIL_ATTEMPTS_CLAIM = "http://wso2" +
             ".org/claims/identity/failedPasswordRecoveryAttempts";
+    public static final String PREFERRED_CHANNEL_CLAIM = "http://wso2.org/claims/identity/preferredChannel";
     public static final String SIGN_UP_ROLE_SEPARATOR = ",";
 
-
+    public static final String NOTIFICATION_EVENTNAME_PREFIX = "TRIGGER_";
+    public static final String NOTIFICATION_EVENTNAME_SUFFIX = "_NOTIFICATION";
+    public static final String SMS_TEMPLATE_PREFIX = "sms";
+    public static final String EMAIL_CHANNEL = "EMAIL";
+    public static final String SMS_CHANNEL = "SMS";
+    public static final String EXTERNAL_NOTIFICATION_CHANNEL = "EXTERNAL";
     public static final String LOCALE_EN_US = "en_US";
     public static final String LOCALE_LK_LK = "lk_lk";
     public static final String SELF_SIGNUP_ROLE = "Internal/selfsignup";
@@ -81,6 +88,8 @@ public class IdentityRecoveryConstants {
     public static final String CALLBACK = "callback";
     public static final String DEFAULT_CALLBACK_REGEX = ".*";
     public static final String IS_USER_PORTAL_URL = "isUserPortalURL";
+    public static final int SMS_OTP_CODE_LENGTH = 6;
+    public static final String SMS_OTP_GENERATE_CHAR_SET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
     private IdentityRecoveryConstants() {
     }
@@ -167,8 +176,19 @@ public class IdentityRecoveryConstants {
         ERROR_CODE_REGISTRY_EXCEPTION_DELETE_CHALLENGE_QUESTION("20059", "Registry exception while deleting challenge" +
                 " question %s of the set %s"),
         ERROR_CODE_ERROR_RETRIVING_CLAIM("18004", "Error when retrieving the locale claim of user '%s' of '%s' domain" +
-                ".");
+                "."),
 
+        // USR - User Self Registration.
+        ERROR_CODE_UNSUPPORTED_PREFERRED_CHANNELS("USR-10001",
+                "User specified communication channel is not supported by the server"),
+        ERROR_CODE_PREFERRED_CHANNEL_VALUE_EMPTY("USR-10002",
+                "User specified communication channel does not have any value"),
+        ERROR_CODE_BAD_SELF_REGISTER_REQUEST("USR-10003",
+                "Bad Request"),
+
+        // UAV - User Account Verification.
+        ERROR_CODE_UNSUPPORTED_VERIFICATION_CHANNEL("UAV-10001",
+                "Unsupported verification channel");
 
         private final String code;
         private final String message;
@@ -193,7 +213,56 @@ public class IdentityRecoveryConstants {
 
     }
 
+    /**
+     * Enum contains the status codes and status messages for successful user self registration scenarios.
+     */
+    public enum SuccessEvents {
+
+        SUCCESS_STATUS_CODE_SUCCESSFUL_USER_CREATION_INTERNAL_VERIFICATION("USR-02001",
+                "Successful user self registration. Pending account verification."),
+        SUCCESS_STATUS_CODE_SUCCESSFUL_USER_CREATION_EXTERNAL_VERIFICATION("USR-02002",
+                "Successful user self registration. Pending External verification."),
+        SUCCESS_STATUS_CODE_SUCCESSFUL_USER_CREATION_UNLOCKED_WITH_NO_VERIFICATION("USR-02003",
+                "Successful user self registration. Account verification not required."),
+        SUCCESS_STATUS_CODE_SUCCESSFUL_USER_CREATION_WITH_VERIFIED_CHANNEL("USR-02004",
+                "Successful user self registration with verified channel. "
+                        + "Account verification not required.");
+
+        private final String code;
+        private final String message;
+
+        SuccessEvents(String code, String message) {
+            this.code = code;
+            this.message = message;
+        }
+
+        /**
+         * Get the code of the SuccessEvents
+         *
+         * @return Code
+         */
+        public String getCode() {
+            return code;
+        }
+
+        /**
+         * Get the message of the success event.
+         *
+         * @return Message
+         */
+        public String getMessage() {
+            return message;
+        }
+
+        @Override
+        public String toString() {
+            return code + " - " + message;
+        }
+    }
+
     public static class ConnectorConfig {
+
+        public static final String REGISTER_WITH_VERIFIED_CHANNELS = "SelfRegistration.RegisterWithVerifiedChannels";
         public static final String NOTIFICATION_INTERNALLY_MANAGE = "Recovery.Notification.InternallyManage";
         public static final String NOTIFY_USER_EXISTENCE = "Recovery.NotifyUserExistence";
         public static final String NOTIFICATION_SEND_RECOVERY_NOTIFICATION_SUCCESS = "Recovery.NotifySuccess";
@@ -218,6 +287,8 @@ public class IdentityRecoveryConstants {
         public static final String SELF_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME = "SelfRegistration" +
                 ".VerificationCode.ExpiryTime";
         public static final String SELF_REGISTRATION_CALLBACK_REGEX = "SelfRegistration.CallbackRegex";
+        public static final String SELF_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME =
+                "SelfRegistration.VerificationCode.SMSOTP.ExpiryTime";
 
         public static final String ENABLE_EMIL_VERIFICATION = "EmailVerification.Enable";
         public static final String EMAIL_VERIFICATION_EXPIRY_TIME = "EmailVerification.ExpiryTime";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -262,8 +262,8 @@ public class IdentityRecoveryConstants {
 
     public static class ConnectorConfig {
 
-        public static final String SKIP_ACCOUNT_LOCK_ON_VERIFIED_PREFERRED_CHANNEL =
-                "SelfRegistration.SkipAccountLockOnVerifiedPreferredChannel";
+        public static final String ENABLE_ACCOUNT_LOCK_FOR_VERIFIED_PREFERRED_CHANNEL =
+                "SelfRegistration.EnableAccountLockForVerifiedPreferredChannel";
         public static final String NOTIFICATION_INTERNALLY_MANAGE = "Recovery.Notification.InternallyManage";
         public static final String NOTIFY_USER_EXISTENCE = "Recovery.NotifyUserExistence";
         public static final String NOTIFICATION_SEND_RECOVERY_NOTIFICATION_SUCCESS = "Recovery.NotifySuccess";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/bean/NotificationResponseBean.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/bean/NotificationResponseBean.java
@@ -30,15 +30,104 @@ public class NotificationResponseBean implements Serializable {
     private static final long serialVersionUID = -2913500114444797062L;
 
     /**
-     * user identifier according to the user store
+     * User identifier according to the user store
      */
     private User user;
 
     /**
-     * key that is received after successful verification
+     * Key that is received after successful verification
      */
     private String key;
 
+    /**
+     * Operation successful code.
+     */
+    private String code;
+
+    /**
+     * Operation info message.
+     */
+    private String message;
+
+    /**
+     * Channel which the notifications were sent to the user.
+     */
+    private String notificationChannel;
+
+    /**
+     * Recovery Id when notifications are externally managed.
+     */
+    private String recoveryId;
+
+    /**
+     * Get recovery Id when the notifications are externally managed.
+     * @return Recovery Id
+     */
+    public String getRecoveryId() {
+        return recoveryId;
+    }
+
+    /**
+     * Set recovery Id when the notifications are externally managed.
+     * @param recoveryId Recovery secret
+     */
+    public void setRecoveryId(String recoveryId) {
+        this.recoveryId = recoveryId;
+    }
+
+    /**
+     * Get the status code of the operation.
+     *
+     * @return Error code
+     */
+    public String getCode() {
+        return code;
+    }
+
+    /**
+     * Set the status code of the operation.
+     *
+     * @param code Error code
+     */
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    /**
+     * Get the status details massage for the operation code.
+     *
+     * @return  Detailed Message about the status
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * Set the status details massage for the operation code.
+     *
+     * @param message Detailed Message about the status
+     */
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+     * Get notification channel which the notifications were sent to the user.
+     *
+     * @return Notification Channel
+     */
+    public String getNotificationChannel() {
+        return notificationChannel;
+    }
+
+    /**
+     * Set notification channel which the notifications were sent to the user.
+     *
+     * @param notificationChannel Notification channel
+     */
+    public void setNotificationChannel(String notificationChannel) {
+        this.notificationChannel = notificationChannel;
+    }
 
     public NotificationResponseBean(User user, String key) {
         this.user = user;

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
@@ -137,7 +137,7 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
         String enableNotificationInternallyManage = "true";
         String enableSelfRegistrationReCaptcha = "true";
         String verificationCodeExpiryTime = "1440";
-        String verificationSMSOTPExpiryTime = "10";
+        String verificationSMSOTPExpiryTime = "1";
         String selfRegistrationCallbackRegex = IdentityRecoveryConstants.DEFAULT_CALLBACK_REGEX;
 
         String selfSignUpProperty = IdentityUtil.getProperty(

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
@@ -70,17 +70,19 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
 
     @Override
     public Map<String, String> getPropertyNameMapping() {
+
         Map<String, String> nameMapping = new HashMap<>();
-        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP,
-                "Enable Self User Registration");
+        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP, "Enable Self User Registration");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION,
                 "Enable Account Lock On Creation");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
                 "Internal Notification Management");
-        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA,
-                "Enable reCaptcha");
+        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA, "Enable reCaptcha");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME,
-                "User self registration code expiry time");
+                "User self registration verification link expiry time");
+        nameMapping
+                .put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME,
+                        "User self registration SMS OTP expiry time");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_CALLBACK_REGEX,
                 "User self registration callback URL regex");
         nameMapping.put(LIST_PURPOSE_PROPERTY_KEY, "Manage Self-Sign-Up purposes");
@@ -89,6 +91,7 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
 
     @Override
     public Map<String, String> getPropertyDescriptionMapping() {
+
         Map<String, String> descriptionMapping = new HashMap<>();
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP,
                 "Enable self user registration");
@@ -100,8 +103,10 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
                 "Enable captcha verification during self registration");
         descriptionMapping.put(
                 IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME,
-                "Set the number of minutes the user self registration verification mail would be valid.(Negative " +
-                        "value for infinite validity)");
+                "Set the number of minutes the user self registration verification mail would be valid");
+        descriptionMapping.put(
+                IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME,
+                "Set the number of minutes that the SMS OTP would be valid");
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_CALLBACK_REGEX,
                 "User self registration callback URL regex");
         descriptionMapping.put(LIST_PURPOSE_PROPERTY_KEY, "Click here to manage Self-Sign-Up purposes");
@@ -117,6 +122,8 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
         properties.add(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME);
+        properties
+                .add(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_CALLBACK_REGEX);
         properties.add(LIST_PURPOSE_PROPERTY_KEY);
         return properties.toArray(new String[properties.size()]);
@@ -130,6 +137,7 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
         String enableNotificationInternallyManage = "true";
         String enableSelfRegistrationReCaptcha = "true";
         String verificationCodeExpiryTime = "1440";
+        String verificationSMSOTPExpiryTime = "10";
         String selfRegistrationCallbackRegex = IdentityRecoveryConstants.DEFAULT_CALLBACK_REGEX;
 
         String selfSignUpProperty = IdentityUtil.getProperty(
@@ -142,6 +150,8 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
                 IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA);
         String verificationCodeExpiryTimeProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME);
+        String verificationSMSOTPExpiryTimeProperty = IdentityUtil.getProperty(
+                IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME);
         String selfRegistrationCallbackRegexProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_CALLBACK_REGEX);
 
@@ -160,6 +170,9 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
         if (StringUtils.isNotEmpty(verificationCodeExpiryTimeProperty)) {
             verificationCodeExpiryTime = verificationCodeExpiryTimeProperty;
         }
+        if (StringUtils.isNotEmpty(verificationSMSOTPExpiryTimeProperty)) {
+            verificationSMSOTPExpiryTime = verificationSMSOTPExpiryTimeProperty;
+        }
         if (StringUtils.isNotEmpty(selfRegistrationCallbackRegexProperty)) {
             selfRegistrationCallbackRegex = selfRegistrationCallbackRegexProperty;
         }
@@ -175,6 +188,9 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
         defaultProperties.put(
                 IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME,
                 verificationCodeExpiryTime);
+        defaultProperties
+                .put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME,
+                        verificationSMSOTPExpiryTime);
         try {
             defaultProperties.put(LIST_PURPOSE_PROPERTY_KEY, consentListURL + "&callback=" + URLEncoder.encode
                     (CALLBACK_URL, StandardCharsets.UTF_8.name()));

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.identity.governance.IdentityGovernanceUtil;
 import org.wso2.carbon.identity.governance.IdentityMgtConstants;
 import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationChannelManagerClientException;
 import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationChannelManagerException;
@@ -194,7 +195,7 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
         }
         if (log.isDebugEnabled()) {
             String message = String
-                    .format("For user : %1$s " + "in domain : %2$s, notification template : %3$s was used.",
+                    .format("For user : %1$s in domain : %2$s, notification template : %3$s was used.",
                             domainName + CarbonConstants.DOMAIN_SEPARATOR + userName, tenantDomain, templateName);
             log.debug(message);
         }
@@ -221,7 +222,7 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
         }
         if (log.isDebugEnabled()) {
             String message = String
-                    .format("For user : %1$s " + "in domain : %2$s, notifications were sent from the event : %3$s",
+                    .format("For user : %1$s in domain : %2$s, notifications were sent from the event : %3$s",
                             domainName + CarbonConstants.DOMAIN_SEPARATOR + userName, tenantDomain, eventName);
             log.debug(message);
         }
@@ -241,6 +242,12 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
     private String resolveNotificationChannel(Map<String, Object> eventProperties, String userName, String tenantDomain,
             String domainName) throws IdentityEventException {
 
+        // If channel resolving logic is not enabled, return the server default notification channel. Do not need to
+        // resolve using user preferred channel.
+        if (!Boolean.parseBoolean(
+                IdentityUtil.getProperty(IdentityMgtConstants.PropertyConfig.RESOLVE_NOTIFICATION_CHANNELS))) {
+            return IdentityGovernanceUtil.getDefaultNotificationChannel();
+        }
         // Get the user preferred notification channel.
         String preferredChannel = (String) eventProperties.get(IdentityRecoveryConstants.PREFERRED_CHANNEL_CLAIM);
 
@@ -256,7 +263,7 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
         }
         if (log.isDebugEnabled()) {
             String message = String
-                    .format("Notification channel : %1$s for the user : %2$s " + "in domain : %3$s.",
+                    .format("Notification channel : %1$s for the user : %2$s in domain : %3$s.",
                             preferredChannel, domainName + CarbonConstants.DOMAIN_SEPARATOR + userName,
                             tenantDomain);
             log.debug(message);
@@ -330,7 +337,7 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
 
             // Get the verified status for given channel.
             boolean notificationChannelVerified = Boolean.parseBoolean((String) eventProperties.get(verifiedClaimUri));
-            if (!notificationChannelVerified) {
+            if (notificationChannelVerified) {
                 if (log.isDebugEnabled()) {
                     String message = String
                             .format("Preferred Notification channel : %1$s is verified for the user : %2$s "

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.identity.recovery.handler;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
@@ -28,6 +29,12 @@ import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
+import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationChannelManagerClientException;
+import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationChannelManagerException;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannelManager;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.RecoveryScenarios;
@@ -43,6 +50,7 @@ import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -109,15 +117,37 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
             UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
 
             try {
+                // Get the user preferred notification channel.
+                String preferredChannel = resolveNotificationChannel(eventProperties, userName, tenantDomain,
+                        domainName);
+
+                // If the preferred channel is already verified, no need to send the notifications or lock
+                // the account.
+                boolean notificationChannelVerified = isNotificationChannelVerified(userName, tenantDomain,
+                        preferredChannel, eventProperties);
+                if (notificationChannelVerified) {
+                    return;
+                }
+                // If notifications are externally managed, no send notifications.
                 if (isNotificationInternallyManage && isAccountLockOnCreation) {
                     userRecoveryDataStore.invalidate(user);
-                    String secretKey = UUIDGenerator.generateUUID();
-                    UserRecoveryData recoveryDataDO = new UserRecoveryData(user, secretKey, RecoveryScenarios
-                            .SELF_SIGN_UP, RecoverySteps.CONFIRM_SIGN_UP);
 
+                    // Create a secret key based on the preferred notification channel.
+                    String secretKey = generateSecretKey(preferredChannel);
+
+                    // Resolve event name.
+                    String eventName = resolveEventName(preferredChannel, userName, domainName, tenantDomain);
+
+                    // Resolve template name.
+                    String templateName = resolveTemplateName(preferredChannel, userName, domainName, tenantDomain);
+
+                    UserRecoveryData recoveryDataDO = new UserRecoveryData(user, secretKey,
+                            RecoveryScenarios.SELF_SIGN_UP, RecoverySteps.CONFIRM_SIGN_UP);
+
+                    // Notified channel is stored in remaining setIds for recovery purposes.
+                    recoveryDataDO.setRemainingSetIds(preferredChannel);
                     userRecoveryDataStore.store(recoveryDataDO);
-                    triggerNotification(user, IdentityRecoveryConstants.NOTIFICATION_TYPE_ACCOUNT_CONFIRM,
-                            secretKey, Utils.getArbitraryProperties());
+                    triggerNotification(user, templateName, secretKey, Utils.getArbitraryProperties(), eventName);
                 }
             } catch (IdentityRecoveryException e) {
                 throw new IdentityEventException("Error while sending self sign up notification ", e);
@@ -141,6 +171,201 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
             }
 
         }
+    }
+
+    /**
+     * Resolve the notification template name according to the notification channel.
+     *
+     * @param preferredChannel Notification channel
+     * @param userName         Username
+     * @param domainName       Domain name
+     * @param tenantDomain     Tenant domain name
+     * @return Resolved notification template name
+     */
+    private String resolveTemplateName(String preferredChannel, String userName, String domainName,
+            String tenantDomain) {
+
+        String templateName;
+        if (IdentityRecoveryConstants.SMS_CHANNEL.equals(preferredChannel)) {
+            templateName = IdentityRecoveryConstants.SMS_TEMPLATE_PREFIX
+                    + IdentityRecoveryConstants.NOTIFICATION_TYPE_ACCOUNT_CONFIRM;
+        } else {
+            templateName = IdentityRecoveryConstants.NOTIFICATION_TYPE_ACCOUNT_CONFIRM;
+        }
+        if (log.isDebugEnabled()) {
+            String message = String
+                    .format("For user : %1$s " + "in domain : %2$s, notification template : %3$s was used.",
+                            domainName + CarbonConstants.DOMAIN_SEPARATOR + userName, tenantDomain, templateName);
+            log.debug(message);
+        }
+        return templateName;
+    }
+
+    /**
+     * Resolve the event name according to the notification channel.
+     *
+     * @param preferredChannel User preferred notification channel
+     * @param userName         Username
+     * @param domainName       Domain name
+     * @param tenantDomain     Tenant domain name
+     * @return Resolved event name
+     */
+    private String resolveEventName(String preferredChannel, String userName, String domainName, String tenantDomain) {
+
+        String eventName;
+        if (IdentityRecoveryConstants.EMAIL_CHANNEL.equals(preferredChannel)) {
+            eventName = IdentityEventConstants.Event.TRIGGER_NOTIFICATION;
+        } else {
+            eventName = IdentityRecoveryConstants.NOTIFICATION_EVENTNAME_PREFIX + preferredChannel
+                    + IdentityRecoveryConstants.NOTIFICATION_EVENTNAME_SUFFIX;
+        }
+        if (log.isDebugEnabled()) {
+            String message = String
+                    .format("For user : %1$s " + "in domain : %2$s, notifications were sent from the event : %3$s",
+                            domainName + CarbonConstants.DOMAIN_SEPARATOR + userName, tenantDomain, eventName);
+            log.debug(message);
+        }
+        return eventName;
+    }
+
+    /**
+     * Resolve the preferred notification channel for the user.
+     *
+     * @param eventProperties Event properties
+     * @param userName        Username
+     * @param tenantDomain    Tenant domain of the user
+     * @param domainName      Userstore domain name of the user
+     * @return Resolved preferred notification channel
+     * @throws IdentityEventException Error while resolving the notification channel
+     */
+    private String resolveNotificationChannel(Map<String, Object> eventProperties, String userName, String tenantDomain,
+            String domainName) throws IdentityEventException {
+
+        // Get the user preferred notification channel.
+        String preferredChannel = (String) eventProperties.get(IdentityRecoveryConstants.PREFERRED_CHANNEL_CLAIM);
+
+        // Resolve preferred notification channel.
+        if (StringUtils.isEmpty(preferredChannel)) {
+            NotificationChannelManager notificationChannelManager = Utils.getNotificationChannelManager();
+            try {
+                preferredChannel = notificationChannelManager
+                        .resolveCommunicationChannel(userName, tenantDomain, domainName);
+            } catch (NotificationChannelManagerException e) {
+                handledNotificationChannelManagerException(e, userName, domainName, tenantDomain);
+            }
+        }
+        if (log.isDebugEnabled()) {
+            String message = String
+                    .format("Notification channel : %1$s for the user : %2$s " + "in domain : %3$s.",
+                            preferredChannel, domainName + CarbonConstants.DOMAIN_SEPARATOR + userName,
+                            tenantDomain);
+            log.debug(message);
+        }
+        return preferredChannel;
+    }
+
+    /**
+     * Handles NotificationChannelManagerException thrown in resolving the channel.
+     *
+     * @param e            NotificationChannelManagerException
+     * @param userName     Username
+     * @param domainName   Domain name
+     * @param tenantDomain Tenant domain name
+     * @throws IdentityEventException Error resolving the channel.
+     */
+    private void handledNotificationChannelManagerException(NotificationChannelManagerException e, String userName,
+            String domainName, String tenantDomain) throws IdentityEventException {
+
+        if (StringUtils.isNotEmpty(e.getErrorCode()) && StringUtils.isNotEmpty(e.getMessage())) {
+            if (IdentityMgtConstants.ErrorMessages.ERROR_CODE_NO_NOTIFICATION_CHANNELS.getCode()
+                    .equals(e.getErrorCode())) {
+                if (log.isDebugEnabled()) {
+                    String error = String.format("No communication channel for user : %1$s in domain: %2$s",
+                            domainName + CarbonConstants.DOMAIN_SEPARATOR + userName, tenantDomain);
+                    log.debug(error, e);
+                }
+            } else {
+                if (log.isDebugEnabled()) {
+                    String error = String.format("Error getting claim values for user : %1$s in domain: %2$s",
+                            domainName + CarbonConstants.DOMAIN_SEPARATOR + userName, tenantDomain);
+                    log.debug(error, e);
+                }
+            }
+        } else {
+            if (log.isDebugEnabled()) {
+                String error = String.format("Error getting claim values for user : %1$s in domain: %2$s",
+                        domainName + CarbonConstants.DOMAIN_SEPARATOR + userName, tenantDomain);
+                log.debug(error, e);
+            }
+        }
+        throw new IdentityEventException(e.getErrorCode(), e.getMessage());
+    }
+
+    /**
+     * Checks whether the notification channel is already verified for the user.
+     *
+     * @param username            Username
+     * @param tenantDomain        Tenant domain
+     * @param notificationChannel Notification channel
+     * @param eventProperties     Properties related to the event
+     * @return True if the channel is already verified.
+     */
+    private boolean isNotificationChannelVerified(String username, String tenantDomain, String notificationChannel,
+            Map<String, Object> eventProperties) throws IdentityRecoveryClientException {
+
+        boolean isRegisterWithVerifiedChannelsEnabled = Boolean.parseBoolean(
+                IdentityUtil.getProperty(IdentityRecoveryConstants.ConnectorConfig.REGISTER_WITH_VERIFIED_CHANNELS));
+        if (isRegisterWithVerifiedChannelsEnabled) {
+            if (log.isDebugEnabled()) {
+                String message = String
+                        .format("RegisterWithVerifiedChannels is enabled for user : %s in domain : %s. Checking "
+                                + "whether the user is already verified", username, tenantDomain);
+                log.debug(message);
+            }
+            // Get the notification channel which matches the given channel type.
+            NotificationChannels channel = getNotificationChannel(username, notificationChannel);
+
+            // Get the matching claim uri for the channel.
+            String verifiedClaimUri = channel.getVerifiedClaimUrl();
+
+            // Get the verified status for given channel.
+            boolean notificationChannelVerified = Boolean.parseBoolean((String) eventProperties.get(verifiedClaimUri));
+            if (!notificationChannelVerified) {
+                if (log.isDebugEnabled()) {
+                    String message = String
+                            .format("Preferred Notification channel : %1$s is verified for the user : %2$s "
+                                            + "in domain : %3$s. Therefore, no notifications will be sent.",
+                                    notificationChannel, username, tenantDomain);
+                    log.debug(message);
+                }
+            }
+            return notificationChannelVerified;
+        }
+        return false;
+    }
+
+    /**
+     * Get the NotificationChannels object which matches the given channel type.
+     *
+     * @param username            Username
+     * @param notificationChannel Notification channel
+     * @return NotificationChannels object
+     * @throws IdentityRecoveryClientException Unsupported channel type
+     */
+    private NotificationChannels getNotificationChannel(String username, String notificationChannel)
+            throws IdentityRecoveryClientException {
+
+        NotificationChannels channel;
+        try {
+            channel = NotificationChannels.getNotificationChannel(notificationChannel);
+        } catch (NotificationChannelManagerClientException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Unsupported channel type : " + notificationChannel);
+            }
+            throw Utils.handleClientException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_UNSUPPORTED_PREFERRED_CHANNELS, username, e);
+        }
+        return channel;
     }
 
     @Override
@@ -183,6 +408,83 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
         } catch (IdentityEventException e) {
             throw Utils.handleServerException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_TRIGGER_NOTIFICATION, user
                     .getUserName(), e);
+        }
+    }
+
+    /**
+     * Triggers notifications according to the given event name.
+     *
+     * @param user                 User
+     * @param notificationTemplate Notification Template
+     * @param code                 Recovery code
+     * @param props                Event properties
+     * @param eventName            Name of the event
+     * @throws IdentityRecoveryException Error triggering notifications
+     */
+    private void triggerNotification(User user, String notificationTemplate, String code, Property[] props,
+            String eventName) throws IdentityRecoveryException {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Sending self user registration notification user: " + user.getUserName());
+        }
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put(IdentityEventConstants.EventProperty.USER_NAME, user.getUserName());
+        properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, user.getTenantDomain());
+        properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, user.getUserStoreDomain());
+
+        if (props != null && props.length > 0) {
+            for (Property prop : props) {
+                properties.put(prop.getKey(), prop.getValue());
+            }
+        }
+        if (StringUtils.isNotBlank(code)) {
+            properties.put(IdentityRecoveryConstants.CONFIRMATION_CODE, code);
+        }
+        properties.put(IdentityRecoveryConstants.TEMPLATE_TYPE, notificationTemplate);
+        Event identityMgtEvent = new Event(eventName, properties);
+        try {
+            IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);
+        } catch (IdentityEventException e) {
+            throw Utils.handleServerException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_TRIGGER_NOTIFICATION,
+                    user.getUserName(), e);
+        }
+    }
+
+    /**
+     * Generate an OTP for password recovery via mobile Channel
+     *
+     * @return OTP
+     */
+    private String generateSMSOTP() {
+
+        char[] chars = IdentityRecoveryConstants.SMS_OTP_GENERATE_CHAR_SET.toCharArray();
+        SecureRandom rnd = new SecureRandom();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < IdentityRecoveryConstants.SMS_OTP_CODE_LENGTH; i++) {
+            sb.append(chars[rnd.nextInt(chars.length)]);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Generate a secret key according to the given channel. Method will generate an OTP for mobile channel and a
+     * UUID for other channels.
+     *
+     * @param channel Recovery notification channel.
+     * @return Secret key
+     */
+    private String generateSecretKey(String channel) {
+
+        if (IdentityRecoveryConstants.SMS_CHANNEL.equals(channel)) {
+            if (log.isDebugEnabled()) {
+                log.debug("OTP was generated for the user for channel : " + channel);
+            }
+            return generateSMSOTP();
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("UUID was generated for the user for channel : " + channel);
+            }
+            return UUIDGenerator.generateUUID();
         }
     }
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
@@ -313,9 +313,9 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
     private boolean isNotificationChannelVerified(String username, String tenantDomain, String notificationChannel,
             Map<String, Object> eventProperties) throws IdentityRecoveryClientException {
 
-        boolean isSkipAccountLockOnVerifiedPreferredChannelEnabled = Boolean.parseBoolean(IdentityUtil.getProperty(
-                IdentityRecoveryConstants.ConnectorConfig.SKIP_ACCOUNT_LOCK_ON_VERIFIED_PREFERRED_CHANNEL));
-        if (isSkipAccountLockOnVerifiedPreferredChannelEnabled) {
+        boolean isEnableAccountLockForVerifiedPreferredChannelEnabled = Boolean.parseBoolean(IdentityUtil.getProperty(
+                IdentityRecoveryConstants.ConnectorConfig.ENABLE_ACCOUNT_LOCK_FOR_VERIFIED_PREFERRED_CHANNEL));
+        if (!isEnableAccountLockForVerifiedPreferredChannelEnabled) {
             if (log.isDebugEnabled()) {
                 String message = String
                         .format("SkipAccountLockOnVerifiedPreferredChannel is enabled for user : %s in domain : %s. "

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
@@ -313,13 +313,13 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
     private boolean isNotificationChannelVerified(String username, String tenantDomain, String notificationChannel,
             Map<String, Object> eventProperties) throws IdentityRecoveryClientException {
 
-        boolean isRegisterWithVerifiedChannelsEnabled = Boolean.parseBoolean(
-                IdentityUtil.getProperty(IdentityRecoveryConstants.ConnectorConfig.REGISTER_WITH_VERIFIED_CHANNELS));
-        if (isRegisterWithVerifiedChannelsEnabled) {
+        boolean isSkipAccountLockOnVerifiedPreferredChannelEnabled = Boolean.parseBoolean(IdentityUtil.getProperty(
+                IdentityRecoveryConstants.ConnectorConfig.SKIP_ACCOUNT_LOCK_ON_VERIFIED_PREFERRED_CHANNEL));
+        if (isSkipAccountLockOnVerifiedPreferredChannelEnabled) {
             if (log.isDebugEnabled()) {
                 String message = String
-                        .format("RegisterWithVerifiedChannels is enabled for user : %s in domain : %s. Checking "
-                                + "whether the user is already verified", username, tenantDomain);
+                        .format("SkipAccountLockOnVerifiedPreferredChannel is enabled for user : %s in domain : %s. "
+                                + "Checking whether the user is already verified", username, tenantDomain);
                 log.debug(message);
             }
             // Get the notification channel which matches the given channel type.

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -79,7 +79,6 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -365,15 +364,15 @@ public class UserSelfRegistrationManager {
      * @param username            Username
      * @param notificationChannel Notification channel
      * @param claimsMap           Properties related to the event
-     * @return True if the channel is already verified.
-     * @throws IdentityRecoveryClientException
+     * @return True if the channel is already verified
+     * @throws IdentityRecoveryClientException Error while getting the notification channel
      */
     private boolean isPreferredChannelVerified(String username, String notificationChannel,
             Map<String, String> claimsMap) throws IdentityRecoveryClientException {
 
-        boolean isRegisterWithVerifiedChannelsEnabled = Boolean.parseBoolean(
-                IdentityUtil.getProperty(IdentityRecoveryConstants.ConnectorConfig.REGISTER_WITH_VERIFIED_CHANNELS));
-        if (isRegisterWithVerifiedChannelsEnabled) {
+        boolean isSkipAccountLockOnVerifiedPreferredChannelEnabled = Boolean.parseBoolean(IdentityUtil.getProperty(
+                IdentityRecoveryConstants.ConnectorConfig.SKIP_ACCOUNT_LOCK_ON_VERIFIED_PREFERRED_CHANNEL));
+        if (isSkipAccountLockOnVerifiedPreferredChannelEnabled) {
             NotificationChannels channel = getNotificationChannel(username, notificationChannel);
 
             // Get the matching claim uri for the channel.

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -370,9 +370,9 @@ public class UserSelfRegistrationManager {
     private boolean isPreferredChannelVerified(String username, String notificationChannel,
             Map<String, String> claimsMap) throws IdentityRecoveryClientException {
 
-        boolean isSkipAccountLockOnVerifiedPreferredChannelEnabled = Boolean.parseBoolean(IdentityUtil.getProperty(
-                IdentityRecoveryConstants.ConnectorConfig.SKIP_ACCOUNT_LOCK_ON_VERIFIED_PREFERRED_CHANNEL));
-        if (isSkipAccountLockOnVerifiedPreferredChannelEnabled) {
+        boolean isEnableAccountLockForVerifiedPreferredChannelEnabled = Boolean.parseBoolean(IdentityUtil.getProperty(
+                IdentityRecoveryConstants.ConnectorConfig.ENABLE_ACCOUNT_LOCK_FOR_VERIFIED_PREFERRED_CHANNEL));
+        if (!isEnableAccountLockForVerifiedPreferredChannelEnabled) {
             NotificationChannels channel = getNotificationChannel(username, notificationChannel);
 
             // Get the matching claim uri for the channel.

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/store/JDBCRecoveryDataStore.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/store/JDBCRecoveryDataStore.java
@@ -17,6 +17,9 @@
 package org.wso2.carbon.identity.recovery.store;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -36,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
 
     private static UserRecoveryDataStore jdbcRecoveryDataStore = new JDBCRecoveryDataStore();
-
+    private static final Log log = LogFactory.getLog(JDBCRecoveryDataStore.class);
 
     private JDBCRecoveryDataStore() {
 
@@ -103,9 +106,11 @@ public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
                 }
                 Timestamp timeCreated = resultSet.getTimestamp("TIME_CREATED");
                 long createdTimeStamp = timeCreated.getTime();
-                if (isCodeExpired(user.getTenantDomain(), recoveryScenario, recoveryStep, createdTimeStamp)) {
-                    throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages
-                            .ERROR_CODE_EXPIRED_CODE, code);
+                String remainingSets = resultSet.getString("REMAINING_SETS");
+                if (isCodeExpired(user.getTenantDomain(), recoveryScenario, recoveryStep, createdTimeStamp,
+                        remainingSets)) {
+                    throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_EXPIRED_CODE,
+                            code);
                 }
                 return userRecoveryData;
             }
@@ -147,10 +152,10 @@ public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
                 }
                 Timestamp timeCreated = resultSet.getTimestamp("TIME_CREATED");
                 long createdTimeStamp = timeCreated.getTime();
-                if (isCodeExpired(user.getTenantDomain(), userRecoveryData.getRecoveryScenario(), userRecoveryData
-                        .getRecoveryStep(), createdTimeStamp)) {
-                    throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages
-                            .ERROR_CODE_EXPIRED_CODE, code);
+                if (isCodeExpired(user.getTenantDomain(), userRecoveryData.getRecoveryScenario(),
+                        userRecoveryData.getRecoveryStep(), createdTimeStamp, userRecoveryData.getRemainingSetIds())) {
+                    throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_EXPIRED_CODE,
+                            code);
                 }
                 return userRecoveryData;
             }
@@ -209,14 +214,15 @@ public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
                 RecoveryScenarios scenario = RecoveryScenarios.valueOf(resultSet.getString("SCENARIO"));
                 RecoverySteps step = RecoverySteps.valueOf(resultSet.getString("STEP"));
                 String code = resultSet.getString("CODE");
-                if (isCodeExpired(user.getTenantDomain(), scenario, step, timeCreated.getTime())) {
-                    throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages
-                            .ERROR_CODE_EXPIRED_CODE, code);
+                String remainingSets = resultSet.getString("REMAINING_SETS");
+                if (isCodeExpired(user.getTenantDomain(), scenario, step, timeCreated.getTime(), remainingSets)) {
+                    throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_EXPIRED_CODE,
+                            code);
                 }
 
                 UserRecoveryData userRecoveryData =
                         new UserRecoveryData(user, code, scenario, step);
-                if (StringUtils.isNotBlank(resultSet.getString("REMAINING_SETS"))) {
+                if (StringUtils.isNotBlank(remainingSets)) {
                     userRecoveryData.setRemainingSetIds(resultSet.getString("REMAINING_SETS"));
                 }
                 return userRecoveryData;
@@ -297,14 +303,61 @@ public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
         }
     }
 
-    private boolean isCodeExpired(String tenantDomain, Enum recoveryScenario, Enum recoveryStep, long createdTimestamp)
-            throws IdentityRecoveryServerException {
+    /**
+     * Checks whether the code has expired or not.
+     *
+     * @param tenantDomain     Tenant domain
+     * @param recoveryScenario Recovery scenario
+     * @param recoveryStep     Recovery step
+     * @param createdTimestamp Time stamp
+     * @param recoveryData     Additional data for validate the code
+     * @return Whether the code has expired or not
+     * @throws IdentityRecoveryServerException Error while reading the configs
+     */
+    private boolean isCodeExpired(String tenantDomain, Enum recoveryScenario, Enum recoveryStep, long createdTimestamp,
+            String recoveryData) throws IdentityRecoveryServerException {
 
         int notificationExpiryTimeInMinutes;
-        if (RecoveryScenarios.SELF_SIGN_UP.equals(recoveryScenario) &&
-                RecoverySteps.CONFIRM_SIGN_UP.equals(recoveryStep)) {
-            notificationExpiryTimeInMinutes = Integer.parseInt(Utils.getRecoveryConfigs(IdentityRecoveryConstants
-                    .ConnectorConfig.SELF_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME, tenantDomain));
+        // Self sign up scenario has two sub scenarios as verification via email or verification via SMS.
+        if (RecoveryScenarios.SELF_SIGN_UP.equals(recoveryScenario) && RecoverySteps.CONFIRM_SIGN_UP
+                .equals(recoveryStep)) {
+
+            // If the verification channel is email, use verification link timeout configs to validate.
+            if (StringUtils.isNotEmpty(recoveryData) && recoveryData.equals(IdentityRecoveryConstants.EMAIL_CHANNEL)) {
+
+                if (log.isDebugEnabled()) {
+                    String message = String.format("Verification channel: %s was detected for recovery scenario: %s "
+                            + "and recovery step: %s", recoveryData, recoveryScenario, recoveryStep);
+                    log.debug(message);
+                }
+                notificationExpiryTimeInMinutes = Integer.parseInt(Utils.getRecoveryConfigs(
+                        IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME,
+                        tenantDomain));
+            } else if (StringUtils.isNotEmpty(recoveryData) && recoveryData
+                    .equals(IdentityRecoveryConstants.SMS_CHANNEL)) {
+
+                // If the verification channel is SMS, use SMS OTP timeout configs to validate.
+                if (log.isDebugEnabled()) {
+                    String message = String.format("Verification channel: %s was detected for recovery scenario: %s "
+                            + "and recovery step: %s", recoveryData, recoveryScenario, recoveryStep);
+                    log.debug(message);
+                }
+                notificationExpiryTimeInMinutes = Integer
+                        .parseInt(Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.
+                                SELF_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME, tenantDomain));
+            } else {
+                // If the verification channel is not specified, verification will takes place according to default
+                // verification link timeout configs.
+                if (log.isDebugEnabled()) {
+                    String message = String.format("No verification channel for recovery scenario: %s "
+                                    + "and recovery step: %s .Therefore, using verification link default timeout configs",
+                            recoveryScenario, recoveryStep);
+                    log.debug(message);
+                }
+                notificationExpiryTimeInMinutes = Integer.parseInt(Utils.getRecoveryConfigs(
+                        IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME,
+                        tenantDomain));
+            }
         } else if (RecoveryScenarios.ASK_PASSWORD.equals(recoveryScenario)) {
             notificationExpiryTimeInMinutes = Integer.parseInt(Utils.getRecoveryConfigs(IdentityRecoveryConstants
                     .ConnectorConfig.ASK_PASSWORD_EXPIRY_TIME, tenantDomain));

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -22,6 +22,7 @@ import org.apache.axiom.om.util.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.base.IdentityException;
@@ -30,6 +31,7 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.governance.IdentityGovernanceException;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannelManager;
 import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockServiceException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
@@ -78,6 +80,16 @@ public class Utils {
             .ERROR_CODE_ERROR_DURING_PRE_UPDATE_CREDENTIAL.getCode()};
 
     private static final String PROPERTY_PASSWORD_ERROR_MSG = "PasswordJavaRegExViolationErrorMsg";
+
+    /**
+     * Get an instance of the NotificationChannelManager.
+     *
+     * @return Instance of the NotificationChannelManager
+     */
+    public static NotificationChannelManager getNotificationChannelManager() {
+        return (NotificationChannelManager) PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .getOSGiService(NotificationChannelManager.class, null);
+    }
 
     /**
      * @return

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImplTest.java
@@ -155,7 +155,7 @@ public class SelfRegistrationConfigImplTest {
         String testEnableNotificationInternallyManage = "true";
         String testEnableSelfRegistrationReCaptcha = "true";
         String testVerificationCodeExpiryTime = "1440";
-        String testVerificationSMSOTPExpiryTime = "10";
+        String testVerificationSMSOTPExpiryTime = "1";
         String selfRegistrationCallbackRegex = IdentityRecoveryConstants.DEFAULT_CALLBACK_REGEX;
 
         Map<String, String> propertiesExpected = new HashMap<>();

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImplTest.java
@@ -91,7 +91,9 @@ public class SelfRegistrationConfigImplTest {
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA,
                 "Enable reCaptcha");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME,
-                "User self registration code expiry time");
+                "User self registration verification link expiry time");
+        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME,
+                "User self registration SMS OTP expiry time");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_CALLBACK_REGEX,
                 "User self registration callback URL regex");
         nameMappingExpected.put(LIST_PURPOSE_PROPERTY_KEY, "Manage Self-Sign-Up purposes");
@@ -113,8 +115,10 @@ public class SelfRegistrationConfigImplTest {
                 "Enable captcha verification during self registration");
         descriptionMappingExpected.put(
                 IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME,
-                "Set the number of minutes the user self registration verification mail would be valid.(Negative " +
-                        "value for infinite validity)");
+                "Set the number of minutes the user self registration verification mail would be valid");
+        descriptionMappingExpected.put(
+                IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME,
+                "Set the number of minutes that the SMS OTP would be valid");
         descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_CALLBACK_REGEX,
                 "User self registration callback URL regex");
         descriptionMappingExpected.put(LIST_PURPOSE_PROPERTY_KEY, "Click here to manage Self-Sign-Up purposes");
@@ -130,7 +134,10 @@ public class SelfRegistrationConfigImplTest {
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA);
-        propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME);
+        propertiesExpected
+                .add(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME);
+        propertiesExpected
+                .add(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_CALLBACK_REGEX);
         String[] propertiesArrayExpected = propertiesExpected.toArray(new String[propertiesExpected.size()]);
 
@@ -148,6 +155,7 @@ public class SelfRegistrationConfigImplTest {
         String testEnableNotificationInternallyManage = "true";
         String testEnableSelfRegistrationReCaptcha = "true";
         String testVerificationCodeExpiryTime = "1440";
+        String testVerificationSMSOTPExpiryTime = "10";
         String selfRegistrationCallbackRegex = IdentityRecoveryConstants.DEFAULT_CALLBACK_REGEX;
 
         Map<String, String> propertiesExpected = new HashMap<>();
@@ -161,6 +169,9 @@ public class SelfRegistrationConfigImplTest {
         propertiesExpected.put(
                 IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME,
                 testVerificationCodeExpiryTime);
+        propertiesExpected.put(
+                IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME,
+                testVerificationSMSOTPExpiryTime);
         propertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_CALLBACK_REGEX,
                 selfRegistrationCallbackRegex);
         try {

--- a/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/MeApi.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/MeApi.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiParam;
 
 import org.wso2.carbon.identity.user.endpoint.dto.ExportedUserDTO;
 import org.wso2.carbon.identity.user.endpoint.dto.SelfUserRegistrationRequestDTO;
+import org.wso2.carbon.identity.user.endpoint.dto.SuccessfulUserCreationDTO;
 import org.wso2.carbon.identity.user.endpoint.dto.ErrorDTO;
 
 import java.util.List;
@@ -31,9 +32,9 @@ public class MeApi  {
     
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Export self user information", notes = "Returns the personal information of the authenticated user", response = ExportedUserDTO.class)
+    @io.swagger.annotations.ApiOperation(value = "Export self user information", notes = "This API is used to retrieve the personal information of the authenticated user.", response = ExportedUserDTO.class)
     @io.swagger.annotations.ApiResponses(value = { 
-        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation"),
+        @io.swagger.annotations.ApiResponse(code = 200, message = "Successful operation"),
         
         @io.swagger.annotations.ApiResponse(code = 401, message = "Unauthorized request") })
 
@@ -45,9 +46,9 @@ public class MeApi  {
     
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Register User\n", notes = "This API is used to user self registration.\n", response = String.class)
+    @io.swagger.annotations.ApiOperation(value = "Register user\n", notes = "This API is used for user self registration.\n", response = SuccessfulUserCreationDTO.class)
     @io.swagger.annotations.ApiResponses(value = { 
-        @io.swagger.annotations.ApiResponse(code = 201, message = "Successful created"),
+        @io.swagger.annotations.ApiResponse(code = 201, message = "Successfully created"),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Bad Request"),
         
@@ -55,7 +56,7 @@ public class MeApi  {
         
         @io.swagger.annotations.ApiResponse(code = 500, message = "Server Error") })
 
-    public Response mePost(@ApiParam(value = "It can be sent optional property parameters over email based on email template." ,required=true ) SelfUserRegistrationRequestDTO user)
+    public Response mePost(@ApiParam(value = "Sends optional property parameters over email based on an email template." ,required=true ) SelfUserRegistrationRequestDTO user)
     {
     return delegate.mePost(user);
     }

--- a/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/MeApiService.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/MeApiService.java
@@ -5,6 +5,7 @@ import org.wso2.carbon.identity.user.endpoint.dto.*;
 
 import org.wso2.carbon.identity.user.endpoint.dto.ExportedUserDTO;
 import org.wso2.carbon.identity.user.endpoint.dto.SelfUserRegistrationRequestDTO;
+import org.wso2.carbon.identity.user.endpoint.dto.SuccessfulUserCreationDTO;
 import org.wso2.carbon.identity.user.endpoint.dto.ErrorDTO;
 
 import java.util.List;

--- a/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/CodeValidationRequestDTO.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/CodeValidationRequestDTO.java
@@ -3,6 +3,7 @@ package org.wso2.carbon.identity.user.endpoint.dto;
 import java.util.ArrayList;
 import java.util.List;
 import org.wso2.carbon.identity.user.endpoint.dto.PropertyDTO;
+import org.wso2.carbon.identity.user.endpoint.dto.VerifiedChannelDTO;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
@@ -21,6 +22,9 @@ public class CodeValidationRequestDTO  {
   private String code = null;
   
   
+  private VerifiedChannelDTO verifiedChannel = null;
+  
+  
   private List<PropertyDTO> properties = new ArrayList<PropertyDTO>();
 
   
@@ -33,6 +37,18 @@ public class CodeValidationRequestDTO  {
   }
   public void setCode(String code) {
     this.code = code;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("verifiedChannel")
+  public VerifiedChannelDTO getVerifiedChannel() {
+    return verifiedChannel;
+  }
+  public void setVerifiedChannel(VerifiedChannelDTO verifiedChannel) {
+    this.verifiedChannel = verifiedChannel;
   }
 
   
@@ -55,6 +71,7 @@ public class CodeValidationRequestDTO  {
     sb.append("class CodeValidationRequestDTO {\n");
     
     sb.append("  code: ").append(code).append("\n");
+    sb.append("  verifiedChannel: ").append(verifiedChannel).append("\n");
     sb.append("  properties: ").append(properties).append("\n");
     sb.append("}\n");
     return sb.toString();

--- a/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/SelfRegistrationUserDTO.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/SelfRegistrationUserDTO.java
@@ -20,13 +20,13 @@ public class SelfRegistrationUserDTO  {
   
   private String username = null;
   
-  
+
   private String tenantDomain = null;
   
   
   private String realm = null;
-  
-  
+
+
   private String password = null;
   
   
@@ -56,7 +56,7 @@ public class SelfRegistrationUserDTO  {
     this.tenantDomain = tenantDomain;
   }
 
-  
+
   /**
    **/
   @ApiModelProperty(value = "")
@@ -68,7 +68,7 @@ public class SelfRegistrationUserDTO  {
     this.realm = realm;
   }
 
-  
+
   /**
    **/
   @ApiModelProperty(value = "")

--- a/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/SuccessfulUserCreationDTO.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/SuccessfulUserCreationDTO.java
@@ -1,0 +1,95 @@
+package org.wso2.carbon.identity.user.endpoint.dto;
+
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.constraints.NotNull;
+
+
+
+
+
+@ApiModel(description = "")
+public class SuccessfulUserCreationDTO  {
+  
+  
+  
+  private String code = null;
+  
+  
+  private String message = null;
+  
+  
+  private String notificationChannel = null;
+  
+  
+  private String confirmationCode = null;
+
+  
+  /**
+   * Status code of the operation.
+   **/
+  @ApiModelProperty(value = "Status code of the operation.")
+  @JsonProperty("code")
+  public String getCode() {
+    return code;
+  }
+  public void setCode(String code) {
+    this.code = code;
+  }
+
+  
+  /**
+   * Descriptive message regarding the operation.
+   **/
+  @ApiModelProperty(value = "Descriptive message regarding the operation.")
+  @JsonProperty("message")
+  public String getMessage() {
+    return message;
+  }
+  public void setMessage(String message) {
+    this.message = message;
+  }
+
+  
+  /**
+   * Account confirmation notification sent channel.
+   **/
+  @ApiModelProperty(value = "Account confirmation notification sent channel.")
+  @JsonProperty("notificationChannel")
+  public String getNotificationChannel() {
+    return notificationChannel;
+  }
+  public void setNotificationChannel(String notificationChannel) {
+    this.notificationChannel = notificationChannel;
+  }
+
+  
+  /**
+   * Confirmation code to verify the user, when notifications are externally managed. In this scenario, *notificationChannel* will be *EXTERNAL*. Use the confirmation code for confirm the user accounut.
+   **/
+  @ApiModelProperty(value = "Confirmation code to verify the user, when notifications are externally managed. In this scenario, *notificationChannel* will be *EXTERNAL*. Use the confirmation code for confirm the user accounut.")
+  @JsonProperty("confirmationCode")
+  public String getConfirmationCode() {
+    return confirmationCode;
+  }
+  public void setConfirmationCode(String confirmationCode) {
+    this.confirmationCode = confirmationCode;
+  }
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class SuccessfulUserCreationDTO {\n");
+    
+    sb.append("  code: ").append(code).append("\n");
+    sb.append("  message: ").append(message).append("\n");
+    sb.append("  notificationChannel: ").append(notificationChannel).append("\n");
+    sb.append("  confirmationCode: ").append(confirmationCode).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/UserDTO.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/UserDTO.java
@@ -17,13 +17,13 @@ public class UserDTO  {
   
   private String username = null;
   
-  
+
   private String tenantDomain = null;
-  
+
   
   private String realm = null;
 
-  
+
   /**
    **/
   @ApiModelProperty(value = "")
@@ -47,7 +47,7 @@ public class UserDTO  {
     this.tenantDomain = tenantDomain;
   }
 
-  
+
   /**
    **/
   @ApiModelProperty(value = "")
@@ -59,7 +59,7 @@ public class UserDTO  {
     this.realm = realm;
   }
 
-  
+
 
   @Override
   public String toString()  {

--- a/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/VerifiedChannelDTO.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/VerifiedChannelDTO.java
@@ -1,0 +1,65 @@
+package org.wso2.carbon.identity.user.endpoint.dto;
+
+import io.swagger.annotations.ApiModel;
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.constraints.NotNull;
+
+
+
+/**
+ * Externally verified channel information
+ **/
+
+
+@ApiModel(description = "Externally verified channel information")
+public class VerifiedChannelDTO  {
+  
+  
+  
+  private String type = null;
+  
+  
+  private String claim = null;
+
+  
+  /**
+   * verified channel type
+   **/
+  @ApiModelProperty(value = "verified channel type")
+  @JsonProperty("type")
+  public String getType() {
+    return type;
+  }
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  
+  /**
+   * verified channel claim
+   **/
+  @ApiModelProperty(value = "verified channel claim")
+  @JsonProperty("claim")
+  public String getClaim() {
+    return claim;
+  }
+  public void setClaim(String claim) {
+    this.claim = claim;
+  }
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class VerifiedChannelDTO {\n");
+    
+    sb.append("  type: ").append(type).append("\n");
+    sb.append("  claim: ").append(claim).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/Constants.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/Constants.java
@@ -29,9 +29,7 @@ public final class Constants {
     public static final String DEFAULT_RESPONSE_CONTENT_TYPE = APPLICATION_JSON;
     public static final String HEADER_CONTENT_TYPE = "Content-Type";
 
-
-
-    //default error messages
+    // Default error messages.
     public static final String STATUS_FORBIDDEN_MESSAGE_DEFAULT = "Forbidden";
     public static final String STATUS_NOT_FOUND_MESSAGE_DEFAULT = "Not Found";
     public static final String STATUS_INTERNAL_SERVER_ERROR_MESSAGE_DEFAULT = "Internal server error";
@@ -44,5 +42,11 @@ public final class Constants {
     public static final String STATUS_INTERNAL_SERVER_ERROR_DESCRIPTION_DEFAULT = "The server encountered "
             + "an internal error. Please contact administrator.";
     public static final String TENANT_NAME_FROM_CONTEXT = "TenantNameFromContext";
+
+    // Response Configurations.
+    public static final String ENABLE_DETAILED_API_RESPONSE =
+            "SelfRegistration.API.EnableDetailedResponseBody";
+
+    public static final String EXTERNAL_NOTIFICATION_CHANNEL = "EXTERNAL";
 
 }

--- a/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateCodeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateCodeApiServiceImpl.java
@@ -23,10 +23,12 @@ import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.signup.UserSelfRegistrationManager;
 import org.wso2.carbon.identity.user.endpoint.Constants;
+import org.wso2.carbon.identity.user.endpoint.dto.VerifiedChannelDTO;
 import org.wso2.carbon.identity.user.endpoint.util.Utils;
 import org.wso2.carbon.identity.user.endpoint.ValidateCodeApiService;
 import org.wso2.carbon.identity.user.endpoint.dto.CodeValidationRequestDTO;
 
+import java.util.HashMap;
 import javax.ws.rs.core.Response;
 
 public class ValidateCodeApiServiceImpl extends ValidateCodeApiService {
@@ -35,11 +37,25 @@ public class ValidateCodeApiServiceImpl extends ValidateCodeApiService {
 
     @Override
     public Response validateCodePost(CodeValidationRequestDTO codeValidationRequestDTO) {
-        UserSelfRegistrationManager userSelfRegistrationManager = Utils
-                .getUserSelfRegistrationManager();
+        UserSelfRegistrationManager userSelfRegistrationManager = Utils.getUserSelfRegistrationManager();
         try {
-            userSelfRegistrationManager.confirmUserSelfRegistration(codeValidationRequestDTO.getCode());
+            // Get the map of properties in the request.
+            HashMap<String, String> propertyMap = Utils.getPropertiesMap(codeValidationRequestDTO.getProperties());
 
+            // Get externally verified channel information.
+            VerifiedChannelDTO verifiedChannelDTO = codeValidationRequestDTO.getVerifiedChannel();
+            String verifiedChannelType = null;
+            String verifiedChannelClaim = null;
+
+            // Handling verified channel details not in the request.
+            if (verifiedChannelDTO != null) {
+                verifiedChannelClaim = verifiedChannelDTO.getClaim();
+                verifiedChannelType = verifiedChannelDTO.getType();
+            }
+            // Confirm self registration.
+            userSelfRegistrationManager
+                    .confirmUserSelfRegistration(codeValidationRequestDTO.getCode(), verifiedChannelType,
+                            verifiedChannelClaim, propertyMap);
         } catch (IdentityRecoveryClientException e) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Client Error while confirming self up user ", e);
@@ -48,10 +64,9 @@ public class ValidateCodeApiServiceImpl extends ValidateCodeApiService {
         } catch (IdentityRecoveryException e) {
             Utils.handleInternalServerError(Constants.SERVER_ERROR, e.getErrorCode(), LOG, e);
         } catch (Throwable throwable) {
-            Utils.handleInternalServerError(Constants.SERVER_ERROR, IdentityRecoveryConstants
-                    .ErrorMessages.ERROR_CODE_UNEXPECTED.getCode(), LOG, throwable);
+            Utils.handleInternalServerError(Constants.SERVER_ERROR,
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_UNEXPECTED.getCode(), LOG, throwable);
         }
-
         return Response.accepted().build();
     }
 }

--- a/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/util/Utils.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/util/Utils.java
@@ -18,10 +18,12 @@
 
 package org.wso2.carbon.identity.user.endpoint.util;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.confirmation.ResendConfirmationManager;
 import org.wso2.carbon.identity.recovery.model.Property;
@@ -47,6 +49,7 @@ import org.wso2.carbon.identity.user.rename.core.service.UsernameUpdateService;
 import org.wso2.carbon.user.api.Claim;
 import org.wso2.carbon.user.core.service.RealmService;
 
+import java.util.HashMap;
 import java.util.List;
 
 public class Utils {
@@ -328,4 +331,20 @@ public class Utils {
         return userRecoveryData;
     }
 
+    /**
+     * Create a map of properties.
+     *
+     * @param propertyDTOS Property DTOs in the API request {@link PropertyDTO}
+     * @return Map of properties
+     */
+    public static HashMap<String, String> getPropertiesMap(List<PropertyDTO> propertyDTOS) {
+
+        HashMap<String, String> propertiesMap = new HashMap<>();
+        if (propertyDTOS != null && propertyDTOS.size() > 0) {
+            for (PropertyDTO property : propertyDTOS) {
+                propertiesMap.put(property.getKey(), property.getValue());
+            }
+        }
+        return propertiesMap;
+    }
 }

--- a/components/org.wso2.carbon.identity.user.endpoint/src/main/resources/api.identity.user.yaml
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/main/resources/api.identity.user.yaml
@@ -13,7 +13,7 @@ info:
   contact:
     name: "WSO2"
     url: "http://wso2.com/products/identity-server/"
-    email: "architecture@wso2.com"
+    email: "architecture@wso2.org"
   license:
     name: "Apache 2.0"
     url: "http://www.apache.org/licenses/LICENSE-2.0.html"
@@ -84,8 +84,7 @@ paths:
         201:
           description: Successfully created
           schema:
-            title: key
-            type: string
+            $ref: '#/definitions/SuccessfulUserCreation'
         400:
           description: Bad Request
           schema:
@@ -130,9 +129,11 @@ paths:
       description: |
          This API is used to validate the code used by self registered users.
       x-wso2-request: |
-       curl -k -v -X POST -H "Authorization: <Base64Encoded_username:password>" -H "Content-Type: application/json" -d '{ "code": "<validation_code>","properties": []}' "https://localhost:9443/api/identity/user/v1.0/validate-code"
+       curl -k -v -X POST -H "Authorization: <Base64Encoded_username:password>" -H "Content-Type: application/json"
+        -d '{ "code": "<validation_code>","verifiedChannel":{"type":<type>, "claim":<claim_uri},
+         "properties": []}' "https://localhost:9443/api/identity/user/v1.0/validate-code"
       x-wso2-curl: |
-        curl -k -v -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{ "code": "84325529-8aa7-4851-8751-5980a7f2d9f7","properties": []}' "https://localhost:9443/api/identity/user/v1.0/validate-code"
+        curl -k -v -X POST -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "Content-Type: application/json" -d '{ "code": "84325529-8aa7-4851-8751-5980a7f2d9f7","verifiedChannel":{"type":"SMS", "claim":"http://wso2.org/claims/mobile"},"properties": []}' "https://localhost:9443/api/identity/user/v1.0/validate-code"
 
       x-wso2-response: |
         "HTTP/1.1 202 Accepted"
@@ -356,9 +357,32 @@ paths:
           - Username Update
 
 definitions:
-#-----------------------------------------------------
-# The SelfRegistrationUser  Object
-#-----------------------------------------------------
+  #-----------------------------------------------------
+  # SuccessfulUserCreation object
+  #-----------------------------------------------------
+  SuccessfulUserCreation:
+    type: object
+    properties:
+      code:
+        type: string
+        example: "USR-02007"
+        description: Status code of the operation.
+      message:
+        type: string
+        example: "successful user self registration"
+        description: Descriptive message regarding the operation.
+      notificationChannel:
+        type: string
+        example: "EMAIL"
+        description: Account confirmation notification sent channel.
+      confirmationCode:
+        type: string
+        example: ""
+        description: Confirmation code to verify the user, when notifications are externally managed. In this scenario, *notificationChannel* will be *EXTERNAL*. Use the confirmation code for confirm the user accounut.
+
+  #-----------------------------------------------------
+  # The SelfRegistrationUser  Object
+  #-----------------------------------------------------
   SelfRegistrationUser:
     type: object
     properties:
@@ -442,10 +466,28 @@ definitions:
     properties:
       code:
         type: string
+      verifiedChannel:
+        $ref: '#/definitions/VerifiedChannel'
       properties:
         type: array
         items:
           $ref: '#/definitions/Property'
+
+  #-----------------------------------------------------
+  # The VerifiedChannel  object
+  #-----------------------------------------------------
+  VerifiedChannel:
+    type: object
+    description: "Verified channel information"
+    properties:
+      type:
+        type: string
+        example: EMAIL
+        description: verified channel type
+      claim:
+        type: string
+        example: http://wso2.org/claims/emailaddress
+        description: verified channel claim
 
 #-----------------------------------------------------
 # The UsernameValidationRequest  object

--- a/components/org.wso2.carbon.identity.user.endpoint/src/test/java/org.wso2.carbon.identity.user.endpoint.Util/UtilsTest.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/test/java/org.wso2.carbon.identity.user.endpoint.Util/UtilsTest.java
@@ -131,6 +131,12 @@ public class UtilsTest {
         assertEquals(Utils.getProperties(buildPropertyDTOs()).length, buildPropertyDTOs().size());
     }
 
+    @Test
+    public void testGetPropertiesMap(){
+        assertEquals(Utils.getPropertiesMap(null).size(),0);
+        assertEquals(Utils.getPropertiesMap(buildPropertyDTOs()).size(),1);
+    }
+
     private List<PropertyDTO> buildPropertyDTOs() {
 
         PropertyDTO propertyDTO = new PropertyDTO();


### PR DESCRIPTION
Related to issue: https://github.com/wso2/product-is/issues/6339

## Narrative
At the self registration process user has the option to provide email and/or mobile. Following two scenarios can be identified.

- Provide either the email address or mobile number.
- Provides both mobile number and email address.

In the first scenario, If the user provides only one value, that value will be considered as the preferred channel for that user.

In the second scenario, If the user provides both values, there should be an option to select, most preferred communication channel. After selecting that option all the verification and notifications shall be via the preferred channel only.

## Approach
- Use the existing self registration and account confirmation APIs with improved responses and additional features.
- User specify a preferred notification channel, mobile number and email address at the self registration. (NOTE: preferred channel is an optional claim at user self registration)
- If the user has not specified a preferred channel, preferred channel will be decided internally.
- Then send confirmation notification on the selected channel

## Other associated PRs
Adding a new stream to manage SMS: https://github.com/wso2-extensions/identity-event-handler-notification/pull/108
Templating the configurations : https://github.com/wso2/carbon-identity-framework/pull/2564
API documentation: https://github.com/wso2/docs-is/pull/881
Adding LDAP attribute: https://github.com/wso2-extensions/identity-userstore-ldap/pull/33