### PR TITLE
Tenant wise email configuration fixed

### DIFF
--- a/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>identity-governance</artifactId>
+        <groupId>org.wso2.carbon.identity.governance</groupId>
+        <version>1.3.30-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>org.wso2.carbon.identity.tenant.resource.manager</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - identity-tenant-resource-manager</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.analytics-common</groupId>
+            <artifactId>org.wso2.carbon.event.publisher.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.governance</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
+            <version>${powermock.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.2.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Private-Package>
+                            org.wso2.carbon.identity.tenant.resource.manager.internal,
+                        </Private-Package>
+                        <Export-Package>
+                            !org.wso2.carbon.identity.tenant.resource.manager.internal,
+                            org.wso2.carbon.identity.tenant.resource.manager.*,
+                        </Export-Package>
+                        <Import-Package>
+                            org.apache.commons.logging.*; version="${commons-logging.osgi.version.range}",
+                            org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",
+                            org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
+                            org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
+                            org.wso2.carbon.context; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.core.util; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.databridge.commons; version="${carbon.analytics.common.version.range}",
+                            org.wso2.carbon.event.publisher.core; version="${carbon.analytics.common.version.range}",
+                            org.wso2.carbon.event.publisher.core.exception; version="${carbon.analytics.common.version.range}",
+                            org.wso2.carbon.event.publisher.core.config; version="${carbon.analytics.common.version.range}",
+                            org.wso2.carbon.event.stream.core.*; version="${carbon.analytics.common.version.range}",
+                            org.wso2.carbon.identity.configuration.mgt.core.*; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.common.model; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.utils.*; version="${carbon.kernel.package.import.version.range}",
+                            org.apache.axis2.context; version="${axis2.osgi.version.range}",
+                            org.wso2.carbon.identity.governance; version="${identity.governance.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.core.*; version="${carbon.identity.framework.imp.pkg.version.range}",
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                    <systemPropertyVariables>
+                        <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+                    </systemPropertyVariables>
+                    <classpathDependencyExcludes>
+                        <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                    </classpathDependencyExcludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/TenantAwareAxis2ConfigurationContextObserver.java
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/TenantAwareAxis2ConfigurationContextObserver.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.tenant.resource.manager;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.event.publisher.core.config.EventPublisherConfiguration;
+import org.wso2.carbon.event.publisher.core.exception.EventPublisherConfigurationException;
+import org.wso2.carbon.event.stream.core.EventStreamConfiguration;
+import org.wso2.carbon.event.stream.core.exception.EventStreamConfigurationException;
+import org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants;
+import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
+import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceFile;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resources;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.tenant.resource.manager.constants.TenantResourceConstants;
+import org.wso2.carbon.identity.tenant.resource.manager.exception.TenantResourceManagementException;
+import org.wso2.carbon.identity.tenant.resource.manager.internal.TenantResourceManagerDataHolder;
+import org.wso2.carbon.utils.AbstractAxis2ConfigurationContextObserver;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import java.util.List;
+
+import static org.wso2.carbon.identity.tenant.resource.manager.constants.TenantResourceConstants.ErrorMessages.ERROR_CODE_ERROR_WHEN_ADDING_EVENT_PUBLISHER_CONFIGURATION;
+import static org.wso2.carbon.identity.tenant.resource.manager.constants.TenantResourceConstants.ErrorMessages.ERROR_CODE_ERROR_WHEN_CREATING_TENANT_EVENT_PUBLISHER_CONFIGURATION_USING_SUPER_TENANT_CONFIG;
+import static org.wso2.carbon.identity.tenant.resource.manager.constants.TenantResourceConstants.ErrorMessages.ERROR_CODE_ERROR_WHEN_CREATING_TENANT_EVENT_STREAM_CONFIGURATION;
+import static org.wso2.carbon.identity.tenant.resource.manager.constants.TenantResourceConstants.ErrorMessages.ERROR_CODE_ERROR_WHEN_FETCHING_TENANT_SPECIFIC_PUBLISHER_FILES;
+import static org.wso2.carbon.identity.tenant.resource.manager.constants.TenantResourceConstants.PUBLISHER;
+import static org.wso2.carbon.identity.tenant.resource.manager.util.ResourceUtils.populateMessageWithData;
+
+/**
+ * Axis2Observer for generating tenant wise publisher configurations.
+ */
+public class TenantAwareAxis2ConfigurationContextObserver extends AbstractAxis2ConfigurationContextObserver {
+
+    private static final Log log = LogFactory.getLog(TenantAwareAxis2ConfigurationContextObserver.class);
+
+    /**
+     * Add the tenant wise publisher and stream Configuration in tenant loading.
+     *
+     * @param tenantId tenant ID.
+     */
+    @Override
+    public void creatingConfigurationContext(int tenantId) {
+
+        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        log.info("Loading configuration context for tenant domain: " + tenantDomain);
+        loadEventStreamAndPublisherConfigurations(tenantId);
+    }
+
+    /**
+     * This method loads event stream and publisher configurations for a specific tenant.
+     *
+     * @param tenantId     tenant id.
+     */
+    private void loadEventStreamAndPublisherConfigurations(int tenantId) {
+
+        List<EventPublisherConfiguration> activeEventPublisherConfigurations;
+        List<EventStreamConfiguration> eventStreamConfigurationList;
+        try {
+            startSuperTenantFlow();
+            activeEventPublisherConfigurations = getSuperTenantEventPublisherConfigurations();
+            eventStreamConfigurationList = getSuperTenantEventStreamConfigurations();
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+        try {
+            startTenantFlow(tenantId);
+            loadTenantEventStreams(eventStreamConfigurationList);
+            loadTenantPublisherConfigurationFromConfigStore();
+
+            if (activeEventPublisherConfigurations != null) {
+                loadTenantPublisherConfigurationFromSuperTenantConfig(activeEventPublisherConfigurations);
+            }
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+    }
+
+    /**
+     * This method loads publisher configurations tenant wise by fetching them from configuration store.
+     */
+    private void loadTenantPublisherConfigurationFromConfigStore() {
+
+        try {
+            List<Resource> resourcesByTypePublisher = TenantResourceManagerDataHolder.getInstance()
+                    .getConfigurationManager().getResourcesByType(PUBLISHER).getResources();
+            for (Resource resource : resourcesByTypePublisher) {
+                ResourceFile tenantSpecificPublisherFile = resource.getFiles().get(0);
+                if (tenantSpecificPublisherFile != null) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("File for publisher name: " + tenantSpecificPublisherFile.getName()
+                                + " is available in the configuration store.");
+                    }
+                    TenantResourceManagerDataHolder.getInstance().getResourceManager()
+                            .addEventPublisherConfiguration(tenantSpecificPublisherFile);
+                }
+            }
+        } catch (ConfigurationManagementException e) {
+            if (e.getErrorCode()
+                    .equals(ConfigurationConstants.ErrorMessages.ERROR_CODE_FEATURE_NOT_ENABLED.getCode())) {
+                log.warn("Configuration store is disabled. Super tenant configuration will be used for the tenant "
+                        + "domain: " + PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+            } else if (e.getErrorCode()
+                    .equals(ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCES_DOES_NOT_EXISTS.getCode())) {
+                log.warn("Configuration store does not contain any resources under resource type publisher. Super "
+                        + "tenant configurations will be used for the tenant domain: " + PrivilegedCarbonContext
+                        .getThreadLocalCarbonContext().getTenantDomain());
+            } else {
+                log.error(populateMessageWithData(ERROR_CODE_ERROR_WHEN_FETCHING_TENANT_SPECIFIC_PUBLISHER_FILES,
+                        PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()), e);
+            }
+        } catch (TenantResourceManagementException e) {
+            log.error(populateMessageWithData(ERROR_CODE_ERROR_WHEN_ADDING_EVENT_PUBLISHER_CONFIGURATION,
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()), e);
+        }
+    }
+
+    /**
+     * This method returns super tenant event publisher configurations.
+     *
+     * @return list of event publisher configurations.
+     */
+    private List<EventPublisherConfiguration> getSuperTenantEventPublisherConfigurations() {
+
+        List<EventPublisherConfiguration> activeEventPublisherConfigurations = null;
+        try {
+            activeEventPublisherConfigurations = TenantResourceManagerDataHolder.getInstance()
+                    .getCarbonEventPublisherService().getAllActiveEventPublisherConfigurations();
+        } catch (EventPublisherConfigurationException e) {
+            log.error(populateMessageWithData(
+                    TenantResourceConstants.ErrorMessages.ERROR_CODE_ERROR_WHEN_FETCHING_SUPER_TENANT_EVENT_PUBLISHER_CONFIGURATION,
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()), e);
+        }
+        return activeEventPublisherConfigurations;
+    }
+
+    /**
+     * This method returns super tenant event stream configurations.
+     *
+     * @return list of event stream configurations.
+     */
+    private List<EventStreamConfiguration> getSuperTenantEventStreamConfigurations() {
+
+        List<EventStreamConfiguration> eventStreamConfigurationList = null;
+        try {
+            eventStreamConfigurationList = TenantResourceManagerDataHolder.getInstance().getCarbonEventStreamService()
+                    .getAllEventStreamConfigurations();
+        } catch (EventStreamConfigurationException e) {
+            log.error(populateMessageWithData(
+                    TenantResourceConstants.ErrorMessages.ERROR_CODE_ERROR_WHEN_FETCHING_SUPER_TENANT_EVENT_STREAM_CONFIGURATION,
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()), e);
+        }
+        return eventStreamConfigurationList;
+    }
+
+    private void startTenantFlow(int tenantId) {
+
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(tenantId);
+        PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .setTenantDomain(IdentityTenantUtil.getTenantDomain(tenantId));
+    }
+
+    private void startSuperTenantFlow() {
+
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+        carbonContext.setTenantId(MultitenantConstants.SUPER_TENANT_ID);
+        carbonContext.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    /**
+     * This method creates event publisher configurations tenant wise by using super tenant publisher configurations.
+     *
+     * @param activeEventPublisherConfigurations list of active super tenant publisher configurations.
+     */
+    private void loadTenantPublisherConfigurationFromSuperTenantConfig(
+            List<EventPublisherConfiguration> activeEventPublisherConfigurations) {
+
+        for (EventPublisherConfiguration eventPublisherConfiguration : activeEventPublisherConfigurations) {
+            try {
+                if (TenantResourceManagerDataHolder.getInstance().getCarbonEventPublisherService()
+                        .getActiveEventPublisherConfiguration(eventPublisherConfiguration.getEventPublisherName())
+                        == null) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Super tenant event publisher configuration for the: " + eventPublisherConfiguration
+                                .getEventPublisherName() + " will be used for the tenant domain: "
+                                + PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+                    }
+                    TenantResourceManagerDataHolder.getInstance().getCarbonEventPublisherService()
+                            .addEventPublisherConfiguration(eventPublisherConfiguration);
+                }
+            } catch (EventPublisherConfigurationException e) {
+                log.error(populateMessageWithData(
+                        ERROR_CODE_ERROR_WHEN_CREATING_TENANT_EVENT_PUBLISHER_CONFIGURATION_USING_SUPER_TENANT_CONFIG,
+                        PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()), e);
+            }
+        }
+    }
+
+    /**
+     * This method loads event stream configurations tenant wise by using super tenant publisher configurations.
+     *
+     * @param eventStreamConfigurationList list of active super tenant stream configurations.
+     */
+    private void loadTenantEventStreams(List<EventStreamConfiguration> eventStreamConfigurationList) {
+
+        if (eventStreamConfigurationList != null) {
+            for (EventStreamConfiguration eventStreamConfiguration : eventStreamConfigurationList) {
+                if (TenantResourceManagerDataHolder.getInstance().getCarbonEventStreamService()
+                        .getEventStreamConfiguration(eventStreamConfiguration.getStreamDefinition().getStreamId())
+                        == null) {
+                    try {
+                        TenantResourceManagerDataHolder.getInstance().getCarbonEventStreamService()
+                                .addEventStreamConfig(eventStreamConfiguration);
+                    } catch (EventStreamConfigurationException e) {
+                        log.error(populateMessageWithData(
+                                ERROR_CODE_ERROR_WHEN_CREATING_TENANT_EVENT_STREAM_CONFIGURATION,
+                                PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()), e);
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/constants/TenantResourceConstants.java
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/constants/TenantResourceConstants.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.tenant.resource.manager.constants;
+
+/**
+ * Constants related to tenant resource management.
+ */
+public class TenantResourceConstants {
+
+    private TenantResourceConstants() {
+    }
+
+    public static final String PUBLISHER = "Publisher";
+
+    public enum ErrorMessages {
+
+        ERROR_CODE_ERROR_WHEN_FETCHING_EVENT_PUBLISHER_FILE("TRM-10001", "Error occurred when fetching the "
+                + "event publisher configuration file with name: %s. for the tenant domain: %s"),
+        ERROR_CODE_ERROR_WHEN_DEPLOYING_EVENT_PUBLISHER_CONFIGURATION("TRM-10002", "Error occurred when deploying the "
+                + "event publisher configuration for with name: %s."),
+        ERROR_CODE_ERROR_WHEN_FETCHING_SUPER_TENANT_EVENT_PUBLISHER_CONFIGURATION("TRM-10003", "Error occurred while "
+                + "loading super tenant event publisher configurations for the tenant with domain: %s."),
+        ERROR_CODE_ERROR_WHEN_FETCHING_SUPER_TENANT_EVENT_STREAM_CONFIGURATION("TRM-10004", "Error occurred while "
+                + "loading super tenant event stream configurations for the tenant with domain: %s."),
+        ERROR_CODE_ERROR_WHEN_CREATING_TENANT_EVENT_STREAM_CONFIGURATION("TRM-10005", "Error occurred while "
+                + "creating tenant event stream configuration: %s."),
+        ERROR_CODE_ERROR_WHEN_FETCHING_TENANT_SPECIFIC_PUBLISHER_FILES("TRM-10007","Error occurred while fetching the"
+                + " tenant specific publisher configuration files from configuration store for the tenant domain: %s"),
+        ERROR_CODE_ERROR_WHEN_ADDING_EVENT_PUBLISHER_CONFIGURATION("TRM-10008","Error occurred while adding the event"
+                + " publisher configuration for the tenant domain: %"),
+        ERROR_CODE_ERROR_WHEN_CREATING_TENANT_EVENT_PUBLISHER_CONFIGURATION_USING_SUPER_TENANT_CONFIG(
+                "TRM-10009", "Error occurred while creating tenant event publisher configuration: %s.Using super"
+                + "tenant configuration, for the tenant domain: %s");
+
+        private final String code;
+        private final String message;
+
+        ErrorMessages(String code, String message) {
+
+            this.code = code;
+            this.message = message;
+        }
+
+        public String getCode() {
+
+            return code;
+        }
+
+        public String getMessage() {
+
+            return message;
+        }
+
+        @Override
+        public String toString() {
+
+            return code + " - " + message;
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/core/ResourceManager.java
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/core/ResourceManager.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.tenant.resource.manager.core;
+
+import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceFile;
+import org.wso2.carbon.identity.tenant.resource.manager.exception.TenantResourceManagementException;
+
+/**
+ * Tenant Resource manager service interface.
+ */
+public interface ResourceManager {
+
+    /**
+     * This API is used to add an EventPublisher for a particular tenant.
+     *
+     * @param resourceFile Event Publisher file.
+     * @throws TenantResourceManagementException
+     */
+    void addEventPublisherConfiguration(ResourceFile resourceFile) throws TenantResourceManagementException;
+
+}

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/core/ResourceManagerImpl.java
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/core/ResourceManagerImpl.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.tenant.resource.manager.core;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.event.publisher.core.EventPublisherService;
+import org.wso2.carbon.event.publisher.core.config.EventPublisherConfiguration;
+import org.wso2.carbon.event.publisher.core.config.EventPublisherConfigurationFile;
+import org.wso2.carbon.event.publisher.core.exception.EventPublisherConfigurationException;
+import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
+import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceFile;
+import org.wso2.carbon.identity.tenant.resource.manager.exception.TenantResourceManagementException;
+import org.wso2.carbon.identity.tenant.resource.manager.internal.TenantResourceManagerDataHolder;
+
+import java.io.InputStream;
+
+import static org.wso2.carbon.identity.tenant.resource.manager.constants.TenantResourceConstants.ErrorMessages.ERROR_CODE_ERROR_WHEN_DEPLOYING_EVENT_PUBLISHER_CONFIGURATION;
+import static org.wso2.carbon.identity.tenant.resource.manager.constants.TenantResourceConstants.ErrorMessages.ERROR_CODE_ERROR_WHEN_FETCHING_EVENT_PUBLISHER_FILE;
+import static org.wso2.carbon.identity.tenant.resource.manager.constants.TenantResourceConstants.PUBLISHER;
+import static org.wso2.carbon.identity.tenant.resource.manager.util.ResourceUtils.handleServerException;
+
+/**
+ * Tenant Resource manager service implementation.
+ */
+public class ResourceManagerImpl implements ResourceManager {
+
+    private static Log log = LogFactory.getLog(ResourceManagerImpl.class);
+
+    @Override
+    public void addEventPublisherConfiguration(ResourceFile resourceFile) throws TenantResourceManagementException {
+
+        try {
+            deployEventPublisherConfiguration(TenantResourceManagerDataHolder.getInstance().getConfigurationManager()
+                    .getFileById(PUBLISHER, resourceFile.getName(), resourceFile.getId()));
+            if (log.isDebugEnabled()) {
+                log.debug("Event Publisher: " + resourceFile.getName() + " deployed from the configuration "
+                        + "store for the tenant domain: " + PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                        .getTenantDomain());
+            }
+        } catch (EventPublisherConfigurationException e) {
+            throw handleServerException(ERROR_CODE_ERROR_WHEN_DEPLOYING_EVENT_PUBLISHER_CONFIGURATION, e,
+                    resourceFile.getName());
+        } catch (ConfigurationManagementException e) {
+            throw handleServerException(ERROR_CODE_ERROR_WHEN_FETCHING_EVENT_PUBLISHER_FILE, e, resourceFile.getName());
+        }
+    }
+
+    /**
+     * This is used to deploy an event publisher configuration using.
+     *
+     * @param publisherConfig Event Publisher Configuration as input stream.
+     * @throws EventPublisherConfigurationException Event Publisher Configuration Exception.
+     */
+    private void deployEventPublisherConfiguration(InputStream publisherConfig)
+            throws EventPublisherConfigurationException {
+
+        EventPublisherService carbonEventPublisherService = TenantResourceManagerDataHolder.getInstance()
+                .getCarbonEventPublisherService();
+        EventPublisherConfiguration eventPublisherConfiguration;
+
+        eventPublisherConfiguration = carbonEventPublisherService.getEventPublisherConfiguration(publisherConfig);
+
+        if (TenantResourceManagerDataHolder.getInstance().getCarbonEventPublisherService()
+                .getActiveEventPublisherConfiguration(eventPublisherConfiguration.getEventPublisherName()) != null) {
+            destroyEventPublisherConfiguration(eventPublisherConfiguration);
+        }
+        carbonEventPublisherService.addEventPublisherConfiguration(eventPublisherConfiguration);
+    }
+
+    /**
+     * This is used to destroy an existing EventPublisher.
+     * As per the implementation in analytics-common we need to add the publisher as a file before destroying it.
+     *
+     * @param eventPublisherConfiguration Event Publisher Configuration.
+     * @throws ConfigurationManagementException Configuration Management Exception.
+     */
+    private void destroyEventPublisherConfiguration(EventPublisherConfiguration eventPublisherConfiguration)
+            throws EventPublisherConfigurationException {
+
+        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+        EventPublisherConfigurationFile eventPublisherConfigurationFile = new EventPublisherConfigurationFile();
+        eventPublisherConfigurationFile.setTenantId(tenantId);
+        eventPublisherConfigurationFile.setEventPublisherName(eventPublisherConfiguration.getEventPublisherName());
+        eventPublisherConfigurationFile.setFileName(eventPublisherConfiguration.getEventPublisherName());
+        eventPublisherConfigurationFile.setStatus(EventPublisherConfigurationFile.Status.DEPLOYED);
+
+        TenantResourceManagerDataHolder.getInstance().getCarbonEventPublisherService()
+                .addEventPublisherConfigurationFile(eventPublisherConfigurationFile, tenantId);
+        TenantResourceManagerDataHolder.getInstance().getCarbonEventPublisherService()
+                .removeEventPublisherConfigurationFile(eventPublisherConfiguration.getEventPublisherName(), tenantId);
+    }
+}

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/exception/TenantResourceManagementException.java
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/exception/TenantResourceManagementException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.tenant.resource.manager.exception;
+
+/**
+ * Base exception for tenant resource configuration management feature.
+ */
+public class TenantResourceManagementException extends Exception {
+
+    private String errorCode;
+
+    public TenantResourceManagementException(String message, String code, Throwable e) {
+
+        super(message, e);
+        this.errorCode = code;
+    }
+
+    public TenantResourceManagementException(String message, String code) {
+
+        super(message);
+        this.errorCode = code;
+    }
+
+    public String getErrorCode() {
+
+        return errorCode;
+    }
+}

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/exception/TenantResourceManagementServerException.java
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/exception/TenantResourceManagementServerException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.tenant.resource.manager.exception;
+
+/**
+ * This class is used to define the server side errors which needs to be handled.
+ */
+public class TenantResourceManagementServerException extends TenantResourceManagementException {
+
+    public TenantResourceManagementServerException(String message, String code, Throwable e) {
+
+        super(message, code, e);
+    }
+
+    public TenantResourceManagementServerException(String message, String code) {
+
+        super(message, code);
+    }
+}

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/internal/TenantResourceManagerDataHolder.java
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/internal/TenantResourceManagerDataHolder.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.tenant.resource.manager.internal;
+
+import org.wso2.carbon.event.publisher.core.EventPublisherService;
+import org.wso2.carbon.event.stream.core.EventStreamService;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.tenant.resource.manager.core.ResourceManager;
+
+/**
+ * DataHolder for Tenant Resource Manager.
+ */
+public class TenantResourceManagerDataHolder {
+
+    private static volatile TenantResourceManagerDataHolder instance = new TenantResourceManagerDataHolder();
+    private ConfigurationManager configurationManager;
+    private EventPublisherService carbonEventPublisherService = null;
+    private EventStreamService carbonEventStreamService = null;
+    private ResourceManager resourceManager = null;
+
+    private TenantResourceManagerDataHolder() {
+    }
+
+    public static TenantResourceManagerDataHolder getInstance() {
+
+        return instance;
+    }
+
+    public EventPublisherService getCarbonEventPublisherService() {
+
+        return carbonEventPublisherService;
+    }
+
+    public void setCarbonEventPublisherService(EventPublisherService carbonEventPublisherService) {
+
+        this.carbonEventPublisherService = carbonEventPublisherService;
+    }
+
+    public void setCarbonEventStreamService(EventStreamService carbonEventStreamService) {
+
+        this.carbonEventStreamService = carbonEventStreamService;
+    }
+
+    public EventStreamService getCarbonEventStreamService() {
+
+        return carbonEventStreamService;
+    }
+
+    public void setConfigurationManager(ConfigurationManager configurationManager) {
+
+        this.configurationManager = configurationManager;
+    }
+
+    public ConfigurationManager getConfigurationManager() {
+
+        return configurationManager;
+    }
+
+    public ResourceManager getResourceManager() {
+
+        return resourceManager;
+    }
+
+    public void setResourceManager(ResourceManager resourceManager) {
+
+        this.resourceManager = resourceManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/internal/TenantResourceManagerServiceDS.java
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/internal/TenantResourceManagerServiceDS.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.tenant.resource.manager.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.event.publisher.core.EventPublisherService;
+import org.wso2.carbon.event.stream.core.EventStreamService;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.tenant.resource.manager.TenantAwareAxis2ConfigurationContextObserver;
+import org.wso2.carbon.identity.tenant.resource.manager.core.ResourceManager;
+import org.wso2.carbon.identity.tenant.resource.manager.core.ResourceManagerImpl;
+import org.wso2.carbon.utils.AbstractAxis2ConfigurationContextObserver;
+import org.wso2.carbon.utils.Axis2ConfigurationContextObserver;
+
+@Component(name = "org.wso2.carbon.identity.tenant.resource.manager.internal.TenantResourceManagerServiceDS",
+           immediate = true)
+public class TenantResourceManagerServiceDS extends AbstractAxis2ConfigurationContextObserver {
+
+    private static final Log log = LogFactory.getLog(TenantResourceManagerServiceDS.class);
+
+    /**
+     * Register Tenant Aware Axis2 Configuration Context Observer as an OSGI service.
+     *
+     * @param context OSGI service component context.
+     */
+    @Activate
+    protected void activate(ComponentContext context) {
+
+        try {
+            TenantAwareAxis2ConfigurationContextObserver tenantAwareAxis2ConfigurationContextObserver =
+                    new TenantAwareAxis2ConfigurationContextObserver();
+
+            context.getBundleContext().registerService(Axis2ConfigurationContextObserver.class.getName(),
+                    tenantAwareAxis2ConfigurationContextObserver, null);
+            ResourceManager resourceManager = new ResourceManagerImpl();
+            context.getBundleContext()
+                    .registerService(ResourceManager.class.getName(), resourceManager, null);
+            TenantResourceManagerDataHolder.getInstance().setResourceManager(resourceManager);
+            if (log.isDebugEnabled()) {
+                log.debug("Successfully deployed the tenant resource manager service.");
+            }
+        } catch (Exception e) {
+            log.error("Can not create the tenant resource manager service.", e);
+        }
+    }
+
+    @Deactivate
+    protected void deactivate(ComponentContext context) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Tenant resource manager bundle is de-activated");
+        }
+    }
+
+    @Reference(name = "CarbonEventPublisherService",
+               service = org.wso2.carbon.event.publisher.core.EventPublisherService.class,
+               cardinality = ReferenceCardinality.MANDATORY,
+               policy = ReferencePolicy.DYNAMIC,
+               unbind = "unsetCarbonEventPublisherService")
+    protected void setCarbonEventPublisherService(EventPublisherService carbonEventPublisherService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Setting the CarbonEventPublisherService");
+        }
+        TenantResourceManagerDataHolder.getInstance().setCarbonEventPublisherService(carbonEventPublisherService);
+    }
+
+    protected void unsetCarbonEventPublisherService(EventPublisherService carbonEventPublisherService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Un Setting the CarbonEventPublisherService Service");
+        }
+        TenantResourceManagerDataHolder.getInstance().setCarbonEventPublisherService(null);
+    }
+
+    @Reference(name = "EventStreamService",
+               service = org.wso2.carbon.event.stream.core.EventStreamService.class,
+               cardinality = ReferenceCardinality.MANDATORY,
+               policy = ReferencePolicy.DYNAMIC,
+               unbind = "unsetCarbonEventStreamService")
+    protected void setCarbonEventStreamService(EventStreamService carbonEventStreamService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Setting the EventStreamService");
+        }
+        TenantResourceManagerDataHolder.getInstance().setCarbonEventStreamService(carbonEventStreamService);
+    }
+
+    protected void unsetCarbonEventStreamService(EventStreamService carbonEventStreamService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Un Setting the EventStreamService");
+        }
+        TenantResourceManagerDataHolder.getInstance().setCarbonEventStreamService(null);
+    }
+
+    @Reference(name = "ConfigurationManager",
+               service = org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager.class,
+               cardinality = ReferenceCardinality.MANDATORY,
+               policy = ReferencePolicy.DYNAMIC,
+               unbind = "unsetConfigurationManager")
+    protected void setConfigurationManager(ConfigurationManager configurationManager) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Setting the CarbonEventPublisherService");
+        }
+        TenantResourceManagerDataHolder.getInstance().setConfigurationManager(configurationManager);
+    }
+
+    protected void unsetConfigurationManager(ConfigurationManager configurationManager) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Un Setting theCarbonEventPublisherService Service");
+        }
+        TenantResourceManagerDataHolder.getInstance().setConfigurationManager(null);
+    }
+}

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/util/ResourceUtils.java
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/util/ResourceUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.tenant.resource.manager.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.tenant.resource.manager.constants.TenantResourceConstants;
+import org.wso2.carbon.identity.tenant.resource.manager.exception.TenantResourceManagementServerException;
+
+/**
+ * Utility methods for tenant resource management.
+ */
+public class ResourceUtils {
+
+    private static final Log log = LogFactory.getLog(ResourceUtils.class);
+
+    /**
+     * This method can be used to generate a TenantResourceManagementServerException from
+     * TenantResourceConstants.ErrorMessages object when no exception is thrown.
+     *
+     * @param error TenantResourceConstants.ErrorMessages.
+     * @param data  data to replace if message needs to be replaced.
+     * @return TenantResourceManagementServerException.
+     */
+    public static TenantResourceManagementServerException handleServerException(
+            TenantResourceConstants.ErrorMessages error, String... data) {
+
+        String message = populateMessageWithData(error, data);
+        return new TenantResourceManagementServerException(message, error.getCode());
+    }
+
+    public static TenantResourceManagementServerException handleServerException(
+            TenantResourceConstants.ErrorMessages error, Throwable e, String... data) {
+
+        String message = populateMessageWithData(error, data);
+        return new TenantResourceManagementServerException(message, error.getCode(), e);
+    }
+
+    public static String populateMessageWithData(TenantResourceConstants.ErrorMessages error, String... data) {
+
+        String message;
+        if (data.length != 0) {
+            message = String.format(error.getMessage(), data);
+        } else {
+            message = error.getMessage();
+        }
+        return message;
+    }
+}

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/test/java/org/wso2/carbon/identity/tenant/resource/manager/TenantAwareAxis2ConfigurationContextObserverTest.java
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/test/java/org/wso2/carbon/identity/tenant/resource/manager/TenantAwareAxis2ConfigurationContextObserverTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.tenant.resource.manager;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import org.junit.Assert;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.base.CarbonBaseConstants;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.databridge.commons.StreamDefinition;
+import org.wso2.carbon.event.publisher.core.config.EventPublisherConfiguration;
+import org.wso2.carbon.event.publisher.core.internal.CarbonEventPublisherService;
+import org.wso2.carbon.event.publisher.core.internal.EventPublisher;
+import org.wso2.carbon.event.publisher.core.internal.ds.EventPublisherServiceValueHolder;
+import org.wso2.carbon.event.stream.core.EventStreamConfiguration;
+import org.wso2.carbon.event.stream.core.EventStreamService;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
+import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceFile;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resources;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.tenant.resource.manager.core.ResourceManager;
+import org.wso2.carbon.identity.tenant.resource.manager.core.ResourceManagerImpl;
+import org.wso2.carbon.identity.tenant.resource.manager.internal.TenantResourceManagerDataHolder;
+import org.wso2.carbon.identity.tenant.resource.manager.util.ResourceUtils;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+@PrepareForTest({
+                        TenantResourceManagerDataHolder.class, PrivilegedCarbonContext.class, ResourceUtils.class,
+                        EventPublisherServiceValueHolder.class, EventPublisherServiceValueHolder.class,
+                        IdentityTenantUtil.class
+                })
+
+public class TenantAwareAxis2ConfigurationContextObserverTest extends PowerMockTestCase {
+
+    private static final String EMAIL_PUBLISHER = "EmailPublisher";
+    private static final String SAMPLE_RESOURCE_FILE_TXT = "sample-resource-file.txt";
+    private static final String TENANT_DOMAIN = "abc.com";
+    private static final String TENANT_SPECIFIC_EMAIL_PUBLISHER = "TENANT_SPECIFIC_EMAIL_PUBLISHER";
+    private static final int TENANT_ID = 1;
+    private CustomCarbonEventPublisherService carbonEventPublisherService = new CustomCarbonEventPublisherService();
+
+    @Mock
+    TenantResourceManagerDataHolder tenantResourceManagerDataHolder;
+    @Mock
+    EventStreamService eventStreamService;
+    @Mock
+    ConfigurationManager configurationManager;
+    @Mock
+    StreamDefinition streamDefinition;
+    @Mock
+    EventPublisher eventPublisher;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        String carbonHome = Paths.get(System.getProperty("user.dir"), "target", "test-classes").toString();
+        System.setProperty(CarbonBaseConstants.CARBON_HOME, carbonHome);
+        System.setProperty(CarbonBaseConstants.CARBON_CONFIG_DIR_PATH, Paths.get(carbonHome, "conf").toString());
+        mockStatic(TenantResourceManagerDataHolder.class);
+        mockStatic(ResourceUtils.class);
+        mockStatic(EventPublisherServiceValueHolder.class);
+        mockStatic(EventPublisherServiceValueHolder.class);
+        mockStatic(IdentityTenantUtil.class);
+        prepareConfigs();
+    }
+
+    private void mockCarbonContext() {
+
+        mockStatic(PrivilegedCarbonContext.class);
+        PrivilegedCarbonContext privilegedCarbonContext = mock(PrivilegedCarbonContext.class);
+        when(PrivilegedCarbonContext.getThreadLocalCarbonContext()).thenReturn(privilegedCarbonContext);
+        when(privilegedCarbonContext.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+        when(privilegedCarbonContext.getTenantId()).thenReturn(TENANT_ID);
+    }
+
+    class CustomCarbonEventPublisherService extends CarbonEventPublisherService {
+
+        private HashMap<String, EventPublisher> tenantSpecificEventPublisherConfigurationMap = new HashMap<>();
+        EventPublisherConfiguration tenantSpecificEventPublisherConfiguration = new EventPublisherConfiguration();
+
+        public EventPublisherConfiguration getEventPublisherConfiguration(InputStream eventPublisherConfiguration) {
+            tenantSpecificEventPublisherConfiguration.setEventPublisherName(TENANT_SPECIFIC_EMAIL_PUBLISHER);
+            return tenantSpecificEventPublisherConfiguration;
+        }
+
+        public void addEventPublisherConfiguration(EventPublisherConfiguration eventPublisherConfiguration) {
+
+            tenantSpecificEventPublisherConfigurationMap.put(EMAIL_PUBLISHER, eventPublisher);
+        }
+
+        public EventPublisherConfiguration getActiveEventPublisherConfiguration(
+                String eventPublisherConfigurationName) {
+            return tenantSpecificEventPublisherConfiguration;
+        }
+
+        public void removeEventPublisherConfigurationFile(String fileName, int tenantId) {
+        }
+
+        private EventPublisher getEventPublisherConfigurationFromMap() {
+            return tenantSpecificEventPublisherConfigurationMap
+                    .get(TenantAwareAxis2ConfigurationContextObserverTest.EMAIL_PUBLISHER);
+        }
+    }
+
+    private void prepareConfigs() throws Exception {
+
+        mockCarbonContext();
+        when(TenantResourceManagerDataHolder.getInstance()).thenReturn(tenantResourceManagerDataHolder);
+        when(IdentityTenantUtil.getTenantDomain(anyInt())).thenReturn(TENANT_DOMAIN);
+        ResourceFile resourceFile = new ResourceFile();
+        resourceFile.setName(EMAIL_PUBLISHER);
+        List<ResourceFile> resourceFiles = new ArrayList<>();
+        resourceFiles.add(resourceFile);
+        when(configurationManager.getFiles(anyString(),anyInt())).thenReturn(resourceFiles);
+
+        ResourceManager resourceManager = new ResourceManagerImpl();
+        when(tenantResourceManagerDataHolder.getResourceManager()).thenReturn(resourceManager);
+
+        when(tenantResourceManagerDataHolder.getCarbonEventPublisherService()).thenReturn(carbonEventPublisherService);
+        when(tenantResourceManagerDataHolder.getCarbonEventStreamService()).thenReturn(eventStreamService);
+        when(tenantResourceManagerDataHolder.getConfigurationManager()).thenReturn(configurationManager);
+        when(tenantResourceManagerDataHolder.getCarbonEventPublisherService()).thenReturn(carbonEventPublisherService);
+
+        File sampleResourceFile = new File(getSamplesPath());
+        InputStream fileStream = FileUtils.openInputStream(sampleResourceFile);
+        when(configurationManager.getFileById(anyString(), anyString(), anyString())).thenReturn(fileStream);
+        Resources resources = new Resources();
+        Resource resource = new Resource();
+        resource.setFiles(resourceFiles);
+        List<Resource> resourceList = new ArrayList<Resource>();
+        resourceList.add(resource);
+        resources.setResources(resourceList);
+        when(configurationManager.getResourcesByType(anyString())).thenReturn(resources);
+        when(eventStreamService.getStreamDefinition(anyString(), anyString())).thenReturn(streamDefinition);
+        List<EventStreamConfiguration> eventStreamConfigurationsList = new ArrayList<>();
+        EventStreamConfiguration eventStreamConfiguration = new EventStreamConfiguration();
+        eventStreamConfiguration.setFileName(EMAIL_PUBLISHER);
+        when(TenantResourceManagerDataHolder.getInstance().getCarbonEventStreamService()
+                .getAllEventStreamConfigurations()).thenReturn(eventStreamConfigurationsList);
+    }
+
+    @Test
+    public void testCreatingConfigurationContext() {
+
+        new TenantAwareAxis2ConfigurationContextObserver().creatingConfigurationContext(TENANT_ID);
+        Assert.assertNotNull(TENANT_SPECIFIC_EMAIL_PUBLISHER,
+                carbonEventPublisherService.getEventPublisherConfigurationFromMap());
+    }
+
+    private static String getSamplesPath() {
+
+        if (StringUtils.isNotBlank(TenantAwareAxis2ConfigurationContextObserverTest.SAMPLE_RESOURCE_FILE_TXT)) {
+            return Paths.get(System.getProperty("user.dir"), "src", "test", "resources", "sample",
+                    TenantAwareAxis2ConfigurationContextObserverTest.SAMPLE_RESOURCE_FILE_TXT).toString();
+        }
+        throw new IllegalArgumentException("Sample name cannot be empty.");
+    }
+}

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/test/resources/sample/sample-resource-file.txt
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/test/resources/sample/sample-resource-file.txt
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<eventPublisher name="EmailPublisher" statistics="disable"
+  trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
+  <from streamName="id_gov_notify_stream" version="1.0.0"/>
+  <mapping customMapping="enable" type="text">
+    <inline>{{body}}{{footer}}</inline>
+  </mapping>
+  <to eventAdapterType="email">
+    <property name="email.address">{{send-to}}</property>
+    <property name="email.type">{{content-type}}</property>
+    <property name="email.subject">{{subject}}</property>
+  </to>
+</eventPublisher>

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/test/resources/testng.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Carbon-Security-Test-Suite">
+
+    <test name="identity-tenant-resource-tests" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.carbon.identity.tenant.resource.manager.TenantAwareAxis2ConfigurationContextObserverTest"></class>
+        </classes>
+    </test>
+</suite>

--- a/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.governance</groupId>
+        <artifactId>identity-governance</artifactId>
+        <version>1.3.30-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.tenant.resource.manager.feature</artifactId>
+    <packaging>pom</packaging>
+    <name>WSO2 Carbon - Identity Tenant Resource Manager Feature</name>
+    <url>http://wso2.org</url>
+    <description>This feature contains the bundles required for Tenant Resource Managing functionality
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.tenant.resource.manager</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.tenant.resource.manager</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>carbon-p2-plugin</artifactId>
+                <version>${carbon.p2.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>p2-feature-generation</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>p2-feature-gen</goal>
+                        </goals>
+                        <configuration>
+                            <id>org.wso2.carbon.identity.tenant.resource.manager</id>
+                            <propertiesFile>../../etc/feature.properties</propertiesFile>
+                            <adviceFile>
+                                <properties>
+                                    <propertyDef>org.wso2.carbon.p2.category.type:console</propertyDef>
+                                    <propertyDef>org.eclipse.equinox.p2.type.group:false</propertyDef>
+                                </properties>
+                            </adviceFile>
+                            <bundles>
+                                <bundleDef>org.wso2.carbon.identity.governance:org.wso2.carbon.identity.tenant.resource.manager</bundleDef>
+                            </bundles>
+                            <importFeatures>
+                                <importFeatureDef>org.wso2.carbon.identity.configuration.mgt.core:compatible:${carbon.identity.framework.version}</importFeatureDef>
+                            </importFeatures>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@
         <module>components/org.wso2.carbon.identity.piicontroller</module>
         <module>components/org.wso2.carbon.identity.user.rename.core</module>
         <module>components/org.wso2.carbon.identity.user.endpoint</module>
+        <module>components/org.wso2.carbon.identity.tenant.resource.manager</module>
 
         <module>service-stubs/identity</module>
 
@@ -140,6 +141,7 @@
         <module>features/org.wso2.carbon.identity.governance.feature</module>
         <module>features/org.wso2.carbon.identity.password.policy.server.feature</module>
         <module>features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature</module>
+        <module>features/org.wso2.carbon.identity.tenant.resource.manager.feature</module>
     </modules>
 
     <dependencyManagement>
@@ -148,6 +150,20 @@
                 <groupId>org.eclipse.equinox</groupId>
                 <artifactId>javax.servlet</artifactId>
                 <version>${equinox.javax.servlet.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.analytics-common</groupId>
+                <artifactId>org.wso2.carbon.event.publisher.core</artifactId>
+                <version>${carbon.analytics.common.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>configuration-mgt</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+                <version>${carbon.identity.framework.version}</version>
             </dependency>
 
             <!--Orbit Dependencies-->
@@ -484,11 +500,6 @@
                 <artifactId>org.wso2.carbon.identity.data.publisher.application.authentication</artifactId>
                 <version>${identity.data.publisher.authentication.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
-                <version>${apache.felix.scr.ds.annotations.version}</version>
-            </dependency>
             <!-- Pax Logging -->
             <dependency>
                 <groupId>org.ops4j.pax.logging</groupId>
@@ -574,6 +585,7 @@
 
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
+        <axis2.osgi.version.range>[1.6.1, 2.0.0)</axis2.osgi.version.range>
 
         <!--Orbit Version-->
         <axis2.wso2.version>1.6.1-wso2v38</axis2.wso2.version>
@@ -613,8 +625,8 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.14.78</carbon.identity.framework.version>
-        <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 6.0.0)
+        <carbon.identity.framework.version>5.15.28</carbon.identity.framework.version>
+        <carbon.identity.framework.imp.pkg.version.range>[5.15.28, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 
         <!--Carbon Identity Extension Versions-->
@@ -658,6 +670,9 @@
 
         <!-- Pax Logging Version -->
         <pax.logging.api.version>1.10.1</pax.logging.api.version>
+
+        <carbon.analytics.common.version>5.2.15</carbon.analytics.common.version>
+        <carbon.analytics.common.version.range>[5.2.15,6.0.0)</carbon.analytics.common.version.range>
     </properties>
 
 </project>


### PR DESCRIPTION
Fix: wso2/product-is#6146

will check for the publisher xml file in the configuration store.
If it is there it will use that configuration to create tenant wise publisher configuration
else it will use super tenant configurations
Merge this after :

wso2/carbon-identity-framework#2480
https://github.com/wso2-extensions/identity-event-handler-notification/pull/105/files
wso2/carbon-analytics-common#717