### PR TITLE
use a lesser framework version to avoid test failure

### DIFF
--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/test/java/org/wso2/carbon/identity/tenant/resource/manager/TenantAwareAxis2ConfigurationContextObserverTest.java
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/test/java/org/wso2/carbon/identity/tenant/resource/manager/TenantAwareAxis2ConfigurationContextObserverTest.java
@@ -145,7 +145,6 @@ public class TenantAwareAxis2ConfigurationContextObserverTest extends PowerMockT
         resourceFile.setName(EMAIL_PUBLISHER);
         List<ResourceFile> resourceFiles = new ArrayList<>();
         resourceFiles.add(resourceFile);
-        when(configurationManager.getFiles(anyString(),anyInt())).thenReturn(resourceFiles);
 
         ResourceManager resourceManager = new ResourceManagerImpl();
         when(tenantResourceManagerDataHolder.getResourceManager()).thenReturn(resourceManager);

--- a/pom.xml
+++ b/pom.xml
@@ -621,8 +621,8 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.15.28</carbon.identity.framework.version>
-        <carbon.identity.framework.imp.pkg.version.range>[5.15.28, 6.0.0)
+        <carbon.identity.framework.version>5.15.25</carbon.identity.framework.version>
+        <carbon.identity.framework.imp.pkg.version.range>[5.15.25, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 
         <!--Carbon Identity Extension Versions-->


### PR DESCRIPTION
When using the 5.15.28 framework version due to the latest fixes on that integration tests fails. due to that using a lesser version. 