### PR TITLE
Implementing user account recovery with multiple notification channels

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/notification/NotificationChannels.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/notification/NotificationChannels.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.governance.service.notification;
 
+import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.governance.IdentityMgtConstants;
 import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationChannelManagerClientException;
 
@@ -29,7 +30,8 @@ public enum NotificationChannels {
     EMAIL_CHANNEL("EMAIL", "http://wso2.org/claims/emailaddress",
             "http://wso2.org/claims/identity/emailVerified"),
     SMS_CHANNEL("SMS", "http://wso2.org/claims/mobile",
-            "http://wso2.org/claims/identity/phoneVerified");
+            "http://wso2.org/claims/identity/phoneVerified"),
+    EXTERNAL_CHANNEL("EXTERNAL", StringUtils.EMPTY, StringUtils.EMPTY);
 
     // Type of the channel. Eg: EMAIL or SMS.
     private String channelType;

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/notification/NotificationChannels.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/notification/NotificationChannels.java
@@ -90,6 +90,8 @@ public enum NotificationChannels {
             return EMAIL_CHANNEL;
         } else if (SMS_CHANNEL.getChannelType().equals(channelType)) {
             return SMS_CHANNEL;
+        } else if (EXTERNAL_CHANNEL.getChannelType().equals(channelType)) {
+            return EXTERNAL_CHANNEL;
         } else {
             throw new NotificationChannelManagerClientException(
                     IdentityMgtConstants.ErrorMessages.ERROR_CODE_NO_NOTIFICATION_CHANNELS.getCode(),

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -352,7 +352,7 @@ public class IdentityRecoveryConstants {
     public static class ConnectorConfig {
 
         public static final String PASSWORD_RECOVERY_SMS_OTP_EXPIRY_TIME =
-                "Recovery.Notification.Recovery.ExpiryTime.SMSOTP";
+                "Recovery.Notification.Password.ExpiryTime.smsOtp";
         public static final String RESEND_CODE_EXPIRY_TIME = "Recovery.Notification.ExpiryTime.ResendCode";
         public static final String RECOVERY_CODE_EXPIRY_TIME = "Recovery.Notification.ExpiryTime.RecoveryCode";
         public static final String ENABLE_ACCOUNT_LOCK_FOR_VERIFIED_PREFERRED_CHANNEL =

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -17,7 +17,7 @@
 package org.wso2.carbon.identity.recovery;
 
 /**
- * Identity management related constants
+ * Identity management related constants.
  */
 public class IdentityRecoveryConstants {
 
@@ -55,12 +55,17 @@ public class IdentityRecoveryConstants {
     public static final String ACCOUNT_DISABLED_CLAIM = "http://wso2.org/claims/identity/accountDisabled";
     public static final String FAILED_LOGIN_LOCKOUT_COUNT_CLAIM =
             "http://wso2.org/claims/identity/failedLoginLockoutCount";
+
+    // Notification channel claims.
     public static final String VERIFY_EMAIL_CLIAM = "http://wso2.org/claims/identity/verifyEmail";
     public static final String EMAIL_VERIFIED_CLAIM = "http://wso2.org/claims/identity/emailVerified";
     public static final String MOBILE_VERIFIED_CLAIM = "http://wso2.org/claims/identity/phoneVerified";
+    public static final String PREFERRED_CHANNEL_CLAIM = "http://wso2.org/claims/identity/preferredChannel";
+
     public static final String ASK_PASSWORD_CLAIM = "http://wso2.org/claims/identity/askPassword";
     public static final String ADMIN_FORCED_PASSWORD_RESET_CLAIM = "http://wso2.org/claims/identity/adminForcedPasswordReset";
     public static final String OTP_PASSWORD_CLAIM = "http://wso2.org/claims/oneTimePassword";
+    public static final String USER_ROLES_CLAIM = "http://wso2.org/claims/role";
     public static final String DEFAULT_CHALLENGE_QUESTION_SEPARATOR = "!";
     public static final String ACCOUNT_STATE_CLAIM_URI = "http://wso2.org/claims/identity/accountState";
     public static final String PENDING_SELF_REGISTRATION = "PENDING_SR";
@@ -71,7 +76,6 @@ public class IdentityRecoveryConstants {
 
     public static final String PASSWORD_RESET_FAIL_ATTEMPTS_CLAIM = "http://wso2" +
             ".org/claims/identity/failedPasswordRecoveryAttempts";
-    public static final String PREFERRED_CHANNEL_CLAIM = "http://wso2.org/claims/identity/preferredChannel";
     public static final String SIGN_UP_ROLE_SEPARATOR = ",";
 
     public static final String NOTIFICATION_EVENTNAME_PREFIX = "TRIGGER_";
@@ -88,12 +92,34 @@ public class IdentityRecoveryConstants {
     public static final String CALLBACK = "callback";
     public static final String DEFAULT_CALLBACK_REGEX = ".*";
     public static final String IS_USER_PORTAL_URL = "isUserPortalURL";
-    public static final int SMS_OTP_CODE_LENGTH = 6;
+    public static final String NOTIFY_CHANNEL_LIST_SEPARATOR = ",";
+    public static final String CHANNEL_ATTRIBUTE_SEPARATOR = ":";
     public static final String SMS_OTP_GENERATE_CHAR_SET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    public static final String EXCEPTION_SCENARIO_SEPARATOR = "-";
+
+    public static final String USE_LEGACY_API_PROPERTY_KEY = "useLegacyAPI";
+    public static final String NOTIFICATION_CHANNEL_PROPERTY_KEY = "notificationChannel";
+    public static final String VERIFIED_USER_PROPERTY_KEY = "verifiedUser";
+    public static final String MANAGE_NOTIFICATIONS_INTERNALLY_PROPERTY_KEY = "manageNotificationsInternally";
+
+    // Recovery Scenarios.
+    public static final String USER_NAME_RECOVERY = "UNR";
+    public static final String USER_SELF_REGISTRATION = "USR";
+    public static final String PASSWORD_RECOVERY_SCENARIO = "PWR";
+    public static final String USER_ACCOUNT_RECOVERY = "UAR";
+
+    public static final int SMS_OTP_CODE_LENGTH = 6;
+
+    // Recovery code given at the username and password recovery initiation.
+    public static final int RECOVERY_CODE_DEFAULT_EXPIRY_TIME = 1;
+    public static final int RESEND_CODE_DEFAULT_EXPIRY_TIME = 1;
 
     private IdentityRecoveryConstants() {
     }
 
+    /**
+     * Enum which contains the error codes and corresponding error messages.
+     */
     public enum ErrorMessages {
 
         ERROR_CODE_INVALID_CODE("18001", "Invalid Code '%s.'"),
@@ -188,7 +214,52 @@ public class IdentityRecoveryConstants {
 
         // UAV - User Account Verification.
         ERROR_CODE_UNSUPPORTED_VERIFICATION_CHANNEL("UAV-10001",
-                "Unsupported verification channel");
+                "Unsupported verification channel"),
+
+        // UNR - Username Recovery
+        ERROR_CODE_USERNAME_RECOVERY_NOT_ENABLED("UNR-10001", "Username recovery is not enabled"),
+
+        // UAR - User Account Recovery.
+        ERROR_CODE_INVALID_RECOVERY_CODE("UAR-10001", "Invalid recoveryCode : '%s'"),
+        ERROR_CODE_NO_USER_FOUND("UAR-10002", "No user found"),
+        ERROR_CODE_NO_VERIFIED_CHANNELS_FOR_USER("UAR-10003", "No verified channels found for user"),
+        ERROR_CODE_INVALID_CHANNEL_ID("UAR-10004", "Channel ID does not exist"),
+        ERROR_CODE_USER_TENANT_DOMAIN_MISS_MATCH_WITH_CONTEXT("UAR-10005", "User's tenant domain does "
+                + "not match the domain in the context"),
+        ERROR_CODE_ERROR_LOADING_USER_CLAIMS("UAR-10006", "Error loading claims of the user"),
+        ERROR_CODE_MULTIPLE_MATCHING_USERS("UAR-10007", "Multiple users found for given claims"),
+        ERROR_CODE_NO_ACCOUNT_RECOVERY_DATA("UAR-10008", "No account recovery data found for "
+                + "recovery code : '%s'"),
+        ERROR_CODE_NO_NOTIFICATION_CHANNELS_FOR_USER("UAR-10009", "Notification channels not "
+                + "found for user"),
+        ERROR_CODE_INVALID_RECOVERY_STEP("UAR-10010", "Invalid recovery step : '%s'"),
+        ERROR_CODE_INVALID_RECOVERY_SCENARIO("UAR-10011", "Invalid recovery scenario : '%s'"),
+        ERROR_CODE_INVALID_RESEND_CODE("UAR-10012", "Invalid resend code : '%s'"),
+        ERROR_CODE_EXPIRED_RECOVERY_CODE("UAR-10013", "Invalid recovery code : '%s'"),
+        ERROR_CODE_ERROR_STORING_RECOVERY_DATA("UAR-15001", "Error storing user recovery data"),
+        ERROR_CODE_ERROR_GETTING_USERSTORE_MANAGER("UAR-15002", "Error getting userstore manager"),
+        ERROR_CODE_ERROR_RETRIEVING_USER_CLAIM("UAR-15003", "Error getting the claims : '%s' "
+                + "from the userstore"),
+        ERROR_CODE_UNEXPECTED_ERROR("UAR-15004", "Unexpected error"),
+        ERROR_CODE_UNSUPPORTED_NOTIFICATION_CHANNEL("UAR-15005",
+                "Unsupported notification channel : '%s'"),
+        ERROR_CODE_ERROR_GENERATING_NEW_RESET_CODE("UAR-15006", "Error while generating new "
+                + "password reset code"),
+
+        // PWR - Password Recovery.
+        ERROR_CODE_INVALID_TENANT_DOMAIN_PASSWORD_RESET("PWR-10001", "User's tenant domain does "
+                + "not match with the domain in the context"),
+        ERROR_CODE_PASSWORD_RECOVERY_WITH_NOTIFICATIONS_NOT_ENABLED(
+                "PWR-10002", "Password recovery with notifications is not enabled"),
+        ERROR_CODE_NO_PASSWORD_IN_REQUEST("PWR-10003", "No password found"),
+        ERROR_CODE_PASSWORD_RECOVERY_NOT_ENABLED("UNR-10004", "Password recovery is not enabled"),
+        ERROR_CODE_PASSWORD_HISTORY_VIOLATION("UNR-10005", "This password has been used in recent "
+                + "history. Please choose a different password"),
+        ERROR_CODE_PASSWORD_POLICY_VIOLATION("UNR-10006", "Password policy violation"),
+        ERROR_CODE_INVALID_CALLBACK_PASSWORD_RESET("UNR-10007", "Invalid callback url in password " +
+                "reset request"),
+        ERROR_CODE_UNEXPECTED_ERROR_PASSWORD_RESET("PWR-15001", "Unexpected error during "
+                + "password reset");
 
         private final String code;
         private final String message;
@@ -218,6 +289,7 @@ public class IdentityRecoveryConstants {
      */
     public enum SuccessEvents {
 
+        // USR - User Self Registration.
         SUCCESS_STATUS_CODE_SUCCESSFUL_USER_CREATION_INTERNAL_VERIFICATION("USR-02001",
                 "Successful user self registration. Pending account verification."),
         SUCCESS_STATUS_CODE_SUCCESSFUL_USER_CREATION_EXTERNAL_VERIFICATION("USR-02002",
@@ -226,7 +298,24 @@ public class IdentityRecoveryConstants {
                 "Successful user self registration. Account verification not required."),
         SUCCESS_STATUS_CODE_SUCCESSFUL_USER_CREATION_WITH_VERIFIED_CHANNEL("USR-02004",
                 "Successful user self registration with verified channel. "
-                        + "Account verification not required.");
+                        + "Account verification not required."),
+
+        // UNR - Username Recovery.
+        SUCCESS_STATUS_CODE_USERNAME_INTERNALLY_NOTIFIED("UNR-02001",
+                "Username recovery information sent via user preferred notification channel."),
+        SUCCESS_STATUS_CODE_USERNAME_EXTERNALLY_NOTIFIED("UNR-02002",
+                "Username recovery information sent externally."),
+
+        // PWR - Password Recovery.
+        SUCCESS_STATUS_CODE_PASSWORD_RECOVERY_INTERNALLY_NOTIFIED("PWR-02001",
+                "Password recovery information sent via user preferred notification channel."),
+        SUCCESS_STATUS_CODE_PASSWORD_RECOVERY_EXTERNALLY_NOTIFIED("PWR-02002",
+                "Password recovery information sent externally"),
+        SUCCESS_STATUS_CODE_SUCCESSFUL_PASSWORD_UPDATE("PWR-02005", "Successful password reset."),
+
+        // UAR - User Account Recovery.
+        SUCCESS_STATUS_CODE_RESEND_CONFIRMATION_CODE("UAR-02001",
+                "Confirmation code resent to the user.");
 
         private final String code;
         private final String message;
@@ -237,7 +326,7 @@ public class IdentityRecoveryConstants {
         }
 
         /**
-         * Get the code of the SuccessEvents
+         * Get the code of the SuccessEvents.
          *
          * @return Code
          */
@@ -262,6 +351,10 @@ public class IdentityRecoveryConstants {
 
     public static class ConnectorConfig {
 
+        public static final String PASSWORD_RECOVERY_SMS_OTP_EXPIRY_TIME =
+                "Recovery.Notification.Recovery.ExpiryTime.SMSOTP";
+        public static final String RESEND_CODE_EXPIRY_TIME = "Recovery.Notification.ExpiryTime.ResendCode";
+        public static final String RECOVERY_CODE_EXPIRY_TIME = "Recovery.Notification.ExpiryTime.RecoveryCode";
         public static final String ENABLE_ACCOUNT_LOCK_FOR_VERIFIED_PREFERRED_CHANNEL =
                 "SelfRegistration.EnableAccountLockForVerifiedPreferredChannel";
         public static final String NOTIFICATION_INTERNALLY_MANAGE = "Recovery.Notification.InternallyManage";
@@ -373,5 +466,16 @@ public class IdentityRecoveryConstants {
         public static final String PURPOSE_ID = "purposeId";
         public static final String INFINITE_TERMINATION = "DATE_UNTIL:INDEFINITE";
         public static final String RESIDENT_IDP = "Resident IDP";
+    }
+
+    /**
+     * Constants used for masking the notification channels.
+     */
+    public static class ChannelMasking {
+
+        public static final String MASKING_CHARACTER = "*";
+        public static final String EMAIL_MASKING_REGEX =
+                "(?<=.)[^@](?=[^@]*?@)|(?:(?<=@.)|(?!^)\\G(?=[^@]*$)).(?=.*[^@]\\.)";
+        public static final String MOBILE_MASKING_REGEX = ".(?=.{4})";
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -218,6 +218,8 @@ public class IdentityRecoveryConstants {
 
         // UNR - Username Recovery
         ERROR_CODE_USERNAME_RECOVERY_NOT_ENABLED("UNR-10001", "Username recovery is not enabled"),
+        ERROR_CODE_USERNAME_RECOVERY_EMPTY_TENANT_DOMAIN("UNR-10002", "Empty tenant domain in username "
+                + "recovery request"),
 
         // UAR - User Account Recovery.
         ERROR_CODE_INVALID_RECOVERY_CODE("UAR-10001", "Invalid recoveryCode : '%s'"),
@@ -258,6 +260,8 @@ public class IdentityRecoveryConstants {
         ERROR_CODE_PASSWORD_POLICY_VIOLATION("UNR-10006", "Password policy violation"),
         ERROR_CODE_INVALID_CALLBACK_PASSWORD_RESET("UNR-10007", "Invalid callback url in password " +
                 "reset request"),
+        ERROR_CODE_PASSWORD_RECOVERY_EMPTY_TENANT_DOMAIN("UNR-10008", "Empty tenant domain in password "
+                + "recovery request"),
         ERROR_CODE_UNEXPECTED_ERROR_PASSWORD_RESET("PWR-15001", "Unexpected error during "
                 + "password reset");
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -254,13 +254,13 @@ public class IdentityRecoveryConstants {
         ERROR_CODE_PASSWORD_RECOVERY_WITH_NOTIFICATIONS_NOT_ENABLED(
                 "PWR-10002", "Password recovery with notifications is not enabled"),
         ERROR_CODE_NO_PASSWORD_IN_REQUEST("PWR-10003", "No password found"),
-        ERROR_CODE_PASSWORD_RECOVERY_NOT_ENABLED("UNR-10004", "Password recovery is not enabled"),
-        ERROR_CODE_PASSWORD_HISTORY_VIOLATION("UNR-10005", "This password has been used in recent "
+        ERROR_CODE_PASSWORD_RECOVERY_NOT_ENABLED("PWR-10004", "Password recovery is not enabled"),
+        ERROR_CODE_PASSWORD_HISTORY_VIOLATION("PWR-10005", "This password has been used in recent "
                 + "history. Please choose a different password"),
-        ERROR_CODE_PASSWORD_POLICY_VIOLATION("UNR-10006", "Password policy violation"),
-        ERROR_CODE_INVALID_CALLBACK_PASSWORD_RESET("UNR-10007", "Invalid callback url in password " +
+        ERROR_CODE_PASSWORD_POLICY_VIOLATION("PWR-10006", "Password policy violation"),
+        ERROR_CODE_INVALID_CALLBACK_PASSWORD_RESET("PWR-10007", "Invalid callback url in password " +
                 "reset request"),
-        ERROR_CODE_PASSWORD_RECOVERY_EMPTY_TENANT_DOMAIN("UNR-10008", "Empty tenant domain in password "
+        ERROR_CODE_PASSWORD_RECOVERY_EMPTY_TENANT_DOMAIN("PWR-10008", "Empty tenant domain in password "
                 + "recovery request"),
         ERROR_CODE_UNEXPECTED_ERROR_PASSWORD_RESET("PWR-15001", "Unexpected error during "
                 + "password reset");

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/RecoveryScenarios.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/RecoveryScenarios.java
@@ -16,6 +16,12 @@
 
 package org.wso2.carbon.identity.recovery;
 
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.recovery.util.Utils;
+
+/**
+ * Enum which contains the recovery scenarios.
+ */
 public enum RecoveryScenarios {
     NOTIFICATION_BASED_PW_RECOVERY,
     QUESTION_BASED_PWD_RECOVERY,
@@ -23,6 +29,30 @@ public enum RecoveryScenarios {
     SELF_SIGN_UP,
     ASK_PASSWORD,
     ADMIN_FORCED_PASSWORD_RESET_VIA_EMAIL_LINK,
-    ADMIN_FORCED_PASSWORD_RESET_VIA_OTP,
+    ADMIN_FORCED_PASSWORD_RESET_VIA_OTP;
+
+    /**
+     * Get recovery scenario which matches the given scenario name.
+     *
+     * @param scenarioName Name of the scenario
+     * @return RecoveryScenarios
+     * @throws IdentityRecoveryClientException Invalid scenario name
+     */
+    public static RecoveryScenarios getRecoveryScenario(String scenarioName) throws IdentityRecoveryClientException {
+
+        RecoveryScenarios[] scenarios = {
+                NOTIFICATION_BASED_PW_RECOVERY, QUESTION_BASED_PWD_RECOVERY, USERNAME_RECOVERY, SELF_SIGN_UP,
+                ASK_PASSWORD, ADMIN_FORCED_PASSWORD_RESET_VIA_EMAIL_LINK, ADMIN_FORCED_PASSWORD_RESET_VIA_OTP
+        };
+        if (StringUtils.isNotEmpty(scenarioName)) {
+            for (RecoveryScenarios scenario : scenarios) {
+                if (scenarioName.equals(scenario.name())) {
+                    return scenario;
+                }
+            }
+        }
+        throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_RECOVERY_SCENARIO,
+                scenarioName);
+    }
 
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/RecoverySteps.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/RecoverySteps.java
@@ -38,6 +38,7 @@ public enum RecoverySteps {
      * @throws IdentityRecoveryClientException Invalid step name
      */
     public static RecoverySteps getRecoveryStep(String stepName) throws IdentityRecoveryClientException {
+
         RecoverySteps[] recoverySteps = {
                 NOTIFY, UPDATE_PASSWORD, VALIDATE_CHALLENGE_QUESTION, VALIDATE_ALL_CHALLENGE_QUESTION, CONFIRM_SIGN_UP,
                 SEND_RECOVERY_INFORMATION, RESEND_CONFIRMATION_CODE

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/RecoverySteps.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/RecoverySteps.java
@@ -13,13 +13,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.wso2.carbon.identity.recovery;
 
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.recovery.util.Utils;
+
+/**
+ * Enum which contains the recovery steps related to recovery scenarios.
+ */
 public enum RecoverySteps {
     NOTIFY,
     UPDATE_PASSWORD,
     VALIDATE_CHALLENGE_QUESTION,
     VALIDATE_ALL_CHALLENGE_QUESTION,
-    CONFIRM_SIGN_UP
+    CONFIRM_SIGN_UP,
+    SEND_RECOVERY_INFORMATION,
+    RESEND_CONFIRMATION_CODE;
+
+    /**
+     * Get Recovery step which matches the given step name.
+     *
+     * @param stepName Name of the step
+     * @return RecoverySteps
+     * @throws IdentityRecoveryClientException Invalid step name
+     */
+    public static RecoverySteps getRecoveryStep(String stepName) throws IdentityRecoveryClientException {
+        RecoverySteps[] recoverySteps = {
+                NOTIFY, UPDATE_PASSWORD, VALIDATE_CHALLENGE_QUESTION, VALIDATE_ALL_CHALLENGE_QUESTION, CONFIRM_SIGN_UP,
+                SEND_RECOVERY_INFORMATION, RESEND_CONFIRMATION_CODE
+        };
+        if (StringUtils.isNotEmpty(stepName)) {
+            for (RecoverySteps step : recoverySteps) {
+                if (stepName.equals(step.name())) {
+                    return step;
+                }
+            }
+        }
+        throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_RECOVERY_STEP,
+                stepName);
+    }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
@@ -146,11 +146,12 @@ public class ResendConfirmationManager {
                     IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_USER_TENANT_DOMAIN_MISS_MATCH_WITH_CONTEXT,
                     tenantDomain);
         }
-        // Validate recovery scenario.
         if (!scenario.equals(userRecoveryData.getRecoveryScenario())) {
             throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_RESEND_CODE,
                     resendCode);
         }
+        //Validate the tenant domain and the recovery scenario in the request.
+        validateRequestAttributes(user,scenario,userRecoveryData.getRecoveryScenario(),tenantDomain,resendCode);
         validateCallback(properties, user.getTenantDomain());
         UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
         userRecoveryDataStore.invalidate(user);
@@ -170,6 +171,32 @@ public class ResendConfirmationManager {
         resendConfirmationDTO.setSuccessMessage(
                 IdentityRecoveryConstants.SuccessEvents.SUCCESS_STATUS_CODE_RESEND_CONFIRMATION_CODE.getMessage());
         return resendConfirmationDTO;
+    }
+
+    /**
+     * Validate the tenant domain and the recovery scenario in the request.
+     *
+     * @param recoveredUser         User recovered using the resend code
+     * @param scenarioInRequest     Recovery scenario in the resend request
+     * @param recoveredScenario     Recovery scenario related to the resend code
+     * @param tenantDomainInRequest Tenant domain in the request
+     * @param resendCode            Resend code
+     * @throws IdentityRecoveryClientException Error in the resend request
+     */
+    private void validateRequestAttributes(User recoveredUser, RecoveryScenarios scenarioInRequest,
+                                           Enum recoveredScenario,
+                                           String tenantDomainInRequest, String resendCode)
+            throws IdentityRecoveryClientException {
+
+        if (!tenantDomainInRequest.equals(recoveredUser.getTenantDomain())) {
+            throw Utils.handleClientException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_USER_TENANT_DOMAIN_MISS_MATCH_WITH_CONTEXT,
+                    tenantDomainInRequest);
+        }
+        if (!scenarioInRequest.equals(recoveredScenario)) {
+            throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_RESEND_CODE,
+                    resendCode);
+        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
@@ -141,7 +141,7 @@ public class ResendConfirmationManager {
         UserRecoveryData userRecoveryData = userAccountRecoveryManager
                 .getUserRecoveryData(resendCode, RecoverySteps.RESEND_CONFIRMATION_CODE);
         User user = userRecoveryData.getUser();
-        if (!StringUtils.equals(tenantDomain,user.getTenantDomain())) {
+        if (!StringUtils.equals(tenantDomain, user.getTenantDomain())) {
             throw Utils.handleClientException(
                     IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_USER_TENANT_DOMAIN_MISS_MATCH_WITH_CONTEXT,
                     tenantDomain);
@@ -151,7 +151,7 @@ public class ResendConfirmationManager {
                     resendCode);
         }
         // Validate the tenant domain and the recovery scenario in the request.
-        validateRequestAttributes(user,scenario,userRecoveryData.getRecoveryScenario(),tenantDomain,resendCode);
+        validateRequestAttributes(user, scenario, userRecoveryData.getRecoveryScenario(), tenantDomain, resendCode);
         validateCallback(properties, user.getTenantDomain());
         UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
         userRecoveryDataStore.invalidate(user);
@@ -195,7 +195,7 @@ public class ResendConfirmationManager {
                                            String tenantDomainInRequest, String resendCode)
             throws IdentityRecoveryClientException {
 
-        if (!StringUtils.equals(tenantDomainInRequest,recoveredUser.getTenantDomain())) {
+        if (!StringUtils.equals(tenantDomainInRequest, recoveredUser.getTenantDomain())) {
             throw Utils.handleClientException(
                     IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_USER_TENANT_DOMAIN_MISS_MATCH_WITH_CONTEXT,
                     tenantDomainInRequest);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
@@ -137,13 +137,10 @@ public class ResendConfirmationManager {
         RecoverySteps step = RecoverySteps.getRecoveryStep(recoveryStep);
         RecoveryScenarios scenario = RecoveryScenarios.getRecoveryScenario(recoveryScenario);
         UserAccountRecoveryManager userAccountRecoveryManager = UserAccountRecoveryManager.getInstance();
-
         // Get Recovery data.
         UserRecoveryData userRecoveryData = userAccountRecoveryManager
                 .getUserRecoveryData(resendCode, RecoverySteps.RESEND_CONFIRMATION_CODE);
         User user = userRecoveryData.getUser();
-
-        // Validate tenantDomain.
         if (!tenantDomain.equals(user.getTenantDomain())) {
             throw Utils.handleClientException(
                     IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_USER_TENANT_DOMAIN_MISS_MATCH_WITH_CONTEXT,
@@ -158,17 +155,12 @@ public class ResendConfirmationManager {
         UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
         userRecoveryDataStore.invalidate(user);
         String notificationChannel = validateNotificationChannel(userRecoveryData.getRemainingSetIds());
-
-        // Generate confirmation code.
         String confirmationCode = generateSecretKey(notificationChannel);
         String eventName = Utils.resolveEventName(notificationChannel);
         triggerNotification(user, notificationChannel, notificationScenario, confirmationCode, eventName, properties);
-
         // Store new confirmation code.
         addRecoveryDataObject(user.getUserName(), user.getTenantDomain(), confirmationCode, notificationChannel,
                 scenario, step);
-
-        // Generate resend code.
         resendCode = generateResendCode(notificationChannel, scenario, userRecoveryData);
         ResendConfirmationDTO resendConfirmationDTO = new ResendConfirmationDTO();
         resendConfirmationDTO.setNotificationChannel(notificationChannel);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
@@ -27,12 +27,18 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationChannelManagerException;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryServerException;
+import org.wso2.carbon.identity.recovery.RecoveryScenarios;
+import org.wso2.carbon.identity.recovery.RecoverySteps;
 import org.wso2.carbon.identity.recovery.bean.NotificationResponseBean;
+import org.wso2.carbon.identity.recovery.dto.ResendConfirmationDTO;
 import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
+import org.wso2.carbon.identity.recovery.internal.service.impl.UserAccountRecoveryManager;
 import org.wso2.carbon.identity.recovery.model.Property;
 import org.wso2.carbon.identity.recovery.model.UserRecoveryData;
 import org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStore;
@@ -40,11 +46,14 @@ import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.util.Utils;
 import org.wso2.carbon.registry.core.utils.UUIDGenerator;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+import java.security.SecureRandom;
 import java.util.HashMap;
 
 /**
  * Generic Manager class which can be used to resend confirmation code for any recovery scenario and self registration
- * using a notification
+ * using a notification.
  */
 public class ResendConfirmationManager {
 
@@ -103,6 +112,240 @@ public class ResendConfirmationManager {
                     user.getUserName());
         }
         return validateAndResendNotification(user, code, recoveryScenario, recoveryStep, notificationType, properties);
+    }
+
+    /**
+     * Resend confirmation information for the user bound to the resend code. The user will be notified via a channel
+     * recovered from the recovery data of the user.
+     *
+     * @param tenantDomain         Tenant domain
+     * @param resendCode           Previously issued confirmation code
+     * @param recoveryScenario     Name of the recovery scenario
+     *                             {@link org.wso2.carbon.identity.recovery.RecoveryScenarios}
+     * @param recoveryStep         Name of the recovery step {@link org.wso2.carbon.identity.recovery.RecoverySteps}
+     * @param notificationScenario Notification template name related to the recovery scenario (Eg: org.wso2.carbon
+     *                             .identity.recovery.IdentityRecoveryConstants
+     *                             .NOTIFICATION_TYPE_RESEND_PASSWORD_RESET
+     * @param properties           Meta properties
+     * @return ResendConfirmationDTO {@link ResendConfirmationDTO} bean resend operation information
+     * @throws IdentityRecoveryException Error while sending confirmation info
+     */
+    public ResendConfirmationDTO resendConfirmation(String tenantDomain, String resendCode, String recoveryScenario,
+                                                    String recoveryStep, String notificationScenario,
+                                                    Property[] properties) throws IdentityRecoveryException {
+
+        RecoverySteps step = RecoverySteps.getRecoveryStep(recoveryStep);
+        RecoveryScenarios scenario = RecoveryScenarios.getRecoveryScenario(recoveryScenario);
+        UserAccountRecoveryManager userAccountRecoveryManager = UserAccountRecoveryManager.getInstance();
+
+        // Get Recovery data.
+        UserRecoveryData userRecoveryData = userAccountRecoveryManager
+                .getUserRecoveryData(resendCode, RecoverySteps.RESEND_CONFIRMATION_CODE);
+        User user = userRecoveryData.getUser();
+
+        // Validate tenantDomain.
+        if (!tenantDomain.equals(user.getTenantDomain())) {
+            throw Utils.handleClientException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_USER_TENANT_DOMAIN_MISS_MATCH_WITH_CONTEXT,
+                    tenantDomain);
+        }
+        // Validate recovery scenario.
+        if (!scenario.equals(userRecoveryData.getRecoveryScenario())) {
+            throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_RESEND_CODE,
+                    resendCode);
+        }
+        validateCallback(properties, user.getTenantDomain());
+        UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
+        userRecoveryDataStore.invalidate(user);
+        String notificationChannel = validateNotificationChannel(userRecoveryData.getRemainingSetIds());
+
+        // Generate confirmation code.
+        String confirmationCode = generateSecretKey(notificationChannel);
+        String eventName = Utils.resolveEventName(notificationChannel);
+        triggerNotification(user, notificationChannel, notificationScenario, confirmationCode, eventName, properties);
+
+        // Store new confirmation code.
+        addRecoveryDataObject(user.getUserName(), user.getTenantDomain(), confirmationCode, notificationChannel,
+                scenario, step);
+
+        // Generate resend code.
+        resendCode = generateResendCode(notificationChannel, scenario, userRecoveryData);
+        ResendConfirmationDTO resendConfirmationDTO = new ResendConfirmationDTO();
+        resendConfirmationDTO.setNotificationChannel(notificationChannel);
+        resendConfirmationDTO.setResendCode(resendCode);
+        resendConfirmationDTO.setSuccessCode(
+                IdentityRecoveryConstants.SuccessEvents.SUCCESS_STATUS_CODE_RESEND_CONFIRMATION_CODE.getCode());
+        resendConfirmationDTO.setSuccessMessage(
+                IdentityRecoveryConstants.SuccessEvents.SUCCESS_STATUS_CODE_RESEND_CONFIRMATION_CODE.getMessage());
+        return resendConfirmationDTO;
+    }
+
+    /**
+     * Trigger notification to send userName recovery information.
+     *
+     * @param user                User
+     * @param notificationChannel Notification channel (Eg: EMAIL or SMS)
+     * @param templateName        Notification Template name
+     * @param code                Secret key
+     * @param eventName           Event name
+     * @param metaProperties      Meta properties to be send with the notification.
+     * @throws IdentityRecoveryException Error while triggering notification.
+     */
+    private void triggerNotification(User user, String notificationChannel, String templateName, String code,
+                                     String eventName, Property[] metaProperties) throws IdentityRecoveryException {
+
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put(IdentityEventConstants.EventProperty.USER_NAME, user.getUserName());
+        properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, user.getTenantDomain());
+        properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, user.getUserStoreDomain());
+        properties.put(IdentityEventConstants.EventProperty.NOTIFICATION_CHANNEL, notificationChannel);
+        if (StringUtils.isNotBlank(code)) {
+            properties.put(IdentityRecoveryConstants.CONFIRMATION_CODE, code);
+        }
+        if (metaProperties != null) {
+            for (Property metaProperty : metaProperties) {
+                if (StringUtils.isNotBlank(metaProperty.getValue()) && StringUtils.isNotBlank(metaProperty.getKey())) {
+                    properties.put(metaProperty.getKey(), metaProperty.getValue());
+                }
+            }
+        }
+        properties.put(IdentityRecoveryConstants.TEMPLATE_TYPE, templateName);
+        Event identityMgtEvent = new Event(eventName, properties);
+        try {
+            IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);
+        } catch (IdentityEventException e) {
+            throw Utils.handleServerException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_TRIGGER_NOTIFICATION,
+                    user.getUserName(), e);
+        }
+
+    }
+
+    /**
+     * Get the resend code.
+     *
+     * @param notificationChannel Notification channel
+     * @param scenario            Recovery scenario
+     * @param userRecoveryData    User Recovery data
+     * @return Resend code
+     * @throws IdentityRecoveryServerException Error while adding the resend code
+     */
+    private String generateResendCode(String notificationChannel, RecoveryScenarios scenario,
+                                      UserRecoveryData userRecoveryData) throws IdentityRecoveryServerException {
+
+        String resendCode = UUIDGenerator.generateUUID();
+        User user = userRecoveryData.getUser();
+        addRecoveryDataObject(user.getUserName(), user.getTenantDomain(), resendCode, notificationChannel, scenario,
+                RecoverySteps.RESEND_CONFIRMATION_CODE);
+        return resendCode;
+    }
+
+    /**
+     * Add the notification channel recovery data to the store.
+     *
+     * @param userName         Username
+     * @param tenantDomain     Tenant domain
+     * @param secretKey        RecoveryId
+     * @param recoveryData     Data to be stored as mata which are needed to evaluate the recovery data object
+     * @param recoveryScenario Recovery scenario
+     * @param recoveryStep     Recovery step
+     * @throws IdentityRecoveryServerException Error storing recovery data
+     */
+    private void addRecoveryDataObject(String userName, String tenantDomain, String secretKey, String recoveryData,
+                                       RecoveryScenarios recoveryScenario, RecoverySteps recoveryStep)
+            throws IdentityRecoveryServerException {
+
+        // Create a user object.
+        User user = new User();
+        user.setUserName(userName);
+        user.setTenantDomain(tenantDomain);
+        user.setUserStoreDomain(IdentityUtil.extractDomainFromName(userName));
+        UserRecoveryData recoveryDataDO = new UserRecoveryData(user, secretKey, recoveryScenario, recoveryStep);
+
+        // Store available channels in remaining setIDs.
+        recoveryDataDO.setRemainingSetIds(recoveryData);
+        try {
+            UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
+            userRecoveryDataStore.store(recoveryDataDO);
+        } catch (IdentityRecoveryException e) {
+            throw Utils.handleServerException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_ERROR_STORING_RECOVERY_DATA,
+                    "Error Storing Recovery Data", e);
+        }
+    }
+
+    /**
+     * Generate a secret key according to the given channel. Method will generate an OTP for mobile channel and a
+     * UUID for other channels.
+     *
+     * @param channel Recovery notification channel.
+     * @return Secret key
+     */
+    private String generateSecretKey(String channel) {
+
+        if (IdentityRecoveryConstants.SMS_CHANNEL.equals(channel)) {
+            return generateSMSOTP();
+        } else {
+            return UUIDGenerator.generateUUID();
+        }
+    }
+
+    /**
+     * Generate an OTP for password recovery via mobile Channel.
+     *
+     * @return OTP
+     */
+    private String generateSMSOTP() {
+
+        char[] chars = IdentityRecoveryConstants.SMS_OTP_GENERATE_CHAR_SET.toCharArray();
+        SecureRandom rnd = new SecureRandom();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < IdentityRecoveryConstants.SMS_OTP_CODE_LENGTH; i++) {
+            sb.append(chars[rnd.nextInt(chars.length)]);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Validate the callback Url.
+     *
+     * @param properties   Properties
+     * @param tenantDomain Tenant Domain
+     * @throws IdentityRecoveryServerException Error validating the callback
+     */
+    private void validateCallback(Property[] properties, String tenantDomain) throws IdentityRecoveryServerException {
+
+        String callbackURL = null;
+        try {
+            callbackURL = Utils.getCallbackURL(properties);
+            if (StringUtils.isNotBlank(callbackURL) && !Utils.validateCallbackURL(callbackURL, tenantDomain,
+                    IdentityRecoveryConstants.ConnectorConfig.RECOVERY_CALLBACK_REGEX)) {
+                throw Utils.handleServerException(
+                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_CALLBACK_URL_NOT_VALID, callbackURL);
+            }
+        } catch (URISyntaxException | UnsupportedEncodingException | IdentityEventException e) {
+            throw Utils.handleServerException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_CALLBACK_URL_NOT_VALID,
+                    callbackURL);
+        }
+    }
+
+    /**
+     * Validate the channel name in the recovery data.
+     *
+     * @param channel Channel in the user recovery data
+     * @return Server supported channel name
+     * @throws IdentityRecoveryClientException Invalid channel type
+     */
+    private String validateNotificationChannel(String channel) throws IdentityRecoveryClientException {
+
+        try {
+            return NotificationChannels.getNotificationChannel(channel).getChannelType();
+        } catch (NotificationChannelManagerException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Unsupported Notification channel : " + channel, e);
+            }
+            throw Utils.handleClientException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_UNSUPPORTED_NOTIFICATION_CHANNEL, channel);
+        }
     }
 
     private NotificationResponseBean validateAndResendNotification(User user, String code, String recoveryScenario,

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
@@ -27,6 +27,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+/**
+ * Class which contains account recovery configs.
+ */
 public class RecoveryConfigImpl implements IdentityConnectorConfig {
 
     private static String connectorName = "account-recovery";
@@ -73,7 +76,9 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.USERNAME_RECOVERY_ENABLE, "Enable Username Recovery");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.USERNAME_RECOVERY_RECAPTCHA_ENABLE, "Enable " +
                 "reCaptcha for Username Recovery");
-        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.EXPIRY_TIME, "Notification Expiry Time");
+        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.EXPIRY_TIME, "Recovery Link Expiry Time");
+        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_EXPIRY_TIME,
+                "SMS OTP Expiry Time");
 
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_SEND_RECOVERY_NOTIFICATION_SUCCESS,
                 "Notify when Recovery Success");
@@ -102,6 +107,8 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
                 "Force users to provide answers to challenge questions during sign in");
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_CALLBACK_REGEX,
                 "Recovery callback URL regex");
+        descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_EXPIRY_TIME,
+                "Expiration time of the SMS OTP code for password recovery");
         return descriptionMapping;
     }
 
@@ -121,6 +128,7 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         properties.add(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_SEND_RECOVERY_NOTIFICATION_SUCCESS);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_SEND_RECOVERY_SECURITY_START);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.EXPIRY_TIME);
+        properties.add(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_EXPIRY_TIME);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.FORCE_ADD_PW_RECOVERY_QUESTION);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_CALLBACK_REGEX);
         return properties.toArray(new String[properties.size()]);
@@ -137,6 +145,7 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         String enableUsernameRecovery = "false";
         String enableNotificationInternallyManage = "true";
         String expiryTime = "1440";
+        String expiryTimeSMSOTP = "1";
         String notifySuccess = "false";
         String notifyStart = "false";
         String enableForceChallengeQuestions = "false";
@@ -159,6 +168,8 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         String notificationInternallyManged = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE);
         String expiryTimeProperty = IdentityUtil.getProperty(IdentityRecoveryConstants.ConnectorConfig.EXPIRY_TIME);
+        String expiryTimeSMSOTPProperty = IdentityUtil
+                .getProperty(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_EXPIRY_TIME);
         String notifySuccessProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_SEND_RECOVERY_NOTIFICATION_SUCCESS);
         String notifyStartProperty = IdentityUtil.getProperty(
@@ -172,6 +183,9 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         String recoveryCallbackRegexProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.RECOVERY_CALLBACK_REGEX);
 
+        if (StringUtils.isNotEmpty(expiryTimeSMSOTPProperty)) {
+            expiryTimeSMSOTP = expiryTimeSMSOTPProperty;
+        }
         if (StringUtils.isNotEmpty(notificationBasedPasswordRecovery)) {
             enableNotificationBasedPasswordRecovery = notificationBasedPasswordRecovery;
         }
@@ -236,6 +250,8 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE,
                 enableNotificationInternallyManage);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.EXPIRY_TIME, expiryTime);
+        defaultProperties
+                .put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_EXPIRY_TIME, expiryTimeSMSOTP);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_SEND_RECOVERY_NOTIFICATION_SUCCESS,
                 notifySuccess);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_SEND_RECOVERY_SECURITY_START,

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/NotificationChannelDTO.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/NotificationChannelDTO.java
@@ -1,0 +1,126 @@
+/*
+ *
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.recovery.dto;
+
+/**
+ * Object that encapsulates the verified notification channels of the user.
+ */
+public class NotificationChannelDTO {
+
+    /**
+     * Channel id to recognize the channel at verification.
+     */
+    private int id;
+
+    /**
+     * Type of the notification channel. Eg: EMAIL
+     */
+    private String type;
+
+    /**
+     * Value associated with the channel. Eg: test@wso2.com
+     * NOTE: This value can be encoded. Eg: tes**********
+     */
+    private String value;
+
+    /**
+     * Whether the channel is user's preferred channel.
+     */
+    private boolean preferred;
+
+    /**
+     * Get the notification channel Id.
+     *
+     * @return Channel Id
+     */
+    public int getId() {
+
+        return id;
+    }
+
+    /**
+     * Set the notification channel Id.
+     *
+     * @param id Channel Id for the notification channel.
+     */
+    public void setId(int id) {
+
+        this.id = id;
+    }
+
+    /**
+     * Get the notification channel type.
+     *
+     * @return Notification channel type
+     */
+    public String getType() {
+
+        return type;
+    }
+
+    /**
+     * Set the notification channel type.
+     *
+     * @param type Notification channel type
+     */
+    public void setType(String type) {
+
+        this.type = type;
+    }
+
+    /**
+     * Get the value of the notification channel.
+     *
+     * @return Notification channel value
+     */
+    public String getValue() {
+
+        return value;
+    }
+
+    /**
+     * Set the value of the notification channel.
+     *
+     * @param value Value of the notification channel
+     */
+    public void setValue(String value) {
+
+        this.value = value;
+    }
+
+    /**
+     * Whether the notification channel is preferred by the user.
+     *
+     * @return True of the user has set the channel as a preferred channel.
+     */
+    public boolean isPreferred() {
+
+        return preferred;
+    }
+
+    /**
+     * Set the notification channel preferred status.
+     *
+     * @param preferred True if the user prefers the notification channel
+     */
+    public void setPreferred(boolean preferred) {
+
+        this.preferred = preferred;
+    }
+}

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/NotificationChannelDTO.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/NotificationChannelDTO.java
@@ -1,6 +1,5 @@
 /*
- *
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/PasswordRecoverDTO.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/PasswordRecoverDTO.java
@@ -1,0 +1,151 @@
+/*
+ *
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.recovery.dto;
+
+/**
+ * Object that encapsulates the password recovery notification for a successful password recovery.
+ */
+public class PasswordRecoverDTO {
+
+    /**
+     * Response code.
+     */
+    private String code;
+
+    /**
+     * Description about the response.
+     */
+    private String message;
+
+    /**
+     * User notified channel.
+     */
+    private String notificationChannel;
+
+    /**
+     * Confirmation code for notifications external management.
+     * NOTE: This will be used when the notification channel is EXTERNAL.
+     */
+    private String confirmationCode;
+
+    /**
+     * Code to resend recovery information to the user.
+     */
+    private String resendCode;
+
+    /**
+     * Get the resend code.
+     *
+     * @return Resend code
+     */
+    public String getResendCode() {
+
+        return resendCode;
+    }
+
+    /**
+     * Set resend code.
+     *
+     * @param resendCode Resend code
+     */
+    public void setResendCode(String resendCode) {
+
+        this.resendCode = resendCode;
+    }
+
+    /**
+     * Get the response code.
+     *
+     * @return Response code
+     */
+    public String getCode() {
+
+        return code;
+    }
+
+    /**
+     * Set the response code.
+     *
+     * @param code Response code
+     */
+    public void setCode(String code) {
+
+        this.code = code;
+    }
+
+    /**
+     * Get the response message.
+     *
+     * @return Response message
+     */
+    public String getMessage() {
+
+        return message;
+    }
+
+    /**
+     * Set the response message.
+     *
+     * @param message Response message
+     */
+    public void setMessage(String message) {
+
+        this.message = message;
+    }
+
+    /**
+     * Get the channel which the notification was sent.
+     *
+     * @return Notification channel
+     */
+    public String getNotificationChannel() {
+
+        return notificationChannel;
+    }
+
+    /**
+     * Set the channel which the notification was sent.
+     *
+     * @param notificationChannel Notification channel
+     */
+    public void setNotificationChannel(String notificationChannel) {
+
+        this.notificationChannel = notificationChannel;
+    }
+
+    /**
+     * Get external confirmation code.
+     *
+     * @return External confirmation code
+     */
+    public String getConfirmationCode() {
+
+        return confirmationCode;
+    }
+
+    /**
+     * Set external confirmation code.
+     *
+     * @param confirmationCode External confirmation code.
+     */
+    public void setConfirmationCode(String confirmationCode) {
+
+        this.confirmationCode = confirmationCode;
+    }
+}

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/PasswordRecoverDTO.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/PasswordRecoverDTO.java
@@ -1,6 +1,5 @@
 /*
- *
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/PasswordResetCodeDTO.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/PasswordResetCodeDTO.java
@@ -1,0 +1,50 @@
+/*
+ *
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.recovery.dto;
+
+/**
+ * Object that encapsulates the token to be used at the password reset.
+ */
+public class PasswordResetCodeDTO {
+
+    /**
+     * Code that is used to validate a password reset.
+     */
+    private String passwordResetCode;
+
+    /**
+     * Get password reset code.
+     *
+     * @return Password reset code
+     */
+    public String getPasswordResetCode() {
+
+        return passwordResetCode;
+    }
+
+    /**
+     * Set password reset code.
+     *
+     * @param passwordResetCode Password reset code
+     */
+    public void setPasswordResetCode(String passwordResetCode) {
+
+        this.passwordResetCode = passwordResetCode;
+    }
+}

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/PasswordResetCodeDTO.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/PasswordResetCodeDTO.java
@@ -1,6 +1,5 @@
 /*
- *
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/RecoveryChannelInfoDTO.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/RecoveryChannelInfoDTO.java
@@ -1,0 +1,100 @@
+/*
+ *
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.recovery.dto;
+
+/**
+ * Object that encapsulates the account recovery channels available for the user with the recovery code.
+ */
+public class RecoveryChannelInfoDTO {
+
+    /**
+     * Username of the recovered user.
+     */
+    private String username;
+
+    /**
+     * Recovery Code given to the user.
+     */
+    private String recoveryCode;
+
+    /**
+     * Available communication channels for the user.
+     */
+    private NotificationChannelDTO[] notificationChannelDTOs;
+
+    /**
+     * Get username of the recovered user.
+     *
+     * @return Username
+     */
+    public String getUsername() {
+
+        return username;
+    }
+
+    /**
+     * Set username of the recovered user.
+     *
+     * @param username Username
+     */
+    public void setUsername(String username) {
+
+        this.username = username;
+    }
+
+    /**
+     * Get the recovery Code of the user.
+     *
+     * @return Recovery Code of the user
+     */
+    public String getRecoveryCode() {
+
+        return recoveryCode;
+    }
+
+    /**
+     * Set the recovery Code for the user.
+     *
+     * @param recoveryCode Recovery Code
+     */
+    public void setRecoveryCode(String recoveryCode) {
+
+        this.recoveryCode = recoveryCode;
+    }
+
+    /**
+     * Get the notification channels available for the user.
+     *
+     * @return List of NotificationChannelDTO objects
+     */
+    public NotificationChannelDTO[] getNotificationChannelDTOs() {
+
+        return notificationChannelDTOs;
+    }
+
+    /**
+     * Set the available notification channel list of the user.
+     *
+     * @param notificationChannelDTOs List of NotificationChannelDTO
+     */
+    public void setNotificationChannelDTOs(NotificationChannelDTO[] notificationChannelDTOs) {
+
+        this.notificationChannelDTOs = notificationChannelDTOs;
+    }
+}

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/RecoveryChannelInfoDTO.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/RecoveryChannelInfoDTO.java
@@ -1,6 +1,5 @@
 /*
- *
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/RecoveryInformationDTO.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/RecoveryInformationDTO.java
@@ -1,0 +1,125 @@
+/*
+ *
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.recovery.dto;
+
+/**
+ * Object that encapsulates the user account recovery details.
+ */
+public class RecoveryInformationDTO {
+
+    /**
+     * Recovered username of the user.
+     */
+    private String username;
+
+    /**
+     * Available Recovery channel Information.
+     */
+    private RecoveryChannelInfoDTO recoveryChannelInfoDTO;
+
+    /**
+     * Whether question based recovery is enabled for the user.
+     */
+    private boolean isQuestionBasedRecoveryEnabled;
+
+    /**
+     * Whether notification based recovery is enabled for the user.
+     */
+    private boolean isNotificationBasedRecoveryEnabled;
+
+    /**
+     * Get whether question based recovery is enabled for the user.
+     *
+     * @return True if question based recovery is enabled for the user
+     */
+    public boolean isQuestionBasedRecoveryEnabled() {
+
+        return isQuestionBasedRecoveryEnabled;
+    }
+
+    /**
+     * set whether question based recovery is enabled for the user.
+     *
+     * @param questionBasedRecoveryEnabled Question based recovery enabled
+     */
+    public void setQuestionBasedRecoveryEnabled(boolean questionBasedRecoveryEnabled) {
+
+        isQuestionBasedRecoveryEnabled = questionBasedRecoveryEnabled;
+    }
+
+    /**
+     * set whether notification based recovery is enabled for the user.
+     *
+     * @param isNotificationBasedRecoveryEnabled Notification based recovery enabled
+     */
+    public void setNotificationBasedRecoveryEnabled(boolean isNotificationBasedRecoveryEnabled) {
+
+        this.isNotificationBasedRecoveryEnabled = isNotificationBasedRecoveryEnabled;
+    }
+
+    /**
+     * Get whether notification based recovery is enabled for the user.
+     *
+     * @return True if notification based recovery is enabled for the user
+     */
+    public boolean isNotificationBasedRecoveryEnabled() {
+
+        return isNotificationBasedRecoveryEnabled;
+    }
+
+    /**
+     * Get recovered username.
+     *
+     * @return Username
+     */
+    public String getUsername() {
+
+        return username;
+    }
+
+    /**
+     * Set recovered username.
+     *
+     * @param userName Username
+     */
+    public void setUsername(String userName) {
+
+        this.username = userName;
+    }
+
+    /**
+     * Get RecoveryChannelInfoDTO.
+     *
+     * @return RecoveryChannelInfoDTO
+     */
+    public RecoveryChannelInfoDTO getRecoveryChannelInfoDTO() {
+
+        return recoveryChannelInfoDTO;
+    }
+
+    /**
+     * Set RecoveryChannelInfoDTO.
+     *
+     * @param recoveryChannelInfoDTO RecoveryChannelInfoDTO
+     */
+    public void setRecoveryChannelInfoDTO(RecoveryChannelInfoDTO recoveryChannelInfoDTO) {
+
+        this.recoveryChannelInfoDTO = recoveryChannelInfoDTO;
+    }
+}

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/RecoveryInformationDTO.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/RecoveryInformationDTO.java
@@ -1,6 +1,5 @@
 /*
- *
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/ResendConfirmationDTO.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/ResendConfirmationDTO.java
@@ -43,6 +43,31 @@ public class ResendConfirmationDTO {
     private String successCode;
 
     /**
+     * Get external confirmation code.
+     *
+     * @return External confirmation code.
+     */
+    public String getExternalConfirmationCode() {
+
+        return externalConfirmationCode;
+    }
+
+    /**
+     * Set external confirmation code.
+     *
+     * @param externalConfirmationCode External confirmation code
+     */
+    public void setExternalConfirmationCode(String externalConfirmationCode) {
+
+        this.externalConfirmationCode = externalConfirmationCode;
+    }
+
+    /**
+     * Code to used to confirm password recovery when the notifications are managed externally.
+     */
+    private String externalConfirmationCode;
+
+    /**
      * Get resend code.
      *
      * @return Resend code

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/ResendConfirmationDTO.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/ResendConfirmationDTO.java
@@ -1,0 +1,126 @@
+/*
+ *
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.recovery.dto;
+
+/**
+ * Object that encapsulates data for a successful resend confirmation.
+ */
+public class ResendConfirmationDTO {
+
+    /**
+     * Success status message.
+     */
+    private String successMessage;
+
+    /**
+     * Recovery Info sent channel.
+     */
+    private String notificationChannel;
+
+    /**
+     * Resend code to resend recovery information.
+     */
+    private String resendCode;
+
+    /**
+     * Success status code.
+     */
+    private String successCode;
+
+    /**
+     * Get resend code.
+     *
+     * @return Resend code
+     */
+    public String getResendCode() {
+
+        return resendCode;
+    }
+
+    /**
+     * Get resend code.
+     *
+     * @param resendCode Resend code
+     */
+    public void setResendCode(String resendCode) {
+
+        this.resendCode = resendCode;
+    }
+
+    /**
+     * Get success code.
+     *
+     * @return Success code
+     */
+    public String getSuccessCode() {
+
+        return successCode;
+    }
+
+    /**
+     * Set success code.
+     *
+     * @param successCode Success code
+     */
+    public void setSuccessCode(String successCode) {
+
+        this.successCode = successCode;
+    }
+
+    /**
+     * Get success message.
+     *
+     * @return Success message
+     */
+    public String getSuccessMessage() {
+
+        return successMessage;
+    }
+
+    /**
+     * Set success message.
+     *
+     * @param successMessage Success message.
+     */
+    public void setSuccessMessage(String successMessage) {
+
+        this.successMessage = successMessage;
+    }
+
+    /**
+     * Get notification channel.
+     *
+     * @return Notification channel
+     */
+    public String getNotificationChannel() {
+
+        return notificationChannel;
+    }
+
+    /**
+     * Set notification channel.
+     *
+     * @param notificationChannel Notification channel
+     */
+    public void setNotificationChannel(String notificationChannel) {
+
+        this.notificationChannel = notificationChannel;
+    }
+
+}

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/ResendConfirmationDTO.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/ResendConfirmationDTO.java
@@ -1,6 +1,5 @@
 /*
- *
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -122,5 +121,4 @@ public class ResendConfirmationDTO {
 
         this.notificationChannel = notificationChannel;
     }
-
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/SuccessfulPasswordResetDTO.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/SuccessfulPasswordResetDTO.java
@@ -1,0 +1,75 @@
+/*
+ *
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.recovery.dto;
+
+/**
+ * Object that encapsulates response after a successful password reset.
+ */
+public class SuccessfulPasswordResetDTO {
+
+    /**
+     * Successful password update status code.
+     */
+    private String successCode;
+
+    /**
+     * Success password update status message.
+     */
+    private String message;
+
+    /**
+     * Get the successful status code.
+     *
+     * @return Status code
+     */
+    public String getSuccessCode() {
+
+        return successCode;
+    }
+
+    /**
+     * Set the successful status code.
+     *
+     * @param successCode Successful status code
+     */
+    public void setSuccessCode(String successCode) {
+
+        this.successCode = successCode;
+    }
+
+    /**
+     * Get the successful status message.
+     *
+     * @return Status message
+     */
+    public String getMessage() {
+
+        return message;
+    }
+
+    /**
+     * Set the successful status message.
+     *
+     * @param message Status message
+     */
+    public void setMessage(String message) {
+
+        this.message = message;
+    }
+}

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/SuccessfulPasswordResetDTO.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/SuccessfulPasswordResetDTO.java
@@ -1,6 +1,5 @@
 /*
- *
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/UsernameRecoverDTO.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/UsernameRecoverDTO.java
@@ -1,6 +1,5 @@
 /*
- *
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/UsernameRecoverDTO.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dto/UsernameRecoverDTO.java
@@ -1,0 +1,128 @@
+/*
+ *
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.recovery.dto;
+
+/**
+ * Object that encapsulates the username recovery notification for a successful username recovery.
+ */
+public class UsernameRecoverDTO {
+
+    /**
+     * Response code.
+     */
+    private String code;
+
+    /**
+     * Description about the response.
+     */
+    private String message;
+
+    /**
+     * User notified channel.
+     */
+    private String notificationChannel;
+
+    /**
+     * Username of the user.
+     * NOTE: This will be used when the notification channel is EXTERNAL.
+     */
+    private String username;
+
+    /**
+     * Get the response code.
+     *
+     * @return Response code
+     */
+    public String getCode() {
+
+        return code;
+    }
+
+    /**
+     * Set the response code.
+     *
+     * @param code Response code
+     */
+    public void setCode(String code) {
+
+        this.code = code;
+    }
+
+    /**
+     * Get the response message.
+     *
+     * @return Response message
+     */
+    public String getMessage() {
+
+        return message;
+    }
+
+    /**
+     * Set the response message.
+     *
+     * @param message Response message
+     */
+    public void setMessage(String message) {
+
+        this.message = message;
+    }
+
+    /**
+     * Get the channel which the notification was sent.
+     *
+     * @return Notification channel
+     */
+    public String getNotificationChannel() {
+
+        return notificationChannel;
+    }
+
+    /**
+     * Set the channel which the notification was sent.
+     *
+     * @param notificationChannel Notification channel
+     */
+    public void setNotificationChannel(String notificationChannel) {
+
+        this.notificationChannel = notificationChannel;
+    }
+
+    /**
+     * Get the username of the user.
+     * (NOTE: use when the notificationChannel is EXTERNAL)
+     *
+     * @return Username
+     */
+    public String getUsername() {
+
+        return username;
+    }
+
+    /**
+     * Set the username of the user.
+     * (NOTE: use when the notificationChannel is EXTERNAL)
+     *
+     * @return Username
+     */
+    public void setUsername(String username) {
+
+        this.username = username;
+    }
+}

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
@@ -41,8 +41,8 @@ import org.wso2.carbon.identity.recovery.handler.CodeInvalidationHandler;
 import org.wso2.carbon.identity.recovery.handler.UserEmailVerificationHandler;
 import org.wso2.carbon.identity.recovery.handler.UserSelfRegistrationHandler;
 import org.wso2.carbon.identity.recovery.handler.request.PostAuthnMissingChallengeQuestionsHandler;
-import org.wso2.carbon.identity.recovery.internal.service.impl.password.DefaultPasswordRecoveryManager;
-import org.wso2.carbon.identity.recovery.internal.service.impl.username.DefaultUsernameRecoveryManager;
+import org.wso2.carbon.identity.recovery.internal.service.impl.password.PasswordRecoveryManagerImpl;
+import org.wso2.carbon.identity.recovery.internal.service.impl.username.UsernameRecoveryManagerImpl;
 import org.wso2.carbon.identity.recovery.listener.TenantManagementListener;
 import org.wso2.carbon.identity.recovery.password.NotificationPasswordRecoveryManager;
 import org.wso2.carbon.identity.recovery.password.SecurityQuestionPasswordRecoveryManager;
@@ -103,10 +103,10 @@ public class IdentityRecoveryServiceComponent {
             bundleContext.registerService(IdentityConnectorConfig.class.getName(), new
                     AdminForcedPasswordResetConfigImpl(), null);
             bundleContext.registerService(AbstractEventHandler.class.getName(), new CodeInvalidationHandler(), null);
-            UsernameRecoveryManager usernameRecoveryManager = new DefaultUsernameRecoveryManager();
+            UsernameRecoveryManager usernameRecoveryManager = new UsernameRecoveryManagerImpl();
             bundleContext.registerService(UsernameRecoveryManager.class.getName(),
                     usernameRecoveryManager, null);
-            PasswordRecoveryManager passwordRecoveryManager = new DefaultPasswordRecoveryManager();
+            PasswordRecoveryManager passwordRecoveryManager = new PasswordRecoveryManagerImpl();
             bundleContext.registerService(PasswordRecoveryManager.class.getName(),
                     passwordRecoveryManager, null);
             // Registering missing challenge question handler as a post authn handler

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
@@ -41,9 +41,13 @@ import org.wso2.carbon.identity.recovery.handler.CodeInvalidationHandler;
 import org.wso2.carbon.identity.recovery.handler.UserEmailVerificationHandler;
 import org.wso2.carbon.identity.recovery.handler.UserSelfRegistrationHandler;
 import org.wso2.carbon.identity.recovery.handler.request.PostAuthnMissingChallengeQuestionsHandler;
+import org.wso2.carbon.identity.recovery.internal.service.impl.password.DefaultPasswordRecoveryManager;
+import org.wso2.carbon.identity.recovery.internal.service.impl.username.DefaultUsernameRecoveryManager;
 import org.wso2.carbon.identity.recovery.listener.TenantManagementListener;
 import org.wso2.carbon.identity.recovery.password.NotificationPasswordRecoveryManager;
 import org.wso2.carbon.identity.recovery.password.SecurityQuestionPasswordRecoveryManager;
+import org.wso2.carbon.identity.recovery.services.password.PasswordRecoveryManager;
+import org.wso2.carbon.identity.recovery.services.username.UsernameRecoveryManager;
 import org.wso2.carbon.identity.recovery.signup.UserSelfRegistrationManager;
 import org.wso2.carbon.identity.recovery.username.NotificationUsernameRecoveryManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
@@ -99,6 +103,12 @@ public class IdentityRecoveryServiceComponent {
             bundleContext.registerService(IdentityConnectorConfig.class.getName(), new
                     AdminForcedPasswordResetConfigImpl(), null);
             bundleContext.registerService(AbstractEventHandler.class.getName(), new CodeInvalidationHandler(), null);
+            UsernameRecoveryManager usernameRecoveryManager = new DefaultUsernameRecoveryManager();
+            bundleContext.registerService(UsernameRecoveryManager.class.getName(),
+                    usernameRecoveryManager, null);
+            PasswordRecoveryManager passwordRecoveryManager = new DefaultPasswordRecoveryManager();
+            bundleContext.registerService(PasswordRecoveryManager.class.getName(),
+                    passwordRecoveryManager, null);
             // Registering missing challenge question handler as a post authn handler
             PostAuthenticationHandler postAuthnMissingChallengeQuestions = PostAuthnMissingChallengeQuestionsHandler
                     .getInstance();

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -1,0 +1,695 @@
+/*
+ *
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.recovery.internal.service.impl;
+
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryServerException;
+import org.wso2.carbon.identity.recovery.RecoveryScenarios;
+import org.wso2.carbon.identity.recovery.RecoverySteps;
+import org.wso2.carbon.identity.recovery.dto.NotificationChannelDTO;
+import org.wso2.carbon.identity.recovery.dto.RecoveryChannelInfoDTO;
+import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
+import org.wso2.carbon.identity.recovery.model.NotificationChannel;
+import org.wso2.carbon.identity.recovery.model.UserRecoveryData;
+import org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStore;
+import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
+import org.wso2.carbon.identity.recovery.util.Utils;
+
+import org.wso2.carbon.registry.core.utils.UUIDGenerator;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Manager class which can be used to recover user account with available verified communication channels for a user.
+ */
+public class UserAccountRecoveryManager {
+
+    private static final Log log = LogFactory.getLog(UserAccountRecoveryManager.class);
+    private static UserAccountRecoveryManager instance = new UserAccountRecoveryManager();
+    private static final String FORWARD_SLASH = "/";
+
+    /**
+     * Constructor.
+     */
+    private UserAccountRecoveryManager() {
+
+    }
+
+    /**
+     * Get an instance of UserAccountRecoveryManager.
+     *
+     * @return UserAccountRecoveryManager instance
+     */
+    public static UserAccountRecoveryManager getInstance() {
+
+        return instance;
+    }
+
+    /**
+     * Initiate the recovery flow for the user with matching claims.
+     *
+     * @param claims           User claims
+     * @param tenantDomain     Tenant domain
+     * @param recoveryScenario Recovery scenario
+     * @param properties       Meta properties
+     * @return RecoveryChannelInfoDTO object
+     */
+    public RecoveryChannelInfoDTO retrieveUserRecoveryInformation(Map<String, String> claims, String tenantDomain,
+                                                                  RecoveryScenarios recoveryScenario,
+                                                                  Map<String, String> properties)
+            throws IdentityRecoveryException {
+
+        // Retrieve the user who matches the given set of claims.
+        String username = getUsernameByClaims(claims, tenantDomain);
+
+        // Get the claims of the user if the user is verified.
+        if (StringUtils.isNotEmpty(username)) {
+
+            // If the account is locked or disabled, do not let the user to recover the account.
+            checkAccountLockedStatus(buildUser(username, tenantDomain));
+            List<NotificationChannel> notificationChannels;
+
+            // Get the notification management mechanism.
+            boolean isNotificationsInternallyManaged = Utils.isNotificationsInternallyManaged(tenantDomain, properties);
+
+            // If the notification is internally managed, then notification channels available for the user needs to
+            // be retrieved. If external notifications are enabled, external channel list should be returned.
+            if (isNotificationsInternallyManaged) {
+                notificationChannels = getInternalNotificationChannelList(username, tenantDomain);
+            } else {
+                notificationChannels = getExternalNotificationChannelList();
+            }
+            // This flow will be initiated only if the user has any verified channels.
+            String recoveryCode = UUIDGenerator.generateUUID();
+            return buildUserRecoveryInformationResponseDTO(username, recoveryCode,
+                    getNotificationChannelsResponseDTOList(username, recoveryCode, tenantDomain, notificationChannels,
+                            recoveryScenario));
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("No valid user found for the given claims");
+            }
+            throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_USER_FOUND, null);
+        }
+    }
+
+    /**
+     * Check whether the account is locked or disabled.
+     *
+     * @param user User
+     * @throws IdentityRecoveryException If account is in locked or disabled status
+     */
+    private void checkAccountLockedStatus(User user) throws IdentityRecoveryException {
+
+        if (Utils.isAccountDisabled(user)) {
+            String errorCode = Utils.prependOperationScenarioToErrorCode(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_DISABLED_ACCOUNT.getCode(),
+                    IdentityRecoveryConstants.USER_ACCOUNT_RECOVERY);
+            throw Utils.handleClientException(errorCode,
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_DISABLED_ACCOUNT.getMessage(),
+                    user.getUserName());
+        } else if (Utils.isAccountLocked(user)) {
+            String errorCode = Utils.prependOperationScenarioToErrorCode(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_LOCKED_ACCOUNT.getCode(),
+                    IdentityRecoveryConstants.USER_ACCOUNT_RECOVERY);
+            throw Utils.handleClientException(errorCode,
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_LOCKED_ACCOUNT.getMessage(), user.getUserName());
+        }
+    }
+
+    /**
+     * Get the matching username for given claims.
+     *
+     * @param claims       List of UserClaims
+     * @param tenantDomain Tenant domain
+     * @return Username (Return null if there are no users)
+     * @throws IdentityRecoveryException Error while retrieving the users list
+     */
+    public String getUsernameByClaims(Map<String, String> claims, String tenantDomain)
+            throws IdentityRecoveryException {
+
+        if (MapUtils.isEmpty(claims)) {
+
+            // Get error code with scenario.
+            String errorCode = Utils.prependOperationScenarioToErrorCode(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_FIELD_FOUND_FOR_USER_RECOVERY.getCode(),
+                    IdentityRecoveryConstants.USER_ACCOUNT_RECOVERY);
+            throw Utils.handleClientException(errorCode,
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_FIELD_FOUND_FOR_USER_RECOVERY.getMessage(),
+                    null);
+        }
+        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+        String[] resultedUserList = ArrayUtils.EMPTY_STRING_ARRAY;
+        for (String key : claims.keySet()) {
+            String value = claims.get(key);
+            if (StringUtils.isNotEmpty(key) && StringUtils.isNotEmpty(value)) {
+                if (log.isDebugEnabled()) {
+                    String message = String.format("Searching users by claim : %s for value : %s", key, value);
+                    log.debug(message);
+                }
+                // Get the matching user list for the given claim.
+                String[] matchedUserList = getUserList(tenantId, key, value);
+
+                // Check for duplicates with the already retrieved users, if the matched users for the claim.
+                if (!ArrayUtils.isEmpty(matchedUserList)) {
+
+                    // In the first iteration resultedUserList will be empty.
+                    if (ArrayUtils.isNotEmpty(resultedUserList)) {
+
+                        // Remove the users from already matched list who are not in the recently matched list.
+                        resultedUserList = getCommonUserEntries(resultedUserList, matchedUserList, key, value);
+                        if (ArrayUtils.isEmpty(resultedUserList)) {
+                            if (log.isDebugEnabled()) {
+                                log.debug("No user matched for given claims");
+                            }
+                            return StringUtils.EMPTY;
+                        }
+                    } else {
+                        resultedUserList = matchedUserList;
+                    }
+                } else {
+                    if (log.isDebugEnabled()) {
+                        String message = String.format("No users matched for claim : %s for value : %s", key, value);
+                        log.debug(message);
+                    }
+                    return StringUtils.EMPTY;
+                }
+            }
+        }
+        // Return matched user.
+        if (ArrayUtils.isNotEmpty(resultedUserList) && resultedUserList.length == 1) {
+            return resultedUserList[0];
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Multiple users matched for given claims set : " + Arrays.toString(resultedUserList));
+            }
+            throw Utils
+                    .handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_MULTIPLE_MATCHING_USERS,
+                            null);
+        }
+    }
+
+    /**
+     * Get the notification channel list when the notification channel is external.
+     *
+     * @return External notification channel information
+     */
+    private List<NotificationChannel> getExternalNotificationChannelList() {
+
+        NotificationChannel channelDataModel = new NotificationChannel();
+        channelDataModel.setType(IdentityRecoveryConstants.EXTERNAL_NOTIFICATION_CHANNEL);
+        List<NotificationChannel> notificationChannels = new ArrayList<>();
+        notificationChannels.add(channelDataModel);
+        return notificationChannels;
+    }
+
+    /**
+     * Get the notification channel list of the user when the notifications are externally managed.
+     *
+     * @param username     Username
+     * @param tenantDomain Tenant domain
+     * @return Notification channel list
+     * @throws IdentityRecoveryClientException No notification channels available for the user
+     * @throws IdentityRecoveryException       Error getting user claim values
+     */
+    private List<NotificationChannel> getInternalNotificationChannelList(String username, String tenantDomain)
+            throws IdentityRecoveryClientException, IdentityRecoveryException {
+
+        // Create a list of required claims that needs to be retrieved from the user attributes.
+        String[] requiredClaims = createRequiredChannelClaimsList();
+
+        // Get channel related claims related to the user.
+        Map<String, String> claimValues = getClaimListOfUser(username, tenantDomain, requiredClaims);
+        if (MapUtils.isEmpty(claimValues)) {
+            throw Utils.handleClientException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_NOTIFICATION_CHANNELS_FOR_USER, null);
+        }
+        // Get the channel list with details.
+        List<NotificationChannel> notificationChannels = getNotificationChannelDetails(claimValues);
+        if (notificationChannels.size() == 0) {
+            throw Utils.handleClientException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_VERIFIED_CHANNELS_FOR_USER, null);
+        }
+        return notificationChannels;
+    }
+
+    /**
+     * Prepare the response to be sent to the recovery APIs.
+     *
+     * @param username                Username of the user
+     * @param recoveryCode            Recovery code given to the user.
+     * @param notificationChannelDTOs List of NotificationChannelsResponseDTOs available for the user.
+     * @return RecoveryChannelInfoDTO object
+     */
+    private RecoveryChannelInfoDTO buildUserRecoveryInformationResponseDTO(String username, String recoveryCode,
+                                                                           NotificationChannelDTO[] notificationChannelDTOs) {
+
+        RecoveryChannelInfoDTO recoveryChannelInfoDTO = new RecoveryChannelInfoDTO();
+        recoveryChannelInfoDTO.setUsername(username);
+        recoveryChannelInfoDTO.setRecoveryCode(recoveryCode);
+        recoveryChannelInfoDTO.setNotificationChannelDTOs(notificationChannelDTOs);
+        return recoveryChannelInfoDTO;
+    }
+
+    /**
+     * Get the list of available channels with the channel attributes associated to each channel as a list of
+     * NotificationChannelsResponseDTOs.
+     *
+     * @param userName             UserName of the user
+     * @param recoveryID           RecoveryId
+     * @param tenantDomain         Tenant domain.
+     * @param notificationChannels Notification channels list
+     * @param recoveryScenario     Recovery scenario
+     * @return NotificationChannelsResponseDTSs list
+     */
+    private NotificationChannelDTO[] getNotificationChannelsResponseDTOList(String userName, String recoveryID,
+                                                                            String tenantDomain,
+                                                                            List<NotificationChannel> notificationChannels,
+                                                                            RecoveryScenarios recoveryScenario)
+            throws IdentityRecoveryException {
+
+        ArrayList<NotificationChannelDTO> notificationChannelDTOs = new ArrayList<>();
+
+        // Store available channels as NotificationChannelDTO objects in the array.
+        int channelId = 1;
+        StringBuilder recoveryChannels = new StringBuilder();
+        for (NotificationChannel channel : notificationChannels) {
+            NotificationChannelDTO dto = buildNotificationChannelsResponseDTO(channelId, channel.getType(),
+                    channel.getChannelValue(), channel.isPreferredStatus());
+            notificationChannelDTOs.add(dto);
+
+            // Creating the notification channel list for recovery.
+            String channelEntry = channel.getType() + IdentityRecoveryConstants.CHANNEL_ATTRIBUTE_SEPARATOR + channel
+                    .getChannelValue();
+            recoveryChannels.append(channelEntry).append(IdentityRecoveryConstants.NOTIFY_CHANNEL_LIST_SEPARATOR);
+            channelId++;
+        }
+        // Notification channel list is stored as the recovery data.
+        addRecoveryDataObject(userName, tenantDomain, recoveryID, recoveryScenario, recoveryChannels.toString());
+        return notificationChannelDTOs.toArray(new NotificationChannelDTO[0]);
+    }
+
+    /**
+     * Set notification channel details for each communication channels available for the user.
+     *
+     * @param channelId   Channel Id
+     * @param channelType Channel Type (Eg: EMAIL)
+     * @param value       Channel Value (Eg: wso2@gmail.com)
+     * @param preference  Whether user marked the channel as a preferred channel of communication
+     * @return NotificationChannelDTO object.
+     */
+    private NotificationChannelDTO buildNotificationChannelsResponseDTO(int channelId, String channelType, String value,
+                                                                        boolean preference) {
+
+        NotificationChannelDTO notificationChannelDTO = new NotificationChannelDTO();
+        notificationChannelDTO.setId(channelId);
+        notificationChannelDTO.setType(channelType);
+
+        // Encode the channel Values.
+        if (NotificationChannels.EMAIL_CHANNEL.getChannelType().equals(channelType)) {
+            notificationChannelDTO.setValue(maskEmailAddress(value));
+        } else if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(channelType)) {
+            notificationChannelDTO.setValue(maskMobileNumber(value));
+        } else {
+            notificationChannelDTO.setValue(value);
+        }
+        notificationChannelDTO.setPreferred(preference);
+        return notificationChannelDTO;
+    }
+
+    /**
+     * Encode the mobile of the user.
+     *
+     * @param mobile Mobile number
+     * @return Encoded mobile number (Empty String if the user has no mobile number).
+     */
+    private String maskMobileNumber(String mobile) {
+
+        if (StringUtils.isNotEmpty(mobile)) {
+            mobile = mobile.replaceAll(IdentityRecoveryConstants.ChannelMasking.MOBILE_MASKING_REGEX,
+                    IdentityRecoveryConstants.ChannelMasking.MASKING_CHARACTER);
+        }
+        return mobile;
+    }
+
+    /**
+     * Encode the email address of the user.
+     *
+     * @param email Email address
+     * @return Encoded email address (Empty String if user has no email)
+     */
+    private String maskEmailAddress(String email) {
+
+        if (StringUtils.isNotEmpty(email)) {
+            email = email.replaceAll(IdentityRecoveryConstants.ChannelMasking.EMAIL_MASKING_REGEX,
+                    IdentityRecoveryConstants.ChannelMasking.MASKING_CHARACTER);
+        }
+        return email;
+    }
+
+    /**
+     * Get the users list for a matching claim.
+     *
+     * @param tenantId   Tenant ID
+     * @param claimUri   Claim to be searched
+     * @param claimValue Claim value to be matched
+     * @return Matched users list
+     * @throws IdentityRecoveryServerException Error while retrieving claims from the userstore manager
+     */
+    private String[] getUserList(int tenantId, String claimUri, String claimValue)
+            throws IdentityRecoveryServerException {
+
+        String[] userList = new String[0];
+        UserStoreManager userStoreManager = getUserStoreManager(tenantId);
+        try {
+            if (userStoreManager != null) {
+                if (StringUtils.isNotBlank(claimValue) && claimValue.contains(FORWARD_SLASH)) {
+                    String extractedDomain = IdentityUtil.extractDomainFromName(claimValue);
+                    UserStoreManager secondaryUserStoreManager = userStoreManager.
+                            getSecondaryUserStoreManager(extractedDomain);
+                    /*
+                    Some claims (Eg:- Birth date) can have "/" in claim values. But in user store level we are trying
+                    to extract the claim value and find the user store domain. Hence we are adding an extra "/" to
+                    the claim value to avoid such issues.
+                     */
+                    if (secondaryUserStoreManager == null) {
+                        claimValue = FORWARD_SLASH + claimValue;
+                    }
+                }
+                userList = userStoreManager.getUserList(claimUri, claimValue, null);
+            }
+            return userList;
+        } catch (UserStoreException e) {
+            if (log.isDebugEnabled()) {
+                String error = String
+                        .format("Unable to retrieve the claim : %1$s for the given tenant : %2$s", claimUri, tenantId);
+                log.debug(error, e);
+            }
+            throw Utils.handleServerException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_USER_CLAIM, claimUri, e);
+        }
+    }
+
+    /**
+     * Get UserStoreManager.
+     *
+     * @param tenantId Tenant id
+     * @return UserStoreManager object
+     * @throws IdentityRecoveryServerException Error getting UserStoreManager
+     */
+    private UserStoreManager getUserStoreManager(int tenantId) throws IdentityRecoveryServerException {
+
+        UserStoreManager userStoreManager = null;
+        RealmService realmService = IdentityRecoveryServiceDataHolder.getInstance().getRealmService();
+        try {
+            if (realmService.getTenantUserRealm(tenantId) != null) {
+                userStoreManager = (UserStoreManager) realmService.getTenantUserRealm(tenantId).
+                        getUserStoreManager();
+            } else {
+                throw Utils.handleServerException(
+                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_ERROR_GETTING_USERSTORE_MANAGER, null);
+            }
+        } catch (UserStoreException e) {
+            if (log.isDebugEnabled()) {
+                String error = String.format("Error retrieving the user store manager for the tenant : %s", tenantId);
+                log.debug(error, e);
+            }
+            throw Utils.handleServerException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_ERROR_GETTING_USERSTORE_MANAGER, null, e);
+        }
+        return userStoreManager;
+    }
+
+    /**
+     * Keep the common users list from the previously matched list and the new list.
+     *
+     * @param resultedUserList Already matched users for previous claims
+     * @param matchedUserList  Retrieved users list for the given claim
+     * @param claim            Claim used for filtering
+     * @param value            Value given for the claim
+     * @return Users list with no duplicates
+     */
+    private String[] getCommonUserEntries(String[] resultedUserList, String[] matchedUserList, String claim,
+                                          String value) {
+
+        ArrayList<String> matchedUsers = new ArrayList<>(Arrays.asList(matchedUserList));
+        ArrayList<String> resultedUsers = new ArrayList<>(Arrays.asList(resultedUserList));
+
+        // Remove not matching users.
+        resultedUsers.retainAll(matchedUsers);
+        if (resultedUsers.size() > 0) {
+            resultedUserList = resultedUsers.toArray(new String[0]);
+            if (log.isDebugEnabled()) {
+                log.debug("Current matching temporary user list :" + Arrays.toString(resultedUserList));
+            }
+            return resultedUserList;
+        } else {
+            if (log.isDebugEnabled()) {
+                String message = String
+                        .format("There are no common users for claim : %1$s with the value : %2$s with the "
+                                + "previously filtered user list", claim, value);
+                log.debug(message);
+            }
+            return new String[0];
+        }
+    }
+
+    /**
+     * Get claim values of a user for a given list of claims.
+     *
+     * @param username          Username of the user
+     * @param tenantDomain      tenant domain
+     * @param requiredClaimURLs Claims that needs to be retrieved.
+     * @return Map of claims and values
+     * @throws IdentityRecoveryException Error while getting the user claims of the user
+     */
+    private Map<String, String> getClaimListOfUser(String username, String tenantDomain, String[] requiredClaimURLs)
+            throws IdentityRecoveryException {
+
+        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+        UserStoreManager userStoreManager = getUserStoreManager(tenantId);
+        Map<String, String> claimValues = null;
+        try {
+            if (userStoreManager != null) {
+                claimValues = userStoreManager.getUserClaimValues(username, requiredClaimURLs, null);
+            }
+        } catch (UserStoreException e) {
+            String error = String
+                    .format("Error getting claims of user : %1$s in tenant domain : %2$s", username, tenantDomain);
+            if (log.isDebugEnabled()) {
+                log.debug(error, e);
+            }
+            throw Utils
+                    .handleServerException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_ERROR_LOADING_USER_CLAIMS,
+                            null);
+        }
+        return claimValues;
+    }
+
+    /**
+     * Create required claim list from the attributes in the Notification channel list. The required claims will be
+     * used to get user's attributes.
+     *
+     * @return Required claims list
+     */
+    private String[] createRequiredChannelClaimsList() {
+
+        List<String> requiredClaims = new ArrayList<>();
+        NotificationChannels[] channels = {NotificationChannels.EMAIL_CHANNEL, NotificationChannels.SMS_CHANNEL};
+        for (NotificationChannels channel : channels) {
+            requiredClaims.add(channel.getClaimUri());
+            requiredClaims.add(channel.getVerifiedClaimUrl());
+        }
+
+        // Set the preferred channel claim uri.
+        requiredClaims.add(IdentityRecoveryConstants.PREFERRED_CHANNEL_CLAIM);
+
+        // Get the list of roles that the user has since the channel selection criteria changes with the availability
+        // of INTERNAL/selfsignup role.
+        requiredClaims.add(IdentityRecoveryConstants.USER_ROLES_CLAIM);
+        return requiredClaims.toArray(new String[0]);
+    }
+
+    /**
+     * get the available verified Notification channel objects.
+     *
+     * @param claimValues Claim values related to the notification channels
+     * @return Verified notification channels for the user.
+     */
+    private List<NotificationChannel> getNotificationChannelDetails(Map<String, String> claimValues) {
+
+        // Check whether the user is self registered user.
+        boolean isSelfRegisteredUser = isSelfSignUpUser(claimValues.get(IdentityRecoveryConstants.USER_ROLES_CLAIM));
+
+        // Create supported notification channels list by the server.
+        NotificationChannels[] notificationChannels = {
+                NotificationChannels.EMAIL_CHANNEL, NotificationChannels.SMS_CHANNEL
+        };
+
+        String preferredChannel = claimValues.get(IdentityRecoveryConstants.PREFERRED_CHANNEL_CLAIM);
+        List<NotificationChannel> verifiedChannels = new ArrayList<>();
+        for (NotificationChannels channel : notificationChannels) {
+            String channelValue = claimValues.get(channel.getClaimUri());
+            boolean channelVerified = Boolean.parseBoolean(claimValues.get(channel.getVerifiedClaimUrl()));
+            NotificationChannel channelDataModel = new NotificationChannel();
+
+            // If the user is self registered, then user has to have the verified channel claims. Check whether channel
+            // is verified and not empty.
+            if (isSelfRegisteredUser && channelVerified && StringUtils.isNotEmpty(channelValue)) {
+                channelDataModel.setType(channel.getChannelType());
+                channelDataModel.setChannelValue(channelValue);
+
+                // Check whether the preferred channel matches the given channel.
+                if (StringUtils.isNotEmpty(preferredChannel) && channel.getChannelType().equals(preferredChannel)) {
+                    channelDataModel.setPreferredStatus(true);
+                }
+                // Add the channel as a verified channel.
+                verifiedChannels.add(channelDataModel);
+            } else if (StringUtils.isNotEmpty(channelValue)) {
+                channelDataModel.setType(channel.getChannelType());
+                channelDataModel.setChannelValue(channelValue);
+
+                // Check whether the preferred channel matches the given channel.
+                if (StringUtils.isNotEmpty(preferredChannel) && channel.getChannelType().equals(preferredChannel)) {
+                    channelDataModel.setPreferredStatus(true);
+                }
+                // Add the channel as a verified channel.
+                verifiedChannels.add(channelDataModel);
+            }
+        }
+        return verifiedChannels;
+    }
+
+    /**
+     * Checks whether the user is a self signed-up user or not.
+     *
+     * @param rolesList Roles that the user has
+     * @return TRUE of the user has self sign-up role
+     */
+    private boolean isSelfSignUpUser(String rolesList) {
+
+        List<String> roles = Arrays.asList(rolesList.split(IdentityRecoveryConstants.SIGN_UP_ROLE_SEPARATOR));
+        return roles.contains(IdentityRecoveryConstants.SELF_SIGNUP_ROLE);
+    }
+
+    /**
+     * Validate the code.
+     *
+     * @param code Code given for recovery
+     * @param step Recovery step
+     * @throws IdentityRecoveryException Error validating the recoveryId
+     */
+    public UserRecoveryData getUserRecoveryData(String code, RecoverySteps step) throws IdentityRecoveryException {
+
+        UserRecoveryData recoveryData;
+        UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
+        try {
+            // Retrieve recovery data bound to the recoveryId.
+            recoveryData = userRecoveryDataStore.load(code);
+        } catch (IdentityRecoveryException e) {
+
+            // Map code expired error to new error codes for user account recovery.
+            if (IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CODE.getCode().equals(e.getErrorCode())) {
+                e.setErrorCode(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_RECOVERY_CODE.getCode());
+            } else if (IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_EXPIRED_CODE.getCode()
+                    .equals(e.getErrorCode())) {
+                e.setErrorCode(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_EXPIRED_RECOVERY_CODE.getCode());
+            } else {
+                e.setErrorCode(Utils.prependOperationScenarioToErrorCode(e.getErrorCode(),
+                        IdentityRecoveryConstants.USER_ACCOUNT_RECOVERY));
+            }
+            throw e;
+        }
+        if (recoveryData == null) {
+            throw Utils
+                    .handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_ACCOUNT_RECOVERY_DATA,
+                            code);
+        }
+        if (!step.equals(recoveryData.getRecoveryStep())) {
+            throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_RECOVERY_CODE,
+                    code);
+        }
+        return recoveryData;
+    }
+
+    /**
+     * Add the notification channel recovery data to the store.
+     *
+     * @param username     Username
+     * @param tenantDomain Tenant domain
+     * @param secretKey    RecoveryId
+     * @param scenario     RecoveryScenario
+     * @param recoveryData Data to be stored as mata which are needed to evaluate the recovery data object
+     * @throws IdentityRecoveryServerException Error storing recovery data
+     */
+    private void addRecoveryDataObject(String username, String tenantDomain, String secretKey,
+                                       RecoveryScenarios scenario, String recoveryData)
+            throws IdentityRecoveryServerException {
+
+        // Create a user object.
+        User user = buildUser(username, tenantDomain);
+        UserRecoveryData recoveryDataDO = new UserRecoveryData(user, secretKey, scenario,
+                RecoverySteps.SEND_RECOVERY_INFORMATION);
+
+        // Store available channels in remaining setIDs.
+        recoveryDataDO.setRemainingSetIds(recoveryData);
+        try {
+            UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
+            userRecoveryDataStore.invalidate(user);
+            userRecoveryDataStore.store(recoveryDataDO);
+        } catch (IdentityRecoveryException e) {
+            throw Utils.handleServerException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_ERROR_STORING_RECOVERY_DATA,
+                    "Error Storing Recovery Data", e);
+        }
+    }
+
+    /**
+     * Build a User object.
+     *
+     * @param username     Username of the user
+     * @param tenantDomain Tenant domain of the user
+     * @return User
+     */
+    private User buildUser(String username, String tenantDomain) {
+
+        User user = new User();
+        user.setUserName(username);
+        user.setTenantDomain(tenantDomain);
+        user.setUserStoreDomain(IdentityUtil.extractDomainFromName(username));
+        return user;
+    }
+}

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -104,8 +104,8 @@ public class UserAccountRecoveryManager {
             // Get the notification management mechanism.
             boolean isNotificationsInternallyManaged = Utils.isNotificationsInternallyManaged(tenantDomain, properties);
 
-            // If the notification is internally managed, then notification channels available for the user needs to
-            // be retrieved. If external notifications are enabled, external channel list should be returned.
+            /* If the notification is internally managed, then notification channels available for the user needs to
+            be retrieved. If external notifications are enabled, external channel list should be returned.*/
             if (isNotificationsInternallyManaged) {
                 notificationChannels = getInternalNotificationChannelList(username, tenantDomain);
             } else {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/password/DefaultPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/password/DefaultPasswordRecoveryManager.java
@@ -1,0 +1,627 @@
+/*
+ *
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.recovery.internal.service.impl.password;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryServerException;
+import org.wso2.carbon.identity.recovery.RecoveryScenarios;
+import org.wso2.carbon.identity.recovery.RecoverySteps;
+import org.wso2.carbon.identity.recovery.bean.NotificationResponseBean;
+import org.wso2.carbon.identity.recovery.confirmation.ResendConfirmationManager;
+import org.wso2.carbon.identity.recovery.dto.PasswordRecoverDTO;
+import org.wso2.carbon.identity.recovery.dto.PasswordResetCodeDTO;
+import org.wso2.carbon.identity.recovery.dto.RecoveryChannelInfoDTO;
+import org.wso2.carbon.identity.recovery.dto.RecoveryInformationDTO;
+import org.wso2.carbon.identity.recovery.dto.ResendConfirmationDTO;
+import org.wso2.carbon.identity.recovery.dto.SuccessfulPasswordResetDTO;
+import org.wso2.carbon.identity.recovery.internal.service.impl.UserAccountRecoveryManager;
+import org.wso2.carbon.identity.recovery.model.Property;
+import org.wso2.carbon.identity.recovery.model.UserRecoveryData;
+import org.wso2.carbon.identity.recovery.password.NotificationPasswordRecoveryManager;
+import org.wso2.carbon.identity.recovery.services.password.PasswordRecoveryManager;
+import org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStore;
+import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
+import org.wso2.carbon.identity.recovery.util.Utils;
+import org.wso2.carbon.registry.core.utils.UUIDGenerator;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+/**
+ * Class that implements the PasswordRecoveryManager.
+ */
+public class DefaultPasswordRecoveryManager implements PasswordRecoveryManager {
+
+    private static final Log log = LogFactory.getLog(DefaultPasswordRecoveryManager.class);
+
+    /**
+     * Get the username recovery information with available verified channel details.
+     *
+     * @param claims       User Claims
+     * @param tenantDomain Tenant domain
+     * @param properties   Meta properties
+     * @return RecoveryInformationDTO {@link RecoveryInformationDTO} object that contains
+     * recovery information of a  verified user
+     * @throws IdentityRecoveryException Error while initiating password recovery
+     */
+    @Override
+    public RecoveryInformationDTO initiate(Map<String, String> claims, String tenantDomain,
+                                           Map<String, String> properties) throws IdentityRecoveryException {
+
+        tenantDomain = resolveTenantDomain(tenantDomain);
+        UserAccountRecoveryManager userAccountRecoveryManager = UserAccountRecoveryManager.getInstance();
+        boolean isQuestionBasedRecoveryEnabled = isQuestionBasedRecoveryEnabled(tenantDomain);
+        boolean isNotificationBasedRecoveryEnabled = isNotificationBasedRecoveryEnabled(tenantDomain);
+
+        if (!isNotificationBasedRecoveryEnabled && !isQuestionBasedRecoveryEnabled) {
+            if (log.isDebugEnabled()) {
+                log.debug("User password recovery is not enabled for the tenant: " + tenantDomain);
+            }
+            throw Utils.handleClientException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PASSWORD_RECOVERY_NOT_ENABLED,
+                    null);
+        }
+
+        // Get recovery channel information.
+        RecoveryChannelInfoDTO recoveryChannelInfoDTO = userAccountRecoveryManager
+                .retrieveUserRecoveryInformation(claims, tenantDomain, RecoveryScenarios.NOTIFICATION_BASED_PW_RECOVERY,
+                        properties);
+
+        // build RecoveryInformationDTO.
+        RecoveryInformationDTO recoveryInformationDTO = new RecoveryInformationDTO();
+        recoveryInformationDTO.setUsername(recoveryChannelInfoDTO.getUsername());
+
+        // Do not add recovery channel information if Notification based recovery is not enabled.
+        recoveryInformationDTO.setNotificationBasedRecoveryEnabled(isNotificationBasedRecoveryEnabled);
+        if (isNotificationBasedRecoveryEnabled) {
+            recoveryInformationDTO.setRecoveryChannelInfoDTO(recoveryChannelInfoDTO);
+        }
+        recoveryInformationDTO.setQuestionBasedRecoveryEnabled(isQuestionBasedRecoveryEnabled);
+        recoveryInformationDTO.setNotificationBasedRecoveryEnabled(isNotificationBasedRecoveryEnabled);
+        return recoveryInformationDTO;
+    }
+
+    /**
+     * Verify the recovery code and send recovery information via channel which matches the given channel id.
+     *
+     * @param recoveryCode RecoveryId of the user
+     * @param channelId    Channel Id of the user
+     * @param tenantDomain Tenant Domain
+     * @param properties   Meta properties in the recovery request
+     * @return UsernameRecoverDTO {@link PasswordRecoverDTO} object that contains notified
+     * channel details and success status code
+     * @throws IdentityRecoveryException Error while notifying user
+     */
+    @Override
+    public PasswordRecoverDTO notify(String recoveryCode, String channelId, String tenantDomain,
+                                     Map<String, String> properties) throws IdentityRecoveryException {
+
+        tenantDomain = resolveTenantDomain(tenantDomain);
+
+        // Verify the configurations.
+        validateConfigurations(tenantDomain);
+
+        // Validate the channel Id in the request.
+        int channelIDCode = validateChannelID(channelId);
+        UserAccountRecoveryManager userAccountRecoveryManager = UserAccountRecoveryManager.getInstance();
+
+        // Get Recovery data.
+        UserRecoveryData userRecoveryData = userAccountRecoveryManager
+                .getUserRecoveryData(recoveryCode, RecoverySteps.SEND_RECOVERY_INFORMATION);
+
+        // Get notification channel.
+        String notificationChannel = extractNotificationChannelDetails(userRecoveryData.getRemainingSetIds(),
+                channelIDCode);
+
+        // Resolve notify status according to the notification channel of the user.
+        boolean manageNotificationsInternally = true;
+        if (IdentityRecoveryConstants.EXTERNAL_NOTIFICATION_CHANNEL.equals(notificationChannel)) {
+            manageNotificationsInternally = false;
+        }
+        NotificationResponseBean notificationResponseBean = notifyUser(userRecoveryData.getUser(), notificationChannel,
+                manageNotificationsInternally, properties);
+        String secretKey = notificationResponseBean.getKey();
+
+        // Generate resend code.
+        String resendCode = generateResendCode(notificationChannel, userRecoveryData);
+        return buildPasswordRecoveryResponseDTO(notificationChannel, secretKey, resendCode);
+    }
+
+    /**
+     * Validate the confirmation code given for password recovery and return the password reset code.
+     *
+     * @param confirmationCode Confirmation code
+     * @param tenantDomain     Tenant domain
+     * @param properties       Meta properties in the confirmation request
+     * @return PasswordResetCodeDTO {@link PasswordResetCodeDTO} object which contains password reset code
+     * @throws IdentityRecoveryException Error while confirming password recovery
+     */
+    @Override
+    public PasswordResetCodeDTO confirm(String confirmationCode, String tenantDomain, Map<String, String> properties)
+            throws IdentityRecoveryException {
+
+        tenantDomain = resolveTenantDomain(tenantDomain);
+        UserAccountRecoveryManager userAccountRecoveryManager = UserAccountRecoveryManager.getInstance();
+
+        // Get Recovery data.
+        UserRecoveryData userRecoveryData = userAccountRecoveryManager
+                .getUserRecoveryData(confirmationCode, RecoverySteps.UPDATE_PASSWORD);
+        if (!tenantDomain.equals(userRecoveryData.getUser().getTenantDomain())) {
+            throw Utils.handleClientException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_USER_TENANT_DOMAIN_MISS_MATCH_WITH_CONTEXT,
+                    tenantDomain);
+        }
+        String domainQualifiedName = IdentityUtil.addDomainToName(userRecoveryData.getUser().getUserName(),
+                userRecoveryData.getUser().getUserStoreDomain());
+        if (log.isDebugEnabled()) {
+            log.debug("Valid confirmation code for user: " + domainQualifiedName);
+        }
+        return buildPasswordResetCodeDTO(confirmationCode);
+    }
+
+    /**
+     * Reset the password for password recovery, if the password reset code is valid.
+     *
+     * @param resetCode  Password reset code
+     * @param password   New password
+     * @param properties Properties
+     * @return SuccessfulPasswordResetDTO {@link SuccessfulPasswordResetDTO} object which contain the information
+     * for a successful password update
+     * @throws IdentityRecoveryException Error while resetting the password
+     */
+    @Override
+    public SuccessfulPasswordResetDTO reset(String resetCode, char[] password, Map<String, String> properties)
+            throws IdentityRecoveryException {
+
+        // Validate the password.
+        if (ArrayUtils.isEmpty(password)) {
+            throw Utils.handleClientException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_PASSWORD_IN_REQUEST.getCode(),
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_PASSWORD_IN_REQUEST.getMessage(), null);
+        }
+        String newPassword = String.valueOf(password);
+        NotificationPasswordRecoveryManager notificationPasswordRecoveryManager = NotificationPasswordRecoveryManager
+                .getInstance();
+        Property[] metaProperties = buildPropertyList(null, properties);
+        try {
+            notificationPasswordRecoveryManager.updatePassword(resetCode, newPassword, metaProperties);
+        } catch (IdentityRecoveryServerException e) {
+            String errorCode = Utils.prependOperationScenarioToErrorCode(e.getErrorCode(),
+                    IdentityRecoveryConstants.PASSWORD_RECOVERY_SCENARIO);
+            throw Utils.handleServerException(errorCode, e.getMessage(), null);
+        } catch (IdentityRecoveryClientException e) {
+            throw mapClientExceptionWithImprovedErrorCodes(e);
+        } catch (IdentityEventException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("DefaultPasswordRecoveryManager: Error while resetting password ", e);
+            }
+            throw Utils.handleServerException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_UNEXPECTED_ERROR_PASSWORD_RESET.getCode(),
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_UNEXPECTED_ERROR_PASSWORD_RESET.getMessage(),
+                    null);
+        }
+        return buildSuccessfulPasswordUpdateDTO();
+    }
+
+    /**
+     * Resend the password recovery information to the user via user specified channel.
+     *
+     * @param tenantDomain Tenant Domain
+     * @param resendCode   Resend code
+     * @param properties   Meta properties
+     * @return ResendConfirmationDTO {@link ResendConfirmationDTO} which wraps the information for a successful
+     * recovery information resend
+     * @throws IdentityRecoveryException Error while sending recovery information
+     */
+    @Override
+    public ResendConfirmationDTO resend(String tenantDomain, String resendCode, Map<String, String> properties)
+            throws IdentityRecoveryException {
+
+        tenantDomain = resolveTenantDomain(tenantDomain);
+        Property[] metaProperties = buildPropertyList(null, properties);
+        ResendConfirmationManager resendConfirmationManager = ResendConfirmationManager.getInstance();
+        try {
+            return resendConfirmationManager.resendConfirmation(tenantDomain, resendCode,
+                    RecoveryScenarios.NOTIFICATION_BASED_PW_RECOVERY.name(), RecoverySteps.UPDATE_PASSWORD.name(),
+                    IdentityRecoveryConstants.NOTIFICATION_TYPE_RESEND_PASSWORD_RESET, metaProperties);
+        } catch (IdentityRecoveryException e) {
+            e.setErrorCode(Utils.prependOperationScenarioToErrorCode(e.getErrorCode(),
+                    IdentityRecoveryConstants.PASSWORD_RECOVERY_SCENARIO));
+            throw e;
+        }
+    }
+
+    /**
+     * Map the client exceptions with the new API error codes and the scenarios.
+     *
+     * @param exception IdentityRecoveryClientException
+     * @return IdentityRecoveryClientException
+     */
+    private IdentityRecoveryClientException mapClientExceptionWithImprovedErrorCodes(
+            IdentityRecoveryClientException exception) {
+
+        if (IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CODE.getCode()
+                .equals(exception.getErrorCode())) {
+            exception.setErrorCode(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_RECOVERY_CODE.getCode());
+        } else if (IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_EXPIRED_CODE.getCode()
+                .equals(exception.getErrorCode())) {
+            exception.setErrorCode(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_EXPIRED_RECOVERY_CODE.getCode());
+        } else if (IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_HISTORY_VIOLATE.getCode()
+                .equals(exception.getErrorCode())) {
+            exception.setErrorCode(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PASSWORD_HISTORY_VIOLATION.getCode());
+        } else if (IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_POLICY_VIOLATION.getCode()
+                .equals(exception.getErrorCode())) {
+            exception.setErrorCode(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PASSWORD_POLICY_VIOLATION.getCode());
+        } else {
+            exception.setErrorCode(Utils.prependOperationScenarioToErrorCode(exception.getErrorCode(),
+                    IdentityRecoveryConstants.PASSWORD_RECOVERY_SCENARIO));
+        }
+        return Utils.handleClientException(exception.getErrorCode(), exception.getMessage(), null);
+    }
+
+    /**
+     * Send recovery information to the user.
+     *
+     * @param user                         User
+     * @param notificationChannel          Notification Channel
+     * @param manageNotificationInternally Manage notifications internally
+     * @param properties                   Meta properties
+     * @return NotificationResponseBean
+     * @throws IdentityRecoveryException Error while sending notifications
+     */
+    private NotificationResponseBean notifyUser(User user, String notificationChannel,
+                                                boolean manageNotificationInternally, Map<String, String> properties)
+            throws IdentityRecoveryException {
+
+        Property[] metaProperties = buildPropertyList(notificationChannel, properties);
+        NotificationResponseBean notificationResponseBean;
+        try {
+            notificationResponseBean = NotificationPasswordRecoveryManager
+                    .getInstance().
+                            sendRecoveryNotification(user, null, manageNotificationInternally, metaProperties);
+        } catch (IdentityRecoveryException exception) {
+            if (StringUtils.isNotEmpty(exception.getErrorCode())) {
+                String errorCode = exception.getErrorCode();
+                if (IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_CALLBACK_URL_NOT_VALID.getCode()
+                        .equals(errorCode)) {
+                    exception.setErrorCode(
+                            IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CALLBACK_PASSWORD_RESET
+                                    .getCode());
+                } else if (IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_UNEXPECTED.getCode()
+                        .equals(errorCode)) {
+                    exception.setErrorCode(
+                            IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_UNEXPECTED_ERROR_PASSWORD_RESET
+                                    .getCode());
+                }
+                exception.setErrorCode(Utils.prependOperationScenarioToErrorCode(exception.getErrorCode(),
+                        IdentityRecoveryConstants.PASSWORD_RECOVERY_SCENARIO));
+            }
+            throw exception;
+        }
+        if (notificationResponseBean == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("Empty Response while notifying password recovery information for user : " + user
+                        .getUserName());
+            }
+            throw Utils
+                    .handleServerException(
+                            IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_UNEXPECTED_ERROR_PASSWORD_RESET, null);
+        }
+        return notificationResponseBean;
+    }
+
+    /**
+     * Build Property list using the meta properties map.
+     *
+     * @param notificationChannel Notification channel
+     * @param properties          Map of properties
+     * @return List of properties
+     */
+    private Property[] buildPropertyList(String notificationChannel, Map<String, String> properties) {
+
+        ArrayList<Property> propertyArrayList = new ArrayList<>();
+
+        // Add already existing meta properties.
+        if (properties != null && properties.size() > 0) {
+            for (String key : properties.keySet()) {
+                if (StringUtils.isNotEmpty(key)) {
+                    propertyArrayList.add(buildProperty(key, properties.get(key)));
+                }
+            }
+        }
+        // Add the notification channel property.
+        if (StringUtils.isNotEmpty(notificationChannel)) {
+            propertyArrayList.add(buildProperty(IdentityRecoveryConstants.NOTIFICATION_CHANNEL_PROPERTY_KEY,
+                    notificationChannel));
+        }
+        // Add the verified user property since the user is already verified and no need to validate the existence
+        // again.
+        propertyArrayList
+                .add(buildProperty(IdentityRecoveryConstants.VERIFIED_USER_PROPERTY_KEY, Boolean.toString(true)));
+        return propertyArrayList.toArray(new Property[0]);
+    }
+
+    /**
+     * Build a property object.
+     *
+     * @param key   Key
+     * @param value Value
+     * @return Property object
+     */
+    private Property buildProperty(String key, String value) {
+
+        Property property = new Property();
+        property.setKey(key);
+        property.setValue(value);
+        return property;
+    }
+
+    /**
+     * Build SuccessfulPasswordResetDTO response for a successful password update.
+     *
+     * @return SuccessfulPasswordResetDTO object
+     */
+    private SuccessfulPasswordResetDTO buildSuccessfulPasswordUpdateDTO() {
+
+        SuccessfulPasswordResetDTO successfulPasswordResetDTO = new SuccessfulPasswordResetDTO();
+        successfulPasswordResetDTO.setSuccessCode(
+                IdentityRecoveryConstants.SuccessEvents.SUCCESS_STATUS_CODE_SUCCESSFUL_PASSWORD_UPDATE.getCode());
+        successfulPasswordResetDTO.setMessage(
+                IdentityRecoveryConstants.SuccessEvents.SUCCESS_STATUS_CODE_SUCCESSFUL_PASSWORD_UPDATE.getMessage());
+        return successfulPasswordResetDTO;
+    }
+
+    /**
+     * Validate the channel Id given in the reqest.
+     *
+     * @param channelId Channel Id in the request.
+     * @return Channel Id
+     * @throws IdentityRecoveryClientException Invalid channel Id
+     */
+    private int validateChannelID(String channelId) throws IdentityRecoveryClientException {
+
+        int id;
+
+        // Check whether the channel Id is an int.
+        try {
+            id = Integer.parseInt(channelId);
+        } catch (NumberFormatException e) {
+            throw Utils
+                    .handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CHANNEL_ID, null);
+        }
+        // Channel id needs to be larger than 0.
+        if (id < 1) {
+            throw Utils
+                    .handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CHANNEL_ID, null);
+        }
+        return id;
+    }
+
+    /**
+     * Build the PasswordResetCodeDTO for successful verification.
+     *
+     * @param resetCode Password reset code
+     * @return PasswordResetCodeDTO
+     */
+    private PasswordResetCodeDTO buildPasswordResetCodeDTO(String resetCode) {
+
+        PasswordResetCodeDTO passwordResetCodeDTO = new PasswordResetCodeDTO();
+        passwordResetCodeDTO.setPasswordResetCode(resetCode);
+        return passwordResetCodeDTO;
+    }
+
+    /**
+     * Build PasswordRecoverDTO for notifying password recovery details successfully.
+     *
+     * @param notificationChannel Notified channel
+     * @param confirmationCode    Confirmation code for confirm recovery
+     * @param resendCode          Code to resend recovery confirmation code
+     * @return PasswordRecoverDTO object
+     */
+    private PasswordRecoverDTO buildPasswordRecoveryResponseDTO(String notificationChannel, String confirmationCode,
+                                                                String resendCode) {
+
+        PasswordRecoverDTO passwordRecoverDTO = new PasswordRecoverDTO();
+        passwordRecoverDTO.setNotificationChannel(notificationChannel);
+
+        // Check for notification method.
+        if (IdentityRecoveryConstants.EXTERNAL_NOTIFICATION_CHANNEL.equals(notificationChannel)) {
+            passwordRecoverDTO.setConfirmationCode(confirmationCode);
+            passwordRecoverDTO.setCode(
+                    IdentityRecoveryConstants.SuccessEvents.SUCCESS_STATUS_CODE_PASSWORD_RECOVERY_EXTERNALLY_NOTIFIED
+                            .getCode());
+            passwordRecoverDTO.setMessage(
+                    IdentityRecoveryConstants.SuccessEvents.SUCCESS_STATUS_CODE_PASSWORD_RECOVERY_EXTERNALLY_NOTIFIED
+                            .getMessage());
+        } else {
+            passwordRecoverDTO.setConfirmationCode(StringUtils.EMPTY);
+            passwordRecoverDTO.setResendCode(resendCode);
+            passwordRecoverDTO.setCode(
+                    IdentityRecoveryConstants.SuccessEvents.SUCCESS_STATUS_CODE_PASSWORD_RECOVERY_INTERNALLY_NOTIFIED
+                            .getCode());
+            passwordRecoverDTO.setMessage(
+                    IdentityRecoveryConstants.SuccessEvents.SUCCESS_STATUS_CODE_PASSWORD_RECOVERY_INTERNALLY_NOTIFIED
+                            .getMessage());
+        }
+        return passwordRecoverDTO;
+    }
+
+    /**
+     * Extract the channel that matches the channelId from the channels stored in recovery data.
+     *
+     * @param recoveryChannels All available recovery channels
+     * @param channelId        User preferred channelId
+     * @throws IdentityRecoveryException Invalid channelId
+     */
+    private String extractNotificationChannelDetails(String recoveryChannels, int channelId)
+            throws IdentityRecoveryException {
+
+        String[] channels = recoveryChannels.split(IdentityRecoveryConstants.NOTIFY_CHANNEL_LIST_SEPARATOR);
+        if (channels.length < channelId) {
+            throw Utils
+                    .handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CHANNEL_ID, null);
+        }
+        String notificationChannel = channels[channelId - 1];
+        String[] channelDetails = notificationChannel.split(IdentityRecoveryConstants.CHANNEL_ATTRIBUTE_SEPARATOR);
+        return channelDetails[0];
+    }
+
+    /**
+     * Check whether recovery is enabled.
+     *
+     * @param tenantDomain Tenant domain
+     * @throws IdentityRecoveryException Error with the configurations
+     */
+    private void validateConfigurations(String tenantDomain) throws IdentityRecoveryException {
+
+        boolean isRecoveryEnable = Boolean.parseBoolean(
+                Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY,
+                        tenantDomain));
+        if (!isRecoveryEnable) {
+            throw Utils.handleClientException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PASSWORD_RECOVERY_WITH_NOTIFICATIONS_NOT_ENABLED,
+                    null);
+        }
+    }
+
+    /**
+     * Resolve the tenant domain in the request.
+     *
+     * @param tenantDomain Tenant domain in the request
+     * @return Resolved tenant domain
+     */
+    private String resolveTenantDomain(String tenantDomain) {
+
+        if (StringUtils.isBlank(tenantDomain)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Tenant domain is not in the request. Therefore, domain set to : "
+                        + MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+            }
+            return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+        }
+        return tenantDomain;
+    }
+
+    /**
+     * Check whether challenge question based recovery is enabled for the tenant.
+     *
+     * @param tenantDomain Tenant domain
+     * @return True if challenge question based recovery is enabled
+     * @throws IdentityRecoveryServerException Error reading configs for the tenant
+     */
+    private boolean isQuestionBasedRecoveryEnabled(String tenantDomain) throws IdentityRecoveryServerException {
+        // Check whether the challenge question based recovery is enabled.
+        try {
+            return Boolean.parseBoolean(
+                    Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.QUESTION_BASED_PW_RECOVERY,
+                            tenantDomain));
+        } catch (IdentityRecoveryServerException e) {
+
+            // Prepend scenario to the thrown exception.
+            String errorCode = Utils
+                    .prependOperationScenarioToErrorCode(IdentityRecoveryConstants.PASSWORD_RECOVERY_SCENARIO,
+                            e.getErrorCode());
+            throw Utils.handleServerException(errorCode, e.getMessage(), null);
+        }
+    }
+
+    /**
+     * Check whether notification based recovery is enabled for the tenant.
+     *
+     * @param tenantDomain Tenant domain
+     * @return True if challenge question based recovery is enabled
+     * @throws IdentityRecoveryServerException Error reading configs for the tenant
+     */
+    private boolean isNotificationBasedRecoveryEnabled(String tenantDomain) throws IdentityRecoveryServerException {
+        // Check whether the challenge question based recovery is enabled.
+        try {
+            return Boolean.parseBoolean(
+                    Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY,
+                            tenantDomain));
+        } catch (IdentityRecoveryServerException e) {
+
+            // Prepend scenario to the thrown exception.
+            String errorCode = Utils
+                    .prependOperationScenarioToErrorCode(IdentityRecoveryConstants.PASSWORD_RECOVERY_SCENARIO,
+                            e.getErrorCode());
+            throw Utils.handleServerException(errorCode, e.getMessage(), null);
+        }
+    }
+
+    /**
+     * Get the resend code.
+     *
+     * @param notificationChannel Notification channel
+     * @param userRecoveryData    User Recovery data
+     * @return Resend code
+     * @throws IdentityRecoveryServerException Error while adding the resend code
+     */
+    private String generateResendCode(String notificationChannel, UserRecoveryData userRecoveryData)
+            throws IdentityRecoveryServerException {
+
+        String resendCode = UUIDGenerator.generateUUID();
+        User user = userRecoveryData.getUser();
+        addRecoveryDataObject(user.getUserName(), user.getTenantDomain(), resendCode, notificationChannel);
+        return resendCode;
+    }
+
+    /**
+     * Add the notification channel recovery data to the store.
+     *
+     * @param userName     Username
+     * @param tenantDomain Tenant domain
+     * @param secretKey    RecoveryId
+     * @param recoveryData Data to be stored as mata which are needed to evaluate the recovery data object
+     * @throws IdentityRecoveryServerException Error storing recovery data
+     */
+    private void addRecoveryDataObject(String userName, String tenantDomain, String secretKey, String recoveryData)
+            throws IdentityRecoveryServerException {
+
+        // Create a user object.
+        User user = new User();
+        user.setUserName(userName);
+        user.setTenantDomain(tenantDomain);
+        user.setUserStoreDomain(IdentityUtil.extractDomainFromName(userName));
+        UserRecoveryData recoveryDataDO = new UserRecoveryData(user, secretKey,
+                RecoveryScenarios.NOTIFICATION_BASED_PW_RECOVERY, RecoverySteps.RESEND_CONFIRMATION_CODE);
+
+        // Store available channels in remaining setIDs.
+        recoveryDataDO.setRemainingSetIds(recoveryData);
+        try {
+            UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
+            userRecoveryDataStore.store(recoveryDataDO);
+        } catch (IdentityRecoveryException e) {
+            throw Utils.handleServerException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_ERROR_STORING_RECOVERY_DATA,
+                    "Error Storing Recovery Data", e);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/password/PasswordRecoveryManagerImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/password/PasswordRecoveryManagerImpl.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
@@ -433,24 +434,16 @@ public class PasswordRecoveryManagerImpl implements PasswordRecoveryManager {
 
         PasswordRecoverDTO passwordRecoverDTO = new PasswordRecoverDTO();
         passwordRecoverDTO.setNotificationChannel(notificationChannel);
-        if (IdentityRecoveryConstants.EXTERNAL_NOTIFICATION_CHANNEL.equals(notificationChannel)) {
+        if (NotificationChannels.EXTERNAL_CHANNEL.getChannelType().equals(notificationChannel)) {
             passwordRecoverDTO.setConfirmationCode(confirmationCode);
-            passwordRecoverDTO.setCode(
-                    IdentityRecoveryConstants.SuccessEvents.SUCCESS_STATUS_CODE_PASSWORD_RECOVERY_EXTERNALLY_NOTIFIED
-                            .getCode());
-            passwordRecoverDTO.setMessage(
-                    IdentityRecoveryConstants.SuccessEvents.SUCCESS_STATUS_CODE_PASSWORD_RECOVERY_EXTERNALLY_NOTIFIED
-                            .getMessage());
-        } else {
-            passwordRecoverDTO.setConfirmationCode(StringUtils.EMPTY);
-            passwordRecoverDTO.setResendCode(resendCode);
-            passwordRecoverDTO.setCode(
-                    IdentityRecoveryConstants.SuccessEvents.SUCCESS_STATUS_CODE_PASSWORD_RECOVERY_INTERNALLY_NOTIFIED
-                            .getCode());
-            passwordRecoverDTO.setMessage(
-                    IdentityRecoveryConstants.SuccessEvents.SUCCESS_STATUS_CODE_PASSWORD_RECOVERY_INTERNALLY_NOTIFIED
-                            .getMessage());
         }
+        passwordRecoverDTO.setResendCode(resendCode);
+        passwordRecoverDTO.setCode(
+                IdentityRecoveryConstants.SuccessEvents.SUCCESS_STATUS_CODE_PASSWORD_RECOVERY_INTERNALLY_NOTIFIED
+                        .getCode());
+        passwordRecoverDTO.setMessage(
+                IdentityRecoveryConstants.SuccessEvents.SUCCESS_STATUS_CODE_PASSWORD_RECOVERY_INTERNALLY_NOTIFIED
+                        .getMessage());
         return passwordRecoverDTO;
     }
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/username/DefaultUsernameRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/username/DefaultUsernameRecoveryManager.java
@@ -1,0 +1,441 @@
+/*
+ *
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.recovery.internal.service.impl.username;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryServerException;
+import org.wso2.carbon.identity.recovery.RecoveryScenarios;
+import org.wso2.carbon.identity.recovery.RecoverySteps;
+import org.wso2.carbon.identity.recovery.dto.RecoveryInformationDTO;
+import org.wso2.carbon.identity.recovery.dto.UsernameRecoverDTO;
+import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
+import org.wso2.carbon.identity.recovery.internal.service.impl.UserAccountRecoveryManager;
+import org.wso2.carbon.identity.recovery.model.UserRecoveryData;
+import org.wso2.carbon.identity.recovery.services.username.UsernameRecoveryManager;
+import org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStore;
+import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
+import org.wso2.carbon.identity.recovery.util.Utils;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Class that implements the UsernameRecoveryManager.
+ */
+public class DefaultUsernameRecoveryManager implements UsernameRecoveryManager {
+
+    private static final Log log = LogFactory.getLog(DefaultUsernameRecoveryManager.class);
+
+    /**
+     * Get the username recovery information with available verified channel details.
+     *
+     * @param claims       User Claims
+     * @param tenantDomain Tenant domain
+     * @param properties   Meta properties
+     * @return RecoveryChannelInfoDTO {@link RecoveryInformationDTO} object that contains
+     * recovery for a verified user
+     * @throws IdentityRecoveryException Error while initiating username recovery
+     */
+    @Override
+    public RecoveryInformationDTO initiate(Map<String, String> claims, String tenantDomain,
+                                           Map<String, String> properties) throws IdentityRecoveryException {
+
+        tenantDomain = resolveTenantDomain(tenantDomain);
+
+        // Verify the configurations.
+        validateConfigurations(tenantDomain);
+
+        UserAccountRecoveryManager userAccountRecoveryManager = UserAccountRecoveryManager.getInstance();
+        RecoveryInformationDTO recoveryInformationDTO = new RecoveryInformationDTO();
+
+        boolean useLegacyAPIApproach = useLegacyAPIApproach(properties);
+        boolean manageNotificationsInternally = Utils.isNotificationsInternallyManaged(tenantDomain, properties);
+
+        if (!useLegacyAPIApproach) {
+
+            // Add notification method in a meta property list.
+            Map<String, String> metaProperties = new HashMap<>();
+            metaProperties.put(IdentityRecoveryConstants.MANAGE_NOTIFICATIONS_INTERNALLY_PROPERTY_KEY,
+                    Boolean.toString(manageNotificationsInternally));
+            recoveryInformationDTO.setRecoveryChannelInfoDTO(userAccountRecoveryManager
+                    .retrieveUserRecoveryInformation(claims, tenantDomain, RecoveryScenarios.USERNAME_RECOVERY,
+                            metaProperties));
+        } else {
+
+            // Else block is used to support legacy username recovery API functionality.
+            String username = userAccountRecoveryManager.getUsernameByClaims(claims, tenantDomain);
+            if (StringUtils.isNotEmpty(username)) {
+
+                // Send notifications.
+                if (manageNotificationsInternally) {
+                    User user = createUser(username, tenantDomain);
+                    triggerNotification(user, NotificationChannels.EMAIL_CHANNEL.getChannelType(),
+                            IdentityEventConstants.Event.TRIGGER_NOTIFICATION, null);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Successful username recovery for user: " + username + ". " +
+                                "User notified Internally");
+                    }
+                    return null;
+                } else {
+                    log.debug("Successful username recovery for user: " + username + ". User notified Externally");
+                    recoveryInformationDTO.setUsername(username);
+                }
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("No user found for the given claims");
+                }
+                if (Boolean.parseBoolean(
+                        IdentityUtil.getProperty(IdentityRecoveryConstants.ConnectorConfig.NOTIFY_USER_EXISTENCE))) {
+                    throw Utils.handleClientException(
+                            IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_USER_OR_MORE_THAN_ONE_USER_FOUND,
+                            null);
+                } else {
+                    return null;
+                }
+            }
+        }
+        return recoveryInformationDTO;
+    }
+
+    /**
+     * Verify the recovery code and send recovery information via channel which matches the given channel id.
+     *
+     * @param recoveryCode RecoveryId of the user
+     * @param channelId    Channel Id of the user
+     * @param tenantDomain Tenant Domain
+     * @param properties   Meta properties in the recovery request
+     * @return UsernameRecoverDTO {@link UsernameRecoverDTO} object that contains notified
+     * channel details and success status code
+     * @throws IdentityRecoveryException Error while notifying user
+     */
+    @Override
+    public UsernameRecoverDTO notify(String recoveryCode, String channelId, String tenantDomain,
+                                     Map<String, String> properties) throws IdentityRecoveryException {
+
+        tenantDomain = resolveTenantDomain(tenantDomain);
+
+        // Validate the channel Id passed in the request.
+        int channelIdCode = validateChannelID(channelId);
+
+        // Verify the configurations.
+        validateConfigurations(tenantDomain);
+        UserAccountRecoveryManager recoveryAccountManager = UserAccountRecoveryManager.getInstance();
+
+        // Validate Recovery data.
+        UserRecoveryData userRecoveryData = recoveryAccountManager
+                .getUserRecoveryData(recoveryCode, RecoverySteps.SEND_RECOVERY_INFORMATION);
+        invalidateRecoveryCode(recoveryCode);
+        String notificationChannel = extractNotificationChannelDetails(userRecoveryData.getRemainingSetIds(),
+                channelIdCode);
+
+        // If the notifications are externally managed we do not need to send notifications internally.
+        if (!IdentityRecoveryConstants.EXTERNAL_NOTIFICATION_CHANNEL.equals(notificationChannel)) {
+
+            // Resolve event name.
+            String eventName = Utils.resolveEventName(notificationChannel);
+
+            // Validate callback url if present in meta data properties.
+            validateCallbackURL(properties, userRecoveryData.getUser());
+            triggerNotification(userRecoveryData.getUser(), notificationChannel, eventName, properties);
+        }
+        // Return successful recovery response object.
+        return buildUserNameRecoveryResponseDTO(userRecoveryData.getUser(), notificationChannel);
+    }
+
+    /**
+     * Whether to use legacy APIs or not.
+     *
+     * @param properties Meta properties
+     * @return True to use legacy API approach
+     */
+    private boolean useLegacyAPIApproach(Map<String, String> properties) {
+
+        if (properties != null && properties.size() > 0) {
+            try {
+                return Boolean.parseBoolean(properties.get(IdentityRecoveryConstants.USE_LEGACY_API_PROPERTY_KEY));
+            } catch (NumberFormatException e) {
+                if (log.isDebugEnabled()) {
+                    String message = String.format("Invalid boolean value : %s to enable legacyAPIs", properties
+                            .get(IdentityRecoveryConstants.USE_LEGACY_API_PROPERTY_KEY));
+                    log.debug(message);
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Create a User object.
+     *
+     * @param userName     Username of the user
+     * @param tenantDomain Tenant domain
+     * @return User
+     */
+    private User createUser(String userName, String tenantDomain) {
+
+        User user = new User();
+        user.setUserName(userName);
+        user.setTenantDomain(tenantDomain);
+        user.setUserStoreDomain(IdentityUtil.extractDomainFromName(userName));
+        return user;
+    }
+
+    /**
+     * Resolve the tenant domain in the request.
+     *
+     * @param tenantDomain Tenant domain in the request
+     * @return Resolved tenant domain
+     */
+    private String resolveTenantDomain(String tenantDomain) {
+
+        if (StringUtils.isBlank(tenantDomain)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Tenant domain is not in the request. Therefore, domain set to : "
+                        + MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+            }
+            return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+        }
+        return tenantDomain;
+    }
+
+    /**
+     * Validate the channel Id given in the reqest.
+     *
+     * @param channelId Channel Id in the request.
+     * @return Channel Id
+     * @throws IdentityRecoveryClientException Invalid client Id
+     */
+    private int validateChannelID(String channelId) throws IdentityRecoveryClientException {
+
+        int id;
+
+        // Check whether the channel Id is an int.
+        try {
+            id = Integer.parseInt(channelId);
+        } catch (NumberFormatException e) {
+            throw Utils
+                    .handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CHANNEL_ID, null);
+        }
+        // Channel id needs to be larger than 0.
+        if (id < 1) {
+            throw Utils
+                    .handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CHANNEL_ID, null);
+        }
+        return id;
+    }
+
+    /**
+     * Build the response object for successful username recovery.
+     *
+     * @param user                User
+     * @param notificationChannel Notification channel selected by the user.
+     * @return UsernameRecoverDTO object
+     */
+    private UsernameRecoverDTO buildUserNameRecoveryResponseDTO(User user, String notificationChannel) {
+
+        // Username regex. Example: username@tenantDomain.
+        String QUALIFIED_USERNAME_REGEX_PATTERN = "%s@%s";
+        UsernameRecoverDTO usernameRecoverDTO = new UsernameRecoverDTO();
+        usernameRecoverDTO.setNotificationChannel(notificationChannel);
+
+        // Check for notification method.
+        if (IdentityRecoveryConstants.EXTERNAL_NOTIFICATION_CHANNEL.equals(notificationChannel)) {
+            usernameRecoverDTO.setCode(
+                    IdentityRecoveryConstants.SuccessEvents.SUCCESS_STATUS_CODE_USERNAME_EXTERNALLY_NOTIFIED.getCode());
+            usernameRecoverDTO.setMessage(
+                    IdentityRecoveryConstants.SuccessEvents.SUCCESS_STATUS_CODE_USERNAME_EXTERNALLY_NOTIFIED
+                            .getMessage());
+
+            // If notifications are externally managed, username needs to be sent with the request.
+            // Build username for external notification.
+            String username =
+                    String.format(QUALIFIED_USERNAME_REGEX_PATTERN, user.getUserName(), user.getTenantDomain());
+            usernameRecoverDTO.setUsername(username);
+        } else {
+            usernameRecoverDTO.setCode(
+                    IdentityRecoveryConstants.SuccessEvents.SUCCESS_STATUS_CODE_USERNAME_INTERNALLY_NOTIFIED.getCode());
+            usernameRecoverDTO.setMessage(
+                    IdentityRecoveryConstants.SuccessEvents.SUCCESS_STATUS_CODE_USERNAME_INTERNALLY_NOTIFIED
+                            .getMessage());
+            usernameRecoverDTO.setUsername(StringUtils.EMPTY);
+        }
+        return usernameRecoverDTO;
+    }
+
+    /**
+     * Invalidate the recovery code.
+     *
+     * @param recoveryCode Recovery code
+     */
+    private void invalidateRecoveryCode(String recoveryCode) throws IdentityRecoveryException {
+
+        UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
+        userRecoveryDataStore.invalidate(recoveryCode);
+    }
+
+    /**
+     * Trigger notification to send userName recovery information.
+     *
+     * @param user                User
+     * @param notificationChannel Notification channel
+     * @param eventName           Event name
+     * @param metaProperties      Meta properties to be send with the notification.
+     * @throws IdentityRecoveryException Error while triggering notification.
+     */
+    private void triggerNotification(User user, String notificationChannel, String eventName,
+                                     Map<String, String> metaProperties)
+            throws IdentityRecoveryException {
+
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put(IdentityEventConstants.EventProperty.USER_NAME, user.getUserName());
+        properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, user.getTenantDomain());
+        properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, user.getUserStoreDomain());
+        properties.put(IdentityEventConstants.EventProperty.NOTIFICATION_CHANNEL, notificationChannel);
+        if (metaProperties != null) {
+            for (String key : metaProperties.keySet()) {
+                String value = metaProperties.get(key);
+                if (StringUtils.isNotBlank(key) && StringUtils.isNotBlank(value)) {
+                    properties.put(key, value);
+                }
+            }
+        }
+        properties.put(IdentityRecoveryConstants.TEMPLATE_TYPE,
+                IdentityRecoveryConstants.NOTIFICATION_ACCOUNT_ID_RECOVERY);
+        Event identityMgtEvent = new Event(eventName, properties);
+        try {
+            IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);
+        } catch (IdentityEventException e) {
+            throw Utils.handleServerException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_TRIGGER_NOTIFICATION,
+                    user.getUserName(), e);
+        }
+    }
+
+    /**
+     * Extract the channel that matches the channelId from the channels stored in recovery data.
+     *
+     * @param recoveryChannels All available recovery channels
+     * @param channelId        User preferred channelId
+     * @throws IdentityRecoveryException Invalid channelId
+     */
+    private String extractNotificationChannelDetails(String recoveryChannels, int channelId)
+            throws IdentityRecoveryException {
+
+        String[] channels = recoveryChannels.split(IdentityRecoveryConstants.NOTIFY_CHANNEL_LIST_SEPARATOR);
+        if (channels.length < channelId) {
+            throw Utils
+                    .handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CHANNEL_ID, null);
+        }
+        String notificationChannel = channels[channelId - 1];
+        String[] channelDetails = notificationChannel.split(IdentityRecoveryConstants.CHANNEL_ATTRIBUTE_SEPARATOR);
+        return channelDetails[0];
+    }
+
+    /**
+     * Check whether the configurations are enabled for username recovery.
+     *
+     * @param tenantDomain String tenant domain
+     * @throws IdentityRecoveryException Configurations are not enabled.
+     */
+    private void validateConfigurations(String tenantDomain) throws IdentityRecoveryException {
+
+        boolean isRecoveryEnable = Boolean.parseBoolean(
+                Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.USERNAME_RECOVERY_ENABLE,
+                        tenantDomain));
+        if (!isRecoveryEnable) {
+            throw Utils.handleClientException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_USERNAME_RECOVERY_NOT_ENABLED, null);
+        }
+    }
+
+    /**
+     * Validate the callback url.
+     *
+     * @param properties Map of notification recovery properties
+     * @param user       User
+     * @throws IdentityRecoveryException Invalid callback url
+     */
+    private void validateCallbackURL(Map<String, String> properties, User user) throws IdentityRecoveryException {
+
+        String callbackURL;
+        callbackURL = getCallbackURL(properties);
+        try {
+            if (StringUtils.isNotBlank(callbackURL) && !Utils.validateCallbackURL(callbackURL, user.getTenantDomain(),
+                    IdentityRecoveryConstants.ConnectorConfig.RECOVERY_CALLBACK_REGEX)) {
+                throw Utils.handleClientException(
+                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_CALLBACK_URL_NOT_VALID, callbackURL);
+            }
+        } catch (IdentityEventException e) {
+            throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_CALLBACK_URL_NOT_VALID,
+                    callbackURL);
+        }
+    }
+
+    /**
+     * Get the callback url from the mpa of properties.
+     *
+     * @param properties Map of properties
+     * @return Callback url
+     * @throws IdentityRecoveryServerException Error while getting the callback url
+     */
+    private String getCallbackURL(Map<String, String> properties) throws IdentityRecoveryServerException {
+
+        String callbackURL = null;
+        try {
+            for (String key : properties.keySet()) {
+                if (IdentityRecoveryConstants.CALLBACK.equals(key)) {
+                    callbackURL = URLDecoder.decode(properties.get(key), IdentityRecoveryConstants.UTF_8);
+                    break;
+                }
+            }
+            if (StringUtils.isNotBlank(callbackURL)) {
+                URI uri = new URI(callbackURL);
+                callbackURL = new URI(uri.getScheme(), uri.getAuthority(), uri.getPath(), null, null).toString();
+            }
+        } catch (UnsupportedEncodingException | URISyntaxException e) {
+            String error = "Error getting callback url";
+            if (log.isDebugEnabled()) {
+                log.debug(error, e);
+            }
+            // Get the new error code to with the scenario prepended the existing error code.
+            String mappedErrorCode = Utils.prependOperationScenarioToErrorCode(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_CALLBACK_URL_NOT_VALID.getCode(),
+                    IdentityRecoveryConstants.USER_ACCOUNT_RECOVERY);
+            throw Utils.handleServerException(mappedErrorCode,
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_CALLBACK_URL_NOT_VALID.getMessage(),
+                    callbackURL);
+        }
+        return callbackURL;
+    }
+}

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/model/NotificationChannel.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/model/NotificationChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/model/NotificationChannel.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/model/NotificationChannel.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.recovery.model;
+
+/**
+ * Model that encapsulates the attributes related to the communication channels.
+ */
+public class NotificationChannel {
+
+    /**
+     * Channel Type (Eg: EMAIL, SMS).
+     */
+    private String type;
+
+    /**
+     * Claim uri of the channel (Eg: http://wso2.org/claims/identity/verifyEmail).
+     */
+    private String claimUri;
+
+    /**
+     * Verified claim uri of the channel (Eg: http://wso2.org/claims/identity/emailVerified).
+     */
+    private String channelVerifiedClaimUri;
+
+    /**
+     * Value of the channel stored at the claim uri (Eg: wso2@gmail.com).
+     */
+    private String channelValue;
+
+    /**
+     * Whether the channel is stored as a user preferred channel to get notifications.
+     */
+    private boolean preferredStatus;
+
+    /**
+     * Notification channel builder.
+     */
+    public NotificationChannel() {
+
+        this.type = "";
+        this.channelVerifiedClaimUri = "";
+        this.claimUri = "";
+        this.channelValue = "";
+        this.preferredStatus = false;
+    }
+
+    /**
+     * Get the verified status of the preferred notification channel.
+     *
+     * @return TRUE if the preferred channel is verified.
+     */
+    public boolean isPreferredStatus() {
+
+        return preferredStatus;
+    }
+
+    /**
+     * Set the verified status of the preferred notification channel.
+     *
+     * @param preferredStatus TRUE if the preferred channel is verified.
+     */
+    public void setPreferredStatus(boolean preferredStatus) {
+
+        this.preferredStatus = preferredStatus;
+    }
+
+    /**
+     * Get Notification channel type.
+     *
+     * @return Notification channel type (Eg: EMAIL or SMS)
+     */
+    public String getType() {
+
+        return type;
+    }
+
+    /**
+     * Set the notification channel type.
+     *
+     * @param type Notification channel type (Eg: EMAIL or SMS)
+     */
+    public void setType(String type) {
+
+        this.type = type;
+    }
+
+    /**
+     * Get notification channel value.
+     *
+     * @return Notification channel value (Eg: user@wso2.com)
+     */
+    public String getChannelValue() {
+
+        return channelValue;
+    }
+
+    /**
+     * Set notification channel value.
+     *
+     * @param channelValue Notification channel value (Eg: user@wso2.com)
+     */
+    public void setChannelValue(String channelValue) {
+
+        this.channelValue = channelValue;
+    }
+
+    /**
+     * Get the value claim uri the notification channel.
+     *
+     * @return Claim uri (Eg: http://wso2.org/claims/emailaddress)
+     */
+    public String getClaimUri() {
+
+        return claimUri;
+    }
+
+    /**
+     * Set the value claim of the notification channel.
+     *
+     * @param claimUri Claim uri (Eg: http://wso2.org/claims/emailaddress)
+     */
+    public void setClaimUri(String claimUri) {
+
+        this.claimUri = claimUri;
+    }
+
+    /**
+     * Get the verified claim of the notification channel.
+     *
+     * @return Verified claim uri (Eg: http://wso2.org/claims/identity/emailVerified)
+     */
+    public String getChannelVerifiedClaimUri() {
+
+        return channelVerifiedClaimUri;
+    }
+
+    /**
+     * Set the verified claim of the notification channel.
+     *
+     * @param channelVerifiedClaimUri Verified claim uri (Eg: http://wso2.org/claims/identity/emailVerified)
+     */
+    public void setChannelVerifiedClaimUri(String channelVerifiedClaimUri) {
+
+        this.channelVerifiedClaimUri = channelVerifiedClaimUri;
+    }
+
+}

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -109,8 +109,8 @@ public class NotificationPasswordRecoveryManager {
         if (!isUserVerified(propertyMap)) {
             if (!isExistingUser(user)) {
 
-                // If the user does not exist, Check for NOTIFY_USER_EXISTENCE property. If the property is not
-                // enabled, notify with an empty NotificationResponseBean.
+                /* If the user does not exist, Check for NOTIFY_USER_EXISTENCE property. If the property is not
+                enabled, notify with an empty NotificationResponseBean.*/
                 boolean notifyUserExistence = Boolean.parseBoolean(
                         IdentityUtil.getProperty(IdentityRecoveryConstants.ConnectorConfig.NOTIFY_USER_EXISTENCE));
                 if (notifyUserExistence) {
@@ -235,10 +235,18 @@ public class NotificationPasswordRecoveryManager {
             throws IdentityRecoveryException {
 
         if (notify == null) {
-            return Boolean.parseBoolean(
+            boolean manageNotificationsInternally = Boolean.parseBoolean(
                     Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE,
                             tenantDomain));
+            if (log.isDebugEnabled()) {
+                log.debug("Notify parameter not in the request. ManageNotificationsInternally set to " +
+                        "server default value: " + manageNotificationsInternally);
+            }
+            return manageNotificationsInternally;
         } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Notify parameter in the request. ManageNotificationsInternally set to : " + notify);
+            }
             return notify;
         }
     }
@@ -304,8 +312,7 @@ public class NotificationPasswordRecoveryManager {
         if (StringUtils.isEmpty(channel)) {
             String defaultNotificationChannel = IdentityGovernanceUtil.getDefaultNotificationChannel();
             if (log.isDebugEnabled()) {
-                String message = String.format("Notification channel is set to : ", defaultNotificationChannel);
-                log.debug(message);
+                log.debug("Notification channel is set to : " + defaultNotificationChannel);
             }
             return defaultNotificationChannel;
         }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -19,6 +19,7 @@
 
 package org.wso2.carbon.identity.recovery.password;
 
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -31,10 +32,13 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.governance.IdentityGovernanceUtil;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
 import org.wso2.carbon.identity.mgt.policy.PolicyViolationException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryServerException;
 import org.wso2.carbon.identity.recovery.RecoveryScenarios;
 import org.wso2.carbon.identity.recovery.RecoverySteps;
 import org.wso2.carbon.identity.recovery.bean.NotificationResponseBean;
@@ -50,10 +54,11 @@ import org.wso2.carbon.user.api.UserStoreManager;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
+import java.security.SecureRandom;
 import java.util.HashMap;
 
 /**
- * Manager class which can be used to recover passwords using a notification
+ * Manager class which can be used to recover passwords using a notification.
  */
 public class NotificationPasswordRecoveryManager {
 
@@ -69,44 +74,292 @@ public class NotificationPasswordRecoveryManager {
         return instance;
     }
 
-    public NotificationResponseBean sendRecoveryNotification(User user, String type, Boolean notify, Property[] properties)
+    /**
+     * Send password recovery information to the user.
+     *
+     * @param user       User
+     * @param type       Notification Type
+     * @param notify     Manage notifications internally
+     * @param properties Meta properties
+     * @return NotificationResponseBean
+     * @throws IdentityRecoveryException Error while sending recovery information.
+     */
+    public NotificationResponseBean sendRecoveryNotification(User user, String type, Boolean notify,
+                                                             Property[] properties)
             throws IdentityRecoveryException {
 
         publishEvent(user, String.valueOf(notify), null, null, properties,
                 IdentityEventConstants.Event.PRE_SEND_RECOVERY_NOTIFICATION);
 
-        if (StringUtils.isBlank(user.getTenantDomain())) {
-            user.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
-            log.info("SendRecoveryNotification :Tenant domain is not in the request. set to default for user : " +
+        // Resolve user attributes.
+        resolveUserAttributes(user);
+        validatePasswordRecoveryConfiguration(user.getTenantDomain());
+        validateCallback(properties, user.getTenantDomain());
+
+        // Build a property map from the properties in the request.
+        HashMap<String, String> propertyMap = buildPropertyMap(properties);
+        String notificationChannel = getNotificationChannelFromProperties(propertyMap);
+
+        // Check whether to manage notifications internally.
+        boolean isNotificationInternallyManage = isNotificationsInternallyManaged(user.getTenantDomain(), notify);
+        if (!isNotificationInternallyManage) {
+            notificationChannel = IdentityRecoveryConstants.EXTERNAL_NOTIFICATION_CHANNEL;
+        }
+        // Check whether the user is already verified ( NOTE: This property is set by the new recovery API).
+        if (!isUserVerified(propertyMap)) {
+            if (!isExistingUser(user)) {
+
+                // If the user does not exist, Check for NOTIFY_USER_EXISTENCE property. If the property is not
+                // enabled, notify with an empty NotificationResponseBean.
+                boolean notifyUserExistence = Boolean.parseBoolean(
+                        IdentityUtil.getProperty(IdentityRecoveryConstants.ConnectorConfig.NOTIFY_USER_EXISTENCE));
+                if (notifyUserExistence) {
+                    throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_USER,
+                            user.getUserName());
+                }
+                return new NotificationResponseBean(user);
+            }
+        }
+        checkAccountLockedStatus(user);
+        UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
+        userRecoveryDataStore.invalidate(user);
+        String secretKey = generateSecretKey(notificationChannel);
+        UserRecoveryData recoveryDataDO = new UserRecoveryData(user, secretKey,
+                RecoveryScenarios.NOTIFICATION_BASED_PW_RECOVERY, RecoverySteps.UPDATE_PASSWORD);
+
+        // Store the notified channel in the recovery object for future reference.
+        recoveryDataDO.setRemainingSetIds(notificationChannel);
+        userRecoveryDataStore.store(recoveryDataDO);
+        NotificationResponseBean notificationResponseBean = new NotificationResponseBean(user);
+        if (isNotificationInternallyManage) {
+
+            // Manage notifications by the identity server.
+            String eventName = Utils.resolveEventName(notificationChannel);
+            triggerNotification(user, notificationChannel, IdentityRecoveryConstants.NOTIFICATION_TYPE_PASSWORD_RESET,
+                    secretKey, eventName, properties);
+        } else {
+            // Set password recovery key since the notifications are managed by an external mechanism.
+            notificationResponseBean.setKey(secretKey);
+        }
+        publishEvent(user, String.valueOf(notify), null, null, properties,
+                IdentityEventConstants.Event.POST_SEND_RECOVERY_NOTIFICATION);
+        return notificationResponseBean;
+    }
+
+    /**
+     * Generate a secret key according to the given channel. Method will generate an OTP for mobile channel and a
+     * UUID for other channels.
+     *
+     * @param channel Recovery notification channel.
+     * @return Secret key
+     */
+    private String generateSecretKey(String channel) {
+
+        if (IdentityRecoveryConstants.SMS_CHANNEL.equals(channel)) {
+            return generateSMSOTP();
+        } else {
+            return UUIDGenerator.generateUUID();
+        }
+    }
+
+    /**
+     * Generate an OTP for password recovery via mobile Channel.
+     *
+     * @return OTP
+     */
+    private String generateSMSOTP() {
+
+        char[] chars = IdentityRecoveryConstants.SMS_OTP_GENERATE_CHAR_SET.toCharArray();
+        SecureRandom rnd = new SecureRandom();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < IdentityRecoveryConstants.SMS_OTP_CODE_LENGTH; i++) {
+            sb.append(chars[rnd.nextInt(chars.length)]);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Check whether the account is locked or disabled.
+     *
+     * @param user User
+     * @throws IdentityRecoveryException If account is in locked or disabled status
+     */
+    private void checkAccountLockedStatus(User user) throws IdentityRecoveryException {
+
+        if (Utils.isAccountDisabled(user)) {
+            throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_DISABLED_ACCOUNT,
+                    user.getUserName());
+        } else if (Utils.isAccountLocked(user)) {
+            throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_LOCKED_ACCOUNT,
                     user.getUserName());
         }
+    }
 
-        if (StringUtils.isBlank(user.getUserStoreDomain())) {
-            user.setUserStoreDomain(IdentityUtil.getPrimaryDomainName());
-            log.info("SendRecoveryNotification :User store domain is not in the request. set to default for user" +
-                    " : " + user.getUserName());
+    /**
+     * Check for user existence.
+     *
+     * @param user User
+     * @return True if the user exists
+     * @throws IdentityRecoveryException Error while checking user existence
+     */
+    private boolean isExistingUser(User user) throws IdentityRecoveryException {
+
+        try {
+            int tenantId = IdentityTenantUtil.getTenantId(user.getTenantDomain());
+            UserStoreManager userStoreManager;
+            userStoreManager = IdentityRecoveryServiceDataHolder.getInstance().getRealmService().
+                    getTenantUserRealm(tenantId).getUserStoreManager();
+            String domainQualifiedUsername = IdentityUtil
+                    .addDomainToName(user.getUserName(), user.getUserStoreDomain());
+            if (!userStoreManager.isExistingUser(domainQualifiedUsername)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("No user found for recovery with username: " + user.toFullQualifiedUsername());
+                }
+                return false;
+            }
+            return true;
+        } catch (UserStoreException e) {
+            throw Utils.handleServerException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_UNEXPECTED, null, e);
         }
+    }
 
-        boolean isRecoveryEnable = Boolean.parseBoolean(Utils.getRecoveryConfigs(IdentityRecoveryConstants
-                .ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY, user.getTenantDomain()));
-        if (!isRecoveryEnable) {
-            throw Utils.handleClientException(
-                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NOTIFICATION_BASED_PASSWORD_RECOVERY_NOT_ENABLE, null);
-        }
+    /**
+     * Check whether notifications are internally managed.
+     *
+     * @param tenantDomain Tenant Domain
+     * @param notify       Manage notifications internally
+     * @return True of the notifications are internally managed
+     * @throws IdentityRecoveryException Error while checking for configurations
+     */
+    private boolean isNotificationsInternallyManaged(String tenantDomain, Boolean notify)
+            throws IdentityRecoveryException {
 
-        boolean isNotificationInternallyManage;
         if (notify == null) {
-            isNotificationInternallyManage = Boolean.parseBoolean(Utils.getRecoveryConfigs
-                    (IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE, user.getTenantDomain()));
+            return Boolean.parseBoolean(
+                    Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE,
+                            tenantDomain));
         } else {
-            isNotificationInternallyManage = notify;
+            return notify;
         }
+    }
 
-        // Callback URL validation
+    /**
+     * Check whether the VERIFIED_USER_PROPERTY_KEY set to TRUE or FALSE in the property map. If the property is not
+     * set, return FALSE.
+     *
+     * @param propertyMap Properties
+     * @return TRUE if the user is already verified.
+     */
+    private boolean isUserVerified(HashMap<String, String> propertyMap) {
+
+        if (MapUtils.isNotEmpty(propertyMap)) {
+            String verified = propertyMap.get(IdentityRecoveryConstants.VERIFIED_USER_PROPERTY_KEY);
+            if (StringUtils.isNotEmpty(verified)) {
+                try {
+                    return Boolean.parseBoolean(verified);
+                } catch (NumberFormatException e) {
+                    if (log.isDebugEnabled()) {
+                        String message = String
+                                .format("Value : %s given for property : %s is not a boolean. Therefore, "
+                                                + "returning false for the property.", verified,
+                                        IdentityRecoveryConstants.VERIFIED_USER_PROPERTY_KEY);
+                        log.debug(message);
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Get notification channel from a given map properties.
+     *
+     * @param propertyMap Properties
+     * @return Notification channel
+     */
+    private String getNotificationChannelFromProperties(HashMap<String, String> propertyMap) {
+
+        if (MapUtils.isEmpty(propertyMap)) {
+            String defaultNotificationChannel = IdentityGovernanceUtil.getDefaultNotificationChannel();
+            if (log.isDebugEnabled()) {
+                String message =
+                        "No notification channel in the request properties. Configuring the notification channel" +
+                                " to the default notification channel: " + defaultNotificationChannel;
+                log.debug(message);
+            }
+            return defaultNotificationChannel;
+        }
+        String notificationChannel = propertyMap.get(IdentityRecoveryConstants.NOTIFICATION_CHANNEL_PROPERTY_KEY);
+        return getServerSupportedNotificationChannel(notificationChannel);
+    }
+
+    /**
+     * Get server supported notification channel.
+     *
+     * @param channel Notification channel
+     * @return Server supported notification channel
+     */
+    private String getServerSupportedNotificationChannel(String channel) {
+
+        if (StringUtils.isEmpty(channel)) {
+            String defaultNotificationChannel = IdentityGovernanceUtil.getDefaultNotificationChannel();
+            if (log.isDebugEnabled()) {
+                String message = String.format("Notification channel is set to : ", defaultNotificationChannel);
+                log.debug(message);
+            }
+            return defaultNotificationChannel;
+        }
+        // Validate notification channels.
+        if (NotificationChannels.EMAIL_CHANNEL.getChannelType().equals(channel)) {
+            return channel;
+        } else if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(channel)) {
+            return channel;
+        } else if (NotificationChannels.EXTERNAL_CHANNEL.getChannelType().equals(channel)) {
+            return channel;
+        } else {
+            String defaultNotificationChannel = IdentityGovernanceUtil.getDefaultNotificationChannel();
+            if (log.isDebugEnabled()) {
+                String message = String.format("Not a server supported notification channel : %s. Therefore "
+                                + "default notification channel : %s will be used.", channel,
+                        defaultNotificationChannel);
+                log.debug(message);
+            }
+            return defaultNotificationChannel;
+        }
+    }
+
+    /**
+     * Build a map of properties.
+     *
+     * @param properties Property list
+     * @return Properties
+     */
+    private HashMap<String, String> buildPropertyMap(Property[] properties) {
+
+        HashMap<String, String> propertyMap = new HashMap<>();
+        if (properties != null && properties.length > 0) {
+            for (Property property : properties) {
+                if (StringUtils.isNotEmpty(property.getKey())) {
+                    propertyMap.put(property.getKey(), property.getValue());
+                }
+            }
+        }
+        return propertyMap;
+    }
+
+    /**
+     * Validate the callback Url.
+     *
+     * @param properties   Properties
+     * @param tenantDomain Tenant Domain
+     * @throws IdentityRecoveryServerException Error validating the callback
+     */
+    private void validateCallback(Property[] properties, String tenantDomain) throws IdentityRecoveryServerException {
+
         String callbackURL = null;
         try {
             callbackURL = Utils.getCallbackURL(properties);
-            if (StringUtils.isNotBlank(callbackURL) && !Utils.validateCallbackURL(callbackURL, user.getTenantDomain(),
+            if (StringUtils.isNotBlank(callbackURL) && !Utils.validateCallbackURL(callbackURL, tenantDomain,
                     IdentityRecoveryConstants.ConnectorConfig.RECOVERY_CALLBACK_REGEX)) {
                 throw Utils.handleServerException(
                         IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_CALLBACK_URL_NOT_VALID, callbackURL);
@@ -115,151 +368,205 @@ public class NotificationPasswordRecoveryManager {
             throw Utils.handleServerException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_CALLBACK_URL_NOT_VALID,
                     callbackURL);
         }
-
-        UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
-        int tenantId = IdentityTenantUtil.getTenantId(user.getTenantDomain());
-        UserStoreManager userStoreManager;
-        try {
-            userStoreManager = IdentityRecoveryServiceDataHolder.getInstance().getRealmService().
-                    getTenantUserRealm(tenantId).getUserStoreManager();
-            String domainQualifiedUsername = IdentityUtil.addDomainToName(user.getUserName(), user.getUserStoreDomain());
-            if (!userStoreManager.isExistingUser(domainQualifiedUsername)) {
-                if (log.isDebugEnabled()) {
-                    log.debug("No user found for recovery with username: " + user.toFullQualifiedUsername());
-                }
-                boolean notifyUserExistence = Boolean.parseBoolean(IdentityUtil.getProperty
-                        (IdentityRecoveryConstants.ConnectorConfig.NOTIFY_USER_EXISTENCE));
-
-                if (notifyUserExistence) {
-                    throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_USER, user
-                            .getUserName());
-                }
-                return new NotificationResponseBean(user);
-            }
-
-        } catch (UserStoreException e) {
-            throw Utils.handleServerException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_UNEXPECTED, null, e);
-        }
-
-        if (Utils.isAccountDisabled(user)) {
-            throw Utils.handleClientException(
-                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_DISABLED_ACCOUNT, user.getUserName());
-        } else if (Utils.isAccountLocked(user)) {
-            throw Utils.handleClientException(
-                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_LOCKED_ACCOUNT, user.getUserName());
-        }
-
-        userRecoveryDataStore.invalidate(user);
-
-        String secretKey = UUIDGenerator.generateUUID();
-        UserRecoveryData recoveryDataDO = new UserRecoveryData(user, secretKey, RecoveryScenarios
-                .NOTIFICATION_BASED_PW_RECOVERY, RecoverySteps.UPDATE_PASSWORD);
-
-        userRecoveryDataStore.store(recoveryDataDO);
-        NotificationResponseBean notificationResponseBean = new NotificationResponseBean(user);
-
-        if (isNotificationInternallyManage) {
-            triggerNotification(user, IdentityRecoveryConstants.NOTIFICATION_TYPE_PASSWORD_RESET, secretKey, properties);
-        } else {
-            notificationResponseBean.setKey(secretKey);
-        }
-
-        publishEvent(user, String.valueOf(notify), null, null, properties,
-                IdentityEventConstants.Event.POST_SEND_RECOVERY_NOTIFICATION);
-        return notificationResponseBean;
     }
 
-    public void updatePassword(String code, String password, Property[] properties) throws IdentityRecoveryException, IdentityEventException {
+    /**
+     * Verify whether password recovery is enabled for the tenant domain.
+     *
+     * @param tenantDomain String tenant domain
+     * @throws IdentityRecoveryException Error while validating configurations
+     */
+    private void validatePasswordRecoveryConfiguration(String tenantDomain) throws IdentityRecoveryException {
+
+        boolean isRecoveryEnable = Boolean.parseBoolean(
+                Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY,
+                        tenantDomain));
+        if (!isRecoveryEnable) {
+            throw Utils.handleClientException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NOTIFICATION_BASED_PASSWORD_RECOVERY_NOT_ENABLE,
+                    null);
+        }
+    }
+
+    /**
+     * Resolve tenant domain and user store domain of the user.
+     *
+     * @param user User
+     */
+    private void resolveUserAttributes(User user) {
+
+        if (StringUtils.isBlank(user.getTenantDomain())) {
+            user.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+            log.info("SendRecoveryNotification :Tenant domain is not in the request. set to default for user : "
+                    + user.getUserName());
+        }
+        if (StringUtils.isBlank(user.getUserStoreDomain())) {
+            user.setUserStoreDomain(IdentityUtil.getPrimaryDomainName());
+            log.info(
+                    "SendRecoveryNotification : User store domain is not in the request. set to default for user : "
+                            + user.getUserName());
+        }
+    }
+
+    /**
+     * Update the password of the user.
+     *
+     * @param code       Password Reset code
+     * @param password   New password
+     * @param properties Properties
+     * @throws IdentityRecoveryException Error while updating the password
+     * @throws IdentityEventException    Error while updating the password
+     */
+    public void updatePassword(String code, String password, Property[] properties)
+            throws IdentityRecoveryException, IdentityEventException {
 
         UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
         UserRecoveryData userRecoveryData = userRecoveryDataStore.load(code);
-
-        String contextTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-        String userTenantDomain = userRecoveryData.getUser().getTenantDomain();
-
-        // Callback URL validation
-        String callbackURL = null;
-        try {
-            callbackURL = Utils.getCallbackURL(properties);
-            boolean isUserPortalURL = Utils.isUserPortalURL(properties);
-            if (!isUserPortalURL && StringUtils.isNotBlank(callbackURL) && !Utils.validateCallbackURL(callbackURL,
-                    userTenantDomain, IdentityRecoveryConstants.ConnectorConfig.RECOVERY_CALLBACK_REGEX)) {
-                throw Utils.handleServerException(
-                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_CALLBACK_URL_NOT_VALID, callbackURL);
-            }
-        } catch (URISyntaxException | UnsupportedEncodingException | IdentityEventException e) {
-            throw Utils.handleServerException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_CALLBACK_URL_NOT_VALID,
-                    callbackURL);
-        }
-
+        validateCallback(properties, userRecoveryData.getUser().getTenantDomain());
         publishEvent(userRecoveryData.getUser(), null, code, password, properties,
                 IdentityEventConstants.Event.PRE_ADD_NEW_PASSWORD);
+        validateTenantDomain(userRecoveryData.getUser());
 
-        if (!StringUtils.equals(contextTenantDomain, userTenantDomain)) {
-            throw new IdentityRecoveryClientException("invalid tenant domain: " + userTenantDomain);
-        }
-        //if return data from load method, it means the code is validated. Otherwise it returns exceptions
-
+        // Validate recovery step.
         if (!RecoverySteps.UPDATE_PASSWORD.equals(userRecoveryData.getRecoveryStep())) {
             throw Utils.handleClientException(
-                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CODE, null);
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CODE, code);
         }
-
-        int tenantId = IdentityTenantUtil.getTenantId(userRecoveryData.getUser().getTenantDomain());
+        // Get the notification channel.
+        String notificationChannel = getServerSupportedNotificationChannel(userRecoveryData.getRemainingSetIds());
+        boolean notificationsInternallyManaged = Boolean.parseBoolean(
+                Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE,
+                        userRecoveryData.getUser().getTenantDomain()));
+        boolean isNotificationSendWhenSuccess = Boolean.parseBoolean(Utils.getRecoveryConfigs(
+                IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_SEND_RECOVERY_NOTIFICATION_SUCCESS,
+                userRecoveryData.getUser().getTenantDomain()));
         String domainQualifiedName = IdentityUtil.addDomainToName(userRecoveryData.getUser().getUserName(),
                 userRecoveryData.getUser().getUserStoreDomain());
 
-        boolean isNotificationInternallyManaged = Boolean.parseBoolean(Utils.getRecoveryConfigs
-                (IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE, userRecoveryData.getUser().
-                        getTenantDomain()));
-        try {
-
-            UserStoreManager userStoreManager = IdentityRecoveryServiceDataHolder.getInstance().getRealmService().
-                    getTenantUserRealm(tenantId).getUserStoreManager();
-            userStoreManager.updateCredentialByAdmin(domainQualifiedName, password);
-            HashMap<String, String> userClaims = new HashMap<>();
-            if (RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_EMAIL_LINK.equals
-                    (userRecoveryData.getRecoveryScenario()) || RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_OTP.
-                    equals(userRecoveryData.getRecoveryScenario())) {
-                userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.FALSE.toString());
-            }
-            if (isNotificationInternallyManaged) {
-                userClaims.put(IdentityRecoveryConstants.EMAIL_VERIFIED_CLAIM, Boolean.TRUE.toString());
-                if (Utils.isAccountStateClaimExisting(userTenantDomain)) {
-                    userClaims.put(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI,
-                            IdentityRecoveryConstants.ACCOUNT_STATE_UNLOCKED);
-                }
-            }
-            userStoreManager.setUserClaimValues(domainQualifiedName, userClaims, null);
-        } catch (UserStoreException e) {
-            checkPasswordValidity(e, userRecoveryData.getUser());
-            throw Utils.handleServerException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_UNEXPECTED, null, e);
-        }
-
-        userRecoveryDataStore.invalidate(code);
-
-        boolean isNotificationSendWhenSuccess = Boolean.parseBoolean(Utils.getRecoveryConfigs
-                (IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_SEND_RECOVERY_NOTIFICATION_SUCCESS,
-                        userRecoveryData.getUser().getTenantDomain()));
-
-        if (isNotificationInternallyManaged && isNotificationSendWhenSuccess) {
+        // Update the password.
+        updateNewPassword(userRecoveryData.getUser(), password, domainQualifiedName, userRecoveryData,
+                notificationsInternallyManaged);
+        userRecoveryDataStore.invalidate(userRecoveryData.getUser());
+        if (notificationsInternallyManaged && isNotificationSendWhenSuccess
+                && !IdentityRecoveryConstants.EXTERNAL_NOTIFICATION_CHANNEL.equals(notificationChannel)) {
             try {
-                triggerNotification(userRecoveryData.getUser(), IdentityRecoveryConstants
-                        .NOTIFICATION_TYPE_PASSWORD_RESET_SUCCESS, null, properties);
+                String eventName = Utils.resolveEventName(notificationChannel);
+                triggerNotification(userRecoveryData.getUser(), notificationChannel,
+                        IdentityRecoveryConstants.NOTIFICATION_TYPE_PASSWORD_RESET_SUCCESS, StringUtils.EMPTY,
+                        eventName, properties);
             } catch (Exception e) {
                 log.warn("Error while sending password reset success notification to user :" + userRecoveryData.
                         getUser().getUserName());
             }
         }
-
         publishEvent(userRecoveryData.getUser(), null, code, password, properties,
                 IdentityEventConstants.Event.POST_ADD_NEW_PASSWORD);
-
         if (log.isDebugEnabled()) {
             String msg = "Password is updated for  user: " + domainQualifiedName;
             log.debug(msg);
         }
+    }
 
+    /**
+     * Update the new password of the user.
+     *
+     * @param user                            User
+     * @param password                        New password
+     * @param domainQualifiedName             Domain qualified name
+     * @param userRecoveryData                User recovery data
+     * @param isNotificationInternallyManaged Whether the notifications are internally managed.
+     * @throws IdentityRecoveryException Error while checking for account state claim
+     * @throws IdentityRecoveryException Error while updating the password
+     */
+    private void updateNewPassword(User user, String password, String domainQualifiedName,
+                                   UserRecoveryData userRecoveryData,
+                                   boolean isNotificationInternallyManaged)
+            throws IdentityEventException, IdentityRecoveryException {
+
+        try {
+            int tenantId = IdentityTenantUtil.getTenantId(userRecoveryData.getUser().getTenantDomain());
+            UserStoreManager userStoreManager = IdentityRecoveryServiceDataHolder.getInstance().getRealmService().
+                    getTenantUserRealm(tenantId).getUserStoreManager();
+            userStoreManager.updateCredentialByAdmin(domainQualifiedName, password);
+
+            // Get the claims that related to a password reset.
+            HashMap<String, String> userClaims = getAccountStateClaims(userRecoveryData,
+                    isNotificationInternallyManaged);
+            if (userClaims != null && !userClaims.isEmpty()) {
+
+                // Update the retrieved claims set.
+                userStoreManager.setUserClaimValues(domainQualifiedName, userClaims, null);
+            }
+        } catch (UserStoreException e) {
+            checkPasswordValidity(e, user);
+            if (log.isDebugEnabled()) {
+                log.debug("NotificationPasswordRecoveryManager: Unexpected Error occurred while updating password "
+                        + "for the user: " + domainQualifiedName, e);
+            }
+            throw Utils.handleServerException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_UNEXPECTED, null, e);
+        }
+    }
+
+    /**
+     * Get the claims that needs to be updated when a user attempts a password reset.
+     *
+     * @param userRecoveryData                User recovery data
+     * @param isNotificationInternallyManaged Whether the notifications are internally managed
+     * @return Claims that are related to account state
+     * @throws IdentityEventException Error while checking for account state claim
+     */
+    private HashMap<String, String> getAccountStateClaims(UserRecoveryData userRecoveryData,
+                                                          boolean isNotificationInternallyManaged)
+            throws IdentityEventException {
+
+        HashMap<String, String> userClaims = new HashMap<>();
+
+        // If the scenario is initiated by the admin, set the account locked claim to TRUE.
+        if (RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_EMAIL_LINK.equals(userRecoveryData.getRecoveryScenario())
+                || RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_OTP.
+                equals(userRecoveryData.getRecoveryScenario())) {
+            userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.FALSE.toString());
+        }
+        // If notifications are internally managed we try to set the verified claims since this is an opportunity
+        // to verify a user channel.
+        if (isNotificationInternallyManaged) {
+            if (IdentityRecoveryConstants.EMAIL_CHANNEL.equals(userRecoveryData.getRemainingSetIds())) {
+                userClaims.put(IdentityRecoveryConstants.EMAIL_VERIFIED_CLAIM, Boolean.TRUE.toString());
+            } else if (IdentityRecoveryConstants.SMS_CHANNEL.equals(userRecoveryData.getRemainingSetIds())) {
+                userClaims.put(IdentityRecoveryConstants.MOBILE_VERIFIED_CLAIM, Boolean.TRUE.toString());
+            } else {
+                if (log.isDebugEnabled()) {
+                    String error = String
+                            .format("No notification channels for the user : %s in tenant domain : " + "%s",
+                                    userRecoveryData.getUser().getUserStoreDomain() + userRecoveryData.getUser()
+                                            .getUserName(), userRecoveryData.getUser().getTenantDomain());
+                    log.debug(error);
+                }
+                userClaims.put(IdentityRecoveryConstants.EMAIL_VERIFIED_CLAIM, Boolean.TRUE.toString());
+            }
+            if (Utils.isAccountStateClaimExisting(userRecoveryData.getUser().getTenantDomain())) {
+                userClaims.put(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI,
+                        IdentityRecoveryConstants.ACCOUNT_STATE_UNLOCKED);
+            }
+        }
+        return userClaims;
+    }
+
+    /**
+     * Validate Tenant domain of the user with the domain in the context.
+     *
+     * @param user User
+     * @throws IdentityRecoveryClientException Tenant domain miss match
+     */
+    private void validateTenantDomain(User user) throws IdentityRecoveryClientException {
+
+        String contextTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        String userTenantDomain = user.getTenantDomain();
+        if (!StringUtils.equals(contextTenantDomain, userTenantDomain)) {
+            throw new IdentityRecoveryClientException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_USER_TENANT_DOMAIN_MISS_MATCH_WITH_CONTEXT
+                            .getCode(), "invalid tenant domain: " + userTenantDomain);
+        }
     }
 
     private void checkPasswordValidity(UserStoreException e, User user) throws IdentityRecoveryClientException {
@@ -285,20 +592,28 @@ public class NotificationPasswordRecoveryManager {
 
     }
 
-    private void triggerNotification(User user, String type, String code, Property[] metaProperties) throws
-            IdentityRecoveryException {
-
-        String eventName = IdentityEventConstants.Event.TRIGGER_NOTIFICATION;
+    /**
+     * Trigger notification to send userName recovery information.
+     *
+     * @param user                User
+     * @param notificationChannel Notification channel
+     * @param templateName        Notification Template name
+     * @param code                Secret key
+     * @param eventName           Event name
+     * @param metaProperties      Meta properties to be send with the notification.
+     * @throws IdentityRecoveryException Error while triggering notification.
+     */
+    private void triggerNotification(User user, String notificationChannel, String templateName, String code,
+                                     String eventName, Property[] metaProperties) throws IdentityRecoveryException {
 
         HashMap<String, Object> properties = new HashMap<>();
         properties.put(IdentityEventConstants.EventProperty.USER_NAME, user.getUserName());
         properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, user.getTenantDomain());
         properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, user.getUserStoreDomain());
-
+        properties.put(IdentityEventConstants.EventProperty.NOTIFICATION_CHANNEL, notificationChannel);
         if (StringUtils.isNotBlank(code)) {
             properties.put(IdentityRecoveryConstants.CONFIRMATION_CODE, code);
         }
-
         if (metaProperties != null) {
             for (Property metaProperty : metaProperties) {
                 if (StringUtils.isNotBlank(metaProperty.getValue()) && StringUtils.isNotBlank(metaProperty.getKey())) {
@@ -306,8 +621,7 @@ public class NotificationPasswordRecoveryManager {
                 }
             }
         }
-
-        properties.put(IdentityRecoveryConstants.TEMPLATE_TYPE, type);
+        properties.put(IdentityRecoveryConstants.TEMPLATE_TYPE, templateName);
         Event identityMgtEvent = new Event(eventName, properties);
         try {
             IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -397,14 +397,17 @@ public class NotificationPasswordRecoveryManager {
 
         if (StringUtils.isBlank(user.getTenantDomain())) {
             user.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
-            log.info("SendRecoveryNotification :Tenant domain is not in the request. set to default for user : "
-                    + user.getUserName());
+            if (log.isDebugEnabled()) {
+                log.debug("SendRecoveryNotification :Tenant domain is not in the request. set to default for " +
+                        "user : " + user.getUserName());
+            }
         }
         if (StringUtils.isBlank(user.getUserStoreDomain())) {
             user.setUserStoreDomain(IdentityUtil.getPrimaryDomainName());
-            log.info(
-                    "SendRecoveryNotification : User store domain is not in the request. set to default for user : "
-                            + user.getUserName());
+            if (log.isDebugEnabled()) {
+                log.debug("SendRecoveryNotification : User store domain is not in the request. set to " +
+                        "default for user : " + user.getUserName());
+            }
         }
     }
 
@@ -454,8 +457,8 @@ public class NotificationPasswordRecoveryManager {
                 triggerNotification(userRecoveryData.getUser(), notificationChannel,
                         IdentityRecoveryConstants.NOTIFICATION_TYPE_PASSWORD_RESET_SUCCESS, StringUtils.EMPTY,
                         eventName, properties);
-            } catch (Exception e) {
-                log.warn("Error while sending password reset success notification to user :" + userRecoveryData.
+            } catch (IdentityRecoveryException e) {
+                log.error("Error while sending password reset success notification to user :" + userRecoveryData.
                         getUser().getUserName());
             }
         }
@@ -492,8 +495,7 @@ public class NotificationPasswordRecoveryManager {
             // Get the claims that related to a password reset.
             HashMap<String, String> userClaims = getAccountStateClaims(userRecoveryData,
                     isNotificationInternallyManaged);
-            if (userClaims != null && !userClaims.isEmpty()) {
-
+            if (MapUtils.isNotEmpty(userClaims)) {
                 // Update the retrieved claims set.
                 userStoreManager.setUserClaimValues(domainQualifiedName, userClaims, null);
             }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -20,6 +20,7 @@
 package org.wso2.carbon.identity.recovery.password;
 
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -344,7 +345,7 @@ public class NotificationPasswordRecoveryManager {
     private HashMap<String, String> buildPropertyMap(Property[] properties) {
 
         HashMap<String, String> propertyMap = new HashMap<>();
-        if (properties != null && properties.length > 0) {
+        if (ArrayUtils.isNotEmpty(properties)) {
             for (Property property : properties) {
                 if (StringUtils.isNotEmpty(property.getKey())) {
                     propertyMap.put(property.getKey(), property.getValue());

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/services/password/PasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/services/password/PasswordRecoveryManager.java
@@ -1,6 +1,5 @@
 /*
- *
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/services/password/PasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/services/password/PasswordRecoveryManager.java
@@ -1,0 +1,99 @@
+/*
+ *
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.recovery.services.password;
+
+import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
+import org.wso2.carbon.identity.recovery.dto.PasswordRecoverDTO;
+import org.wso2.carbon.identity.recovery.dto.PasswordResetCodeDTO;
+import org.wso2.carbon.identity.recovery.dto.RecoveryInformationDTO;
+import org.wso2.carbon.identity.recovery.dto.ResendConfirmationDTO;
+import org.wso2.carbon.identity.recovery.dto.SuccessfulPasswordResetDTO;
+
+import java.util.Map;
+
+/**
+ * Service Interface for password recovery.
+ */
+public interface PasswordRecoveryManager {
+
+    /**
+     * Get the username recovery information with available verified channel details.
+     *
+     * @param claims       User Claims
+     * @param tenantDomain Tenant domain
+     * @param properties   Meta properties
+     * @return RecoveryInformationDTO {@link RecoveryInformationDTO} object that contains
+     * recovery information of a  verified user
+     * @throws IdentityRecoveryException Error while initiating password recovery
+     */
+    RecoveryInformationDTO initiate(Map<String, String> claims, String tenantDomain, Map<String, String> properties)
+            throws IdentityRecoveryException;
+
+    /**
+     * Verify the recovery code and send recovery information via channel which matches the given channel id.
+     *
+     * @param recoveryId   RecoveryId of the user
+     * @param channelId    Channel Id of the user
+     * @param tenantDomain Tenant Domain
+     * @param properties   Meta properties in the recovery request
+     * @return UsernameRecoverDTO {@link PasswordRecoverDTO} object that contains notified
+     * channel details and success status code
+     * @throws IdentityRecoveryException Error while notifying user
+     */
+    PasswordRecoverDTO notify(String recoveryId, String channelId, String tenantDomain, Map<String, String> properties)
+            throws IdentityRecoveryException;
+
+    /**
+     * Validate the confirmation code given for password recovery and return the password reset token.
+     *
+     * @param confirmationCode Confirmation code
+     * @param tenantDomain     Tenant domain
+     * @param properties       Meta properties in the confirmation request
+     * @return PasswordResetCodeDTO {@link PasswordResetCodeDTO} object which contains password reset code
+     * @throws IdentityRecoveryException Error while confirming password recovery
+     */
+    PasswordResetCodeDTO confirm(String confirmationCode, String tenantDomain, Map<String, String> properties)
+            throws IdentityRecoveryException;
+
+    /**
+     * Update the password for password recovery, if the password reset code is valid.
+     *
+     * @param resetCode  Password reset code
+     * @param password   New password
+     * @param properties Properties
+     * @return SuccessfulPasswordResetDTO {@link SuccessfulPasswordResetDTO} object which contain the information
+     * for a successful password update
+     * @throws IdentityRecoveryException Error while resetting the password
+     */
+    SuccessfulPasswordResetDTO reset(String resetCode, char[] password, Map<String, String> properties)
+            throws IdentityRecoveryException;
+
+    /**
+     * Resend the password recovery information to the user via user specified channel.
+     *
+     * @param tenantDomain Tenant Domain
+     * @param resendCode   Resend code
+     * @param properties   Meta properties
+     * @return ResendConfirmationDTO {@link ResendConfirmationDTO} which wraps the information for a successful
+     * recovery information resend
+     * @throws IdentityRecoveryException Error while sending recovery information
+     */
+    ResendConfirmationDTO resend(String tenantDomain, String resendCode, Map<String, String> properties)
+            throws IdentityRecoveryException;
+}

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/services/username/UsernameRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/services/username/UsernameRecoveryManager.java
@@ -1,0 +1,58 @@
+/*
+ *
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.recovery.services.username;
+
+import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
+import org.wso2.carbon.identity.recovery.dto.RecoveryInformationDTO;
+import org.wso2.carbon.identity.recovery.dto.UsernameRecoverDTO;
+
+import java.util.Map;
+
+/**
+ * Service Interface for username recovery.
+ */
+public interface UsernameRecoveryManager {
+
+    /**
+     * Get the username recovery information with available verified channel details.
+     *
+     * @param claims       User Claims
+     * @param tenantDomain Tenant domain
+     * @param properties   Meta properties
+     * @return RecoveryInformationDTO {@link RecoveryInformationDTO} object that contains
+     * recovery information of a  verified user
+     * @throws IdentityRecoveryException Error while initiating username recovery
+     */
+    RecoveryInformationDTO initiate(Map<String, String> claims, String tenantDomain, Map<String, String> properties)
+            throws IdentityRecoveryException;
+
+    /**
+     * Verify the recovery code and send recovery information via channel which matches the given channel id.
+     *
+     * @param recoveryId   RecoveryId of the user
+     * @param channelId    Channel Id of the user
+     * @param tenantDomain Tenant Domain
+     * @param properties   Meta properties in the recovery request
+     * @return UsernameRecoverDTO {@link UsernameRecoverDTO} object that contains notified
+     * channel details and success status code
+     * @throws IdentityRecoveryException Error while notifying user
+     */
+    UsernameRecoverDTO notify(String recoveryId, String channelId, String tenantDomain, Map<String, String> properties)
+            throws IdentityRecoveryException;
+}

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/services/username/UsernameRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/services/username/UsernameRecoveryManager.java
@@ -1,6 +1,5 @@
 /*
- *
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/username/NotificationUsernameRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/username/NotificationUsernameRecoveryManager.java
@@ -19,7 +19,6 @@
 
 package org.wso2.carbon.identity.recovery.username;
 
-import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -29,27 +28,19 @@ import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.core.IdentityClaimManager;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
-import org.wso2.carbon.identity.event.IdentityEventConstants;
-import org.wso2.carbon.identity.event.IdentityEventException;
-import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryServerException;
 import org.wso2.carbon.identity.recovery.dto.RecoveryInformationDTO;
-import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
-import org.wso2.carbon.identity.recovery.internal.service.impl.username.DefaultUsernameRecoveryManager;
+import org.wso2.carbon.identity.recovery.internal.service.impl.username.UsernameRecoveryManagerImpl;
 import org.wso2.carbon.identity.recovery.model.UserClaim;
 import org.wso2.carbon.identity.recovery.util.Utils;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
-import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.claim.Claim;
-import org.wso2.carbon.user.core.service.RealmService;
-import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,7 +54,7 @@ public class NotificationUsernameRecoveryManager {
     private static final String FORWARD_SLASH = "/";
 
     private static NotificationUsernameRecoveryManager instance = new NotificationUsernameRecoveryManager();
-    private static DefaultUsernameRecoveryManager defaultUsernameRecoveryManager = new DefaultUsernameRecoveryManager();
+    private static UsernameRecoveryManagerImpl usernameRecoveryManagerImpl = new UsernameRecoveryManagerImpl();
 
     private NotificationUsernameRecoveryManager() {
 
@@ -191,7 +182,7 @@ public class NotificationUsernameRecoveryManager {
             properties.put(IdentityRecoveryConstants.USE_LEGACY_API_PROPERTY_KEY, Boolean.toString(true));
             properties.put(IdentityRecoveryConstants.MANAGE_NOTIFICATIONS_INTERNALLY_PROPERTY_KEY,
                     Boolean.toString(manageNotificationsInternally));
-            return defaultUsernameRecoveryManager.initiate(claims, tenantDomain, properties);
+            return usernameRecoveryManagerImpl.initiate(claims, tenantDomain, properties);
         } catch (IdentityRecoveryServerException exception) {
             if (StringUtils.isNotEmpty(exception.getErrorCode())) {
                 String errorCode = exception.getErrorCode();

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/username/NotificationUsernameRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/username/NotificationUsernameRecoveryManager.java
@@ -156,7 +156,6 @@ public class NotificationUsernameRecoveryManager {
         // Resolve notification internally managed status.
         boolean isNotificationInternallyManaged = isNotificationsInternallyManaged(tenantDomain, notify);
         HashMap<String, String> userClaims = buildUserClaimsMap(claims);
-
         // Validate the claims.
         if (claims.length < 1) {
             throw Utils.handleClientException(
@@ -196,7 +195,6 @@ public class NotificationUsernameRecoveryManager {
         } catch (IdentityRecoveryServerException exception) {
             if (StringUtils.isNotEmpty(exception.getErrorCode())) {
                 String errorCode = exception.getErrorCode();
-
                 // Userstore not found error.
                 if (IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_ERROR_GETTING_USERSTORE_MANAGER.getCode()
                         .equals(errorCode)) {
@@ -214,7 +212,6 @@ public class NotificationUsernameRecoveryManager {
         } catch (IdentityRecoveryClientException exception) {
             if (StringUtils.isNotEmpty(exception.getErrorCode())) {
                 String errorCode = exception.getErrorCode();
-
                 // Multiple users matched error.
                 if (IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_MULTIPLE_MATCHING_USERS.getCode()
                         .equals(errorCode)) {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -634,7 +634,6 @@ public class Utils {
     public static String prependOperationScenarioToErrorCode(String exceptionErrorCode, String scenario) {
 
         if (StringUtils.isNotEmpty(exceptionErrorCode)) {
-
             // Check whether the scenario is already in the errorCode.
             if (exceptionErrorCode.contains(IdentityRecoveryConstants.EXCEPTION_SCENARIO_SEPARATOR)) {
                 return exceptionErrorCode;
@@ -663,7 +662,6 @@ public class Utils {
             try {
                 String manageNotificationsInternally = properties
                         .get(IdentityRecoveryConstants.MANAGE_NOTIFICATIONS_INTERNALLY_PROPERTY_KEY);
-
                 // Notification managed mechanism is not specified in the request.
                 if (StringUtils.isEmpty(manageNotificationsInternally)) {
                     return Boolean.parseBoolean(Utils.getRecoveryConfigs(

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.governance.IdentityGovernanceException;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
@@ -63,6 +64,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Class which contains the Utils for user recovery.
+ */
 public class Utils {
     private static final Log log = LogFactory.getLog(Utils.class);
 
@@ -210,6 +214,26 @@ public class Utils {
                 IdentityRecoveryServerException.class, error.getCode(), errorDescription, e);
     }
 
+    /**
+     * Handle Server Exceptions.
+     *
+     * @param errorCode    Error code of the exception
+     * @param errorMessage Error message of the exception
+     * @param data         Meta data associated with the exception
+     * @return IdentityRecoveryServerException as the server error
+     */
+    public static IdentityRecoveryServerException handleServerException(String errorCode, String errorMessage,
+                                                                        String data) {
+
+        String errorDescription;
+        if (StringUtils.isNotBlank(data)) {
+            errorDescription = String.format(errorMessage, data);
+        } else {
+            errorDescription = errorMessage;
+        }
+        return IdentityException.error(IdentityRecoveryServerException.class, errorCode, errorDescription);
+    }
+
     public static IdentityRecoveryClientException handleClientException(IdentityRecoveryConstants.ErrorMessages
                                                                                 error, String data)
             throws IdentityRecoveryClientException {
@@ -237,6 +261,26 @@ public class Utils {
         }
 
         return IdentityException.error(IdentityRecoveryClientException.class, error.getCode(), errorDescription, e);
+    }
+
+    /**
+     * Handle Client Exceptions.
+     *
+     * @param errorCode    Error code of the exception
+     * @param errorMessage Error message of the exception
+     * @param data         Meta data associated with the exception
+     * @return IdentityRecoveryClientException
+     */
+    public static IdentityRecoveryClientException handleClientException(String errorCode, String errorMessage,
+                                                                        String data) {
+
+        String errorDescription;
+        if (StringUtils.isNotBlank(data)) {
+            errorDescription = String.format(errorMessage, data);
+        } else {
+            errorDescription = errorMessage;
+        }
+        return IdentityException.error(IdentityRecoveryClientException.class, errorCode, errorDescription);
     }
 
     /**
@@ -576,5 +620,91 @@ public class Utils {
             }
         }
         return isExist;
+    }
+
+    /**
+     * Prepend the operation scenario to the existing exception error code.
+     * (Eg: USR-20045)
+     *
+     * @param exceptionErrorCode Existing error code.
+     * @param scenario           Operation scenario
+     * @return New error code with the scenario prepended (NOTE: Return an empty String if the provided error code is
+     * empty)
+     */
+    public static String prependOperationScenarioToErrorCode(String exceptionErrorCode, String scenario) {
+
+        if (StringUtils.isNotEmpty(exceptionErrorCode)) {
+
+            // Check whether the scenario is already in the errorCode.
+            if (exceptionErrorCode.contains(IdentityRecoveryConstants.EXCEPTION_SCENARIO_SEPARATOR)) {
+                return exceptionErrorCode;
+            }
+            if (StringUtils.isNotEmpty(scenario)) {
+                exceptionErrorCode =
+                        scenario + IdentityRecoveryConstants.EXCEPTION_SCENARIO_SEPARATOR + exceptionErrorCode;
+            }
+        }
+        return exceptionErrorCode;
+    }
+
+    /**
+     * Check whether the internally notification management property is send with the meta properties. If management
+     * mechanism is specified, return the specified boolean value. If the management mechanism is not specified in
+     * meta properties return server configurations.
+     *
+     * @param tenantDomain Tenant domain
+     * @param properties   Meta properties
+     * @return True when notifications are managed internally
+     */
+    public static boolean isNotificationsInternallyManaged(String tenantDomain, Map<String, String> properties)
+            throws IdentityRecoveryException {
+
+        if (properties != null && properties.size() > 0) {
+            try {
+                String manageNotificationsInternally = properties
+                        .get(IdentityRecoveryConstants.MANAGE_NOTIFICATIONS_INTERNALLY_PROPERTY_KEY);
+
+                // Notification managed mechanism is not specified in the request.
+                if (StringUtils.isEmpty(manageNotificationsInternally)) {
+                    return Boolean.parseBoolean(Utils.getRecoveryConfigs(
+                            IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE, tenantDomain));
+                } else {
+                    return Boolean.parseBoolean(manageNotificationsInternally);
+                }
+            } catch (NumberFormatException e) {
+                String manageNotificationsInternally = Utils
+                        .getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE,
+                                tenantDomain);
+                if (log.isDebugEnabled()) {
+                    String error = String
+                            .format("Invalid boolean value : %s to enable enable internal notification management. "
+                                            + "Server default value : %s will be used.", properties.get
+                                            (IdentityRecoveryConstants.MANAGE_NOTIFICATIONS_INTERNALLY_PROPERTY_KEY),
+                                    manageNotificationsInternally);
+                    log.debug(error);
+                }
+                return Boolean.parseBoolean(manageNotificationsInternally);
+            }
+        }
+        // The request has no meta properties, then server configurations will be returned.
+        return Boolean.parseBoolean(
+                Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE,
+                        tenantDomain));
+    }
+
+    /**
+     * Resolve event name according to the notification channel.
+     *
+     * @param notificationChannel Notification channel
+     * @return Resolved event name
+     */
+    public static String resolveEventName(String notificationChannel) {
+
+        if (IdentityRecoveryConstants.SMS_CHANNEL.equals(notificationChannel)) {
+            return IdentityRecoveryConstants.NOTIFICATION_EVENTNAME_PREFIX + notificationChannel
+                    + IdentityRecoveryConstants.NOTIFICATION_EVENTNAME_SUFFIX;
+        } else {
+            return IdentityEventConstants.Event.TRIGGER_NOTIFICATION;
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.recovery.util;
 
 import org.apache.axiom.om.util.Base64;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -658,7 +659,7 @@ public class Utils {
     public static boolean isNotificationsInternallyManaged(String tenantDomain, Map<String, String> properties)
             throws IdentityRecoveryException {
 
-        if (properties != null && properties.size() > 0) {
+        if (MapUtils.isNotEmpty(properties)) {
             try {
                 String manageNotificationsInternally = properties
                         .get(IdentityRecoveryConstants.MANAGE_NOTIFICATIONS_INTERNALLY_PROPERTY_KEY);

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImplTest.java
@@ -83,7 +83,9 @@ public class RecoveryConfigImplTest {
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.USERNAME_RECOVERY_ENABLE, "Enable Username Recovery");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.USERNAME_RECOVERY_RECAPTCHA_ENABLE,
                 "Enable reCaptcha for Username Recovery");
-        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.EXPIRY_TIME, "Notification Expiry Time");
+        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.EXPIRY_TIME, "Recovery Link Expiry Time");
+        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_EXPIRY_TIME,
+                "SMS OTP Expiry Time");
 
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_SEND_RECOVERY_NOTIFICATION_SUCCESS,
                 "Notify when Recovery Success");
@@ -115,6 +117,8 @@ public class RecoveryConfigImplTest {
                 "Force users to provide answers to challenge questions during sign in");
         descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_CALLBACK_REGEX,
                 "Recovery callback URL regex");
+        descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_EXPIRY_TIME,
+                "Expiration time of the SMS OTP code for password recovery");
         Map<String, String> descriptionMapping = recoveryConfigImpl.getPropertyDescriptionMapping();
 
         assertEquals(descriptionMapping, descriptionMappingExpected, "Maps are not equal");
@@ -135,6 +139,7 @@ public class RecoveryConfigImplTest {
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_SEND_RECOVERY_NOTIFICATION_SUCCESS);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_SEND_RECOVERY_SECURITY_START);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.EXPIRY_TIME);
+        propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_EXPIRY_TIME);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.FORCE_ADD_PW_RECOVERY_QUESTION);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_CALLBACK_REGEX);
 
@@ -157,6 +162,7 @@ public class RecoveryConfigImplTest {
         String testEnableUsernameRecovery = "false";
         String testEnableNotificationInternallyManage = "true";
         String testExpiryTime = "1440";
+        String testExpiryTimeSMSOTP = "1";
         String testNotifySuccess = "false";
         String testNotifyStart = "false";
         String testForceChallengeQuestions = "false";
@@ -185,6 +191,8 @@ public class RecoveryConfigImplTest {
         defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE,
                 testEnableNotificationInternallyManage);
         defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.EXPIRY_TIME, testExpiryTime);
+        defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_EXPIRY_TIME,
+                testExpiryTimeSMSOTP);
         defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_SEND_RECOVERY_NOTIFICATION_SUCCESS,
                 testNotifySuccess);
         defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_SEND_RECOVERY_SECURITY_START,

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
@@ -49,7 +49,10 @@ import org.wso2.carbon.user.core.service.RealmService;
 import java.util.HashMap;
 
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertNull;
 
 /**
  * Class which contains the test cases for UserAccountRecoveryManager.

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,10 +103,8 @@ public class UserAccountRecoveryManagerTest {
 
         // Test no matching users for a given set of claims.
         testNoMatchingUsersForGivenClaims();
-
         // Test notifications externally managed.
         testGetUserWithNotificationsExternallyManaged();
-
         // Test notifications internally managed.
         testGetUserWithNotificationsInternallyManaged();
     }
@@ -122,10 +120,8 @@ public class UserAccountRecoveryManagerTest {
         mockRecoveryConfigs(true);
         mockUserstoreManager();
         mockJDBCRecoveryDataStore();
-
         // Test when the user is self-registered.
         testGetSelfSignUpUsers();
-
         // Test when the user is not self registered.
         testGetGeneralUsers();
     }
@@ -282,16 +278,12 @@ public class UserAccountRecoveryManagerTest {
 
         // Test no claims provided error.
         testNoClaimsProvidedToRetrieveMatchingUsers();
-
         // Test multiple users matching for the given set of claims.
         testMultipleUsersMatchingForGivenClaims();
-
         // Test no matching users for given set of claims.
         testNoMatchingUsers();
-
         // Test get matched user for given set of claims.
         testGetMatchedUser();
-
         // Test no matching users for given set of claims.
         testNoMatchedUsers();
     }
@@ -412,7 +404,6 @@ public class UserAccountRecoveryManagerTest {
         // Mock getTenantId.
         mockStatic(IdentityTenantUtil.class);
         when(IdentityTenantUtil.getTenantId(Matchers.anyString())).thenReturn(-1234);
-
         // Get UserStoreManager.
         mockStatic(IdentityRecoveryServiceDataHolder.class);
         when(IdentityRecoveryServiceDataHolder.getInstance()).thenReturn(identityRecoveryServiceDataHolder);

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
@@ -1,0 +1,479 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.identity.recovery.internal.service.impl;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import org.apache.commons.lang.StringUtils;
+import org.mockito.InjectMocks;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.IObjectFactory;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.ObjectFactory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
+import org.wso2.carbon.identity.recovery.RecoveryScenarios;
+import org.wso2.carbon.identity.recovery.dto.NotificationChannelDTO;
+import org.wso2.carbon.identity.recovery.dto.RecoveryChannelInfoDTO;
+import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
+import org.wso2.carbon.identity.recovery.model.UserRecoveryData;
+import org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStore;
+import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
+import org.wso2.carbon.identity.recovery.util.Utils;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
+
+import java.util.HashMap;
+
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.testng.Assert.*;
+
+/**
+ * Class which contains the test cases for UserAccountRecoveryManager.
+ */
+@PrepareForTest({IdentityTenantUtil.class, IdentityRecoveryServiceDataHolder.class, IdentityUtil.class,
+        Utils.class, JDBCRecoveryDataStore.class })
+public class UserAccountRecoveryManagerTest {
+
+    @InjectMocks
+    private UserAccountRecoveryManager userAccountRecoveryManager;
+
+    @Mock
+    private IdentityRecoveryServiceDataHolder identityRecoveryServiceDataHolder;
+
+    @Mock
+    RealmService realmService;
+
+    @Mock
+    UserRealm userRealm;
+
+    @Mock
+    UserStoreManager userStoreManager;
+
+    @Mock
+    UserRecoveryDataStore userRecoveryDataStore;
+
+    @ObjectFactory
+    public IObjectFactory getObjectFactory() {
+
+        return new org.powermock.modules.testng.PowerMockObjectFactory();
+    }
+
+    /**
+     * User claims map.
+     */
+    private HashMap<String, String> userClaims;
+
+    @BeforeTest
+    private void setup() {
+        userAccountRecoveryManager = UserAccountRecoveryManager.getInstance();
+        userClaims = buildUserClaimsMap();
+    }
+
+    /**
+     * Test retrieve user recovery information.
+     *
+     * @throws Exception Error while getting user recovery information
+     */
+    @Test
+    public void testRetrieveUserRecoveryInformation() throws Exception {
+
+        // Test no matching users for a given set of claims.
+        testNoMatchingUsersForGivenClaims();
+
+        // Test notifications externally managed.
+        testGetUserWithNotificationsExternallyManaged();
+
+        // Test notifications internally managed.
+        testGetUserWithNotificationsInternallyManaged();
+    }
+
+    /**
+     * Test get user recovery when the notifications are internally managed.
+     *
+     * @throws Exception Error getting recovery information
+     */
+    private void testGetUserWithNotificationsInternallyManaged() throws Exception {
+
+        mockGetUserList(new String[] { UserProfile.USERNAME.getValue() });
+        mockRecoveryConfigs(true);
+        mockUserstoreManager();
+        mockJDBCRecoveryDataStore();
+
+        // Test when the user is self-registered.
+        testGetSelfSignUpUsers();
+
+        // Test when the user is not self registered.
+        testGetGeneralUsers();
+    }
+
+    /**
+     * Test recovery data for self registered users with verified notification channels.
+     *
+     * @throws Exception Error while getting recovery information
+     */
+    private void testGetGeneralUsers() throws Exception {
+
+        HashMap<String, String> userClaims = new HashMap<>(this.userClaims);
+
+        // Changing the role to internal and remove channel verified information.
+        userClaims.put(UserProfile.USER_ROLE.key, "INTERNAL");
+        userClaims.remove(UserProfile.EMAIL_VERIFIED.key);
+        userClaims.remove(UserProfile.PHONE_VERIFIED.key);
+        when(userStoreManager
+                .getUserClaimValues(Matchers.anyString(), Matchers.any(String[].class), Matchers.anyString()))
+                .thenReturn(userClaims);
+        RecoveryChannelInfoDTO recoveryChannelInfoDTO = userAccountRecoveryManager
+                .retrieveUserRecoveryInformation(userClaims, StringUtils.EMPTY, RecoveryScenarios.USERNAME_RECOVERY,
+                        null);
+        assertNotNull(recoveryChannelInfoDTO, "Recovery Information for user : ");
+        assertEquals(recoveryChannelInfoDTO.getUsername(), UserProfile.USERNAME.getValue(),
+                "Notifications Externally managed scenario. Recovered username : ");
+        assertNotNull(recoveryChannelInfoDTO.getRecoveryCode(),
+                "Notifications Externally managed scenario. RecoveryCode : ");
+        NotificationChannelDTO[] notificationChannelDTOS = recoveryChannelInfoDTO.getNotificationChannelDTOs();
+        assertEquals(notificationChannelDTOS.length, 2,
+                "Notifications Externally managed scenario. Available recovery channels");
+        checkMaskedRecoveryValues(notificationChannelDTOS);
+    }
+
+    /**
+     * Test recovery data for self registered users with verified notification channels.
+     *
+     * @throws Exception Error while getting recovery information
+     */
+    private void testGetSelfSignUpUsers() throws Exception {
+
+        when(userStoreManager
+                .getUserClaimValues(Matchers.anyString(), Matchers.any(String[].class), Matchers.anyString()))
+                .thenReturn(userClaims);
+        RecoveryChannelInfoDTO recoveryChannelInfoDTO = userAccountRecoveryManager
+                .retrieveUserRecoveryInformation(userClaims, StringUtils.EMPTY, RecoveryScenarios.USERNAME_RECOVERY,
+                        null);
+        assertNotNull(recoveryChannelInfoDTO, "Recovery Information for user : ");
+        assertEquals(recoveryChannelInfoDTO.getUsername(), UserProfile.USERNAME.getValue(),
+                "Notifications Externally managed scenario. Recovered username : ");
+        assertNotNull(recoveryChannelInfoDTO.getRecoveryCode(),
+                "Notifications Externally managed scenario. RecoveryCode : ");
+        NotificationChannelDTO[] notificationChannelDTOS = recoveryChannelInfoDTO.getNotificationChannelDTOs();
+        assertEquals(notificationChannelDTOS.length, 2,
+                "Notifications Externally managed scenario. Available recovery channels");
+        checkMaskedRecoveryValues(notificationChannelDTOS);
+    }
+
+    /**
+     * Check the length of masked notification channel information.
+     *
+     * @param notificationChannelDTOS NotificationChannelDTO list
+     */
+    private void checkMaskedRecoveryValues(NotificationChannelDTO[] notificationChannelDTOS) {
+
+        for (NotificationChannelDTO notificationChannelDTO : notificationChannelDTOS) {
+            if (notificationChannelDTO.getType().equals(NotificationChannels.EMAIL_CHANNEL.getChannelType())) {
+                assertEquals(notificationChannelDTO.getValue().length(), UserProfile.EMAIL_ADDRESS.value.length());
+            } else {
+                assertEquals(notificationChannelDTO.getValue().length(), UserProfile.MOBILE.value.length());
+            }
+        }
+    }
+
+    /**
+     * Test notifications externally managed scenario.
+     *
+     * @throws Exception Error while getting user recovery data
+     */
+    private void testGetUserWithNotificationsExternallyManaged() throws Exception {
+
+        mockGetUserList(new String[] { UserProfile.USERNAME.getValue() });
+        mockRecoveryConfigs(false);
+        mockJDBCRecoveryDataStore();
+        RecoveryChannelInfoDTO recoveryChannelInfoDTO = userAccountRecoveryManager
+                .retrieveUserRecoveryInformation(userClaims, StringUtils.EMPTY, RecoveryScenarios.USERNAME_RECOVERY,
+                        null);
+        assertEquals(recoveryChannelInfoDTO.getUsername(), UserProfile.USERNAME.getValue(),
+                "Notifications Externally managed scenario. Recovered username : ");
+        assertNotNull(recoveryChannelInfoDTO.getRecoveryCode(),
+                "Notifications Externally managed scenario. RecoveryCode : ");
+        NotificationChannelDTO[] notificationChannelDTOS = recoveryChannelInfoDTO.getNotificationChannelDTOs();
+        assertEquals(notificationChannelDTOS.length, 1,
+                "Notifications Externally managed scenario. Available recovery channels");
+        assertEquals(notificationChannelDTOS[0].getType(), IdentityRecoveryConstants.EXTERNAL_NOTIFICATION_CHANNEL,
+                "Notification channel : ");
+    }
+
+    /**
+     * No users matched for the given claims.
+     *
+     * @throws Exception Error while getting the user recovery information
+     */
+    private void testNoMatchingUsersForGivenClaims() throws Exception {
+
+        try {
+            mockGetUserList(new String[] {});
+            userAccountRecoveryManager
+                    .retrieveUserRecoveryInformation(userClaims, StringUtils.EMPTY, RecoveryScenarios.USERNAME_RECOVERY,
+                            null);
+        } catch (IdentityRecoveryException e) {
+            assertEquals(e.getErrorCode(), IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_USER_FOUND.getCode(),
+                    "No matching users for given set of claims : ");
+        }
+    }
+
+    /**
+     * Mock JDBCRecoveryDataStore to store user recovery data.
+     *
+     * @throws IdentityRecoveryException Error while mocking JDBCRecoveryDataStore
+     */
+    private void mockJDBCRecoveryDataStore() throws IdentityRecoveryException {
+
+        mockStatic(JDBCRecoveryDataStore.class);
+        when(JDBCRecoveryDataStore.getInstance()).thenReturn(userRecoveryDataStore);
+        doNothing().when(userRecoveryDataStore).invalidate(Matchers.any(User.class));
+        doNothing().when(userRecoveryDataStore).store(Matchers.any(UserRecoveryData.class));
+    }
+
+    /**
+     * Mock recovery configs.
+     *
+     * @param isNotificationInternallyManaged Whether the notifications internally managed
+     * @throws Exception Error while mocking the configs
+     */
+    private void mockRecoveryConfigs(boolean isNotificationInternallyManaged) throws Exception {
+
+        mockStatic(IdentityUtil.class);
+        when(IdentityUtil.extractDomainFromName(Matchers.anyString())).thenReturn("PRIMARY");
+        mockStatic(Utils.class);
+        when(Utils.isAccountDisabled(Matchers.any(User.class))).thenReturn(false);
+        when(Utils.isAccountLocked(Matchers.any(User.class))).thenReturn(false);
+        when(Utils.isNotificationsInternallyManaged(Matchers.anyString(), Matchers.anyMap()))
+                .thenReturn(isNotificationInternallyManaged);
+    }
+
+    /**
+     * Test get username by claims list.
+     *
+     * @throws Exception Error testing for testGetUsernameByClaims
+     */
+    @Test
+    public void testGetUsernameByClaims() throws Exception {
+
+        // Test no claims provided error.
+        testNoClaimsProvidedToRetrieveMatchingUsers();
+
+        // Test multiple users matching for the given set of claims.
+        testMultipleUsersMatchingForGivenClaims();
+
+        // Test no matching users for given set of claims.
+        testNoMatchingUsers();
+
+        // Test get matched user for given set of claims.
+        testGetMatchedUser();
+
+        // Test no matching users for given set of claims.
+        testNoMatchedUsers();
+    }
+
+    /**
+     * Test get matched user for given claims.
+     *
+     * @throws Exception Error while getting the matched user
+     */
+    private void testNoMatchedUsers() throws Exception {
+
+        String testUsername1 = UserProfile.USERNAME.value;
+        String testUsername2 = "sominda2";
+        String testUsername3 = "sominda3";
+
+        mockUserstoreManager();
+        when(userStoreManager.getUserList(Matchers.anyString(), Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(new String[] { testUsername1, testUsername2 }).thenReturn(new String[] { testUsername3 });
+        String username = userAccountRecoveryManager
+                .getUsernameByClaims(userClaims, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        assertTrue(username.isEmpty(), "Different Users matched for different claims : ");
+    }
+
+    /**
+     * Test get matched user for given claims.
+     *
+     * @throws Exception Error while getting the matched user
+     */
+    private void testGetMatchedUser() throws Exception {
+
+        String testUsername1 = UserProfile.USERNAME.value;
+        String testUsername2 = "sominda2";
+        String testUsername3 = "sominda3";
+
+        mockUserstoreManager();
+        when(userStoreManager.getUserList(Matchers.anyString(), Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(new String[] { testUsername1, testUsername2, testUsername3 })
+                .thenReturn(new String[] { testUsername1, testUsername2 }).thenReturn(new String[] { testUsername1 })
+                .thenReturn(new String[] { testUsername1 });
+        String username = userAccountRecoveryManager
+                .getUsernameByClaims(userClaims, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        assertEquals(username, testUsername1, "Test get matched users fot given claims : ");
+    }
+
+    /**
+     * Test no matching claims for given set of claims.
+     *
+     * @throws Exception Error getting the matching username
+     */
+    private void testNoMatchingUsers() throws Exception {
+
+        mockGetUserList(new String[] {});
+        String username = userAccountRecoveryManager
+                .getUsernameByClaims(userClaims, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        assertTrue(username.isEmpty(), "No matching users for given set of claims : ");
+    }
+
+    /**
+     * Test no claims provided to retrieve a matching user for the given set of claims.
+     */
+    private void testNoClaimsProvidedToRetrieveMatchingUsers() {
+
+        // Test no claims provided scenario.
+        try {
+            String username = userAccountRecoveryManager
+                    .getUsernameByClaims(new HashMap<String, String>(), MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+            assertNull(username, "UserAccountRecoveryManager: No claims have provided to retrieve the user : ");
+        } catch (IdentityRecoveryException e) {
+            // Get error code with scenario.
+            String errorCode = Utils.prependOperationScenarioToErrorCode(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_FIELD_FOUND_FOR_USER_RECOVERY.getCode(),
+                    IdentityRecoveryConstants.USER_ACCOUNT_RECOVERY);
+            assertEquals(e.getErrorCode(), errorCode,
+                    "UserAccountRecoveryManager: No claims have provided to retrieve the user : ");
+        }
+    }
+
+    /**
+     * Test multiple users matching for the given set of claims error.
+     *
+     * @throws Exception Error while checking for matched users.
+     */
+    private void testMultipleUsersMatchingForGivenClaims() throws Exception {
+
+        mockGetUserList(new String[] { "Sominda1", "Sominda2" });
+        try {
+            String username = userAccountRecoveryManager
+                    .getUsernameByClaims(userClaims, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+            assertNull(username, "UserAccountRecoveryManager: Exception should be thrown. Therefore, a "
+                    + "value for an identified user cannot be returned : ");
+        } catch (IdentityRecoveryException e) {
+            assertEquals(e.getErrorCode(),
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_MULTIPLE_MATCHING_USERS.getCode(),
+                    "Invalid error code for existing multiple users for given set of claims");
+        }
+    }
+
+    /**
+     * Build matched user list for a given set of claims.
+     *
+     * @param matchedUsersForGivenClaim Matched users list.
+     * @throws Exception Error while mocking the userstore manager.
+     */
+    private void mockGetUserList(String[] matchedUsersForGivenClaim) throws Exception {
+
+        mockUserstoreManager();
+        when(userStoreManager.getUserList(Matchers.anyString(), Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(matchedUsersForGivenClaim);
+    }
+
+    /**
+     * Get UserstoreManager by mocking IdentityRecoveryServiceDataHolder.
+     *
+     * @throws Exception Error while getting UserstoreManager
+     */
+    private void mockUserstoreManager() throws Exception {
+
+        // Mock getTenantId.
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getTenantId(Matchers.anyString())).thenReturn(-1234);
+
+        // Get UserStoreManager.
+        mockStatic(IdentityRecoveryServiceDataHolder.class);
+        when(IdentityRecoveryServiceDataHolder.getInstance()).thenReturn(identityRecoveryServiceDataHolder);
+        when(identityRecoveryServiceDataHolder.getRealmService()).thenReturn(realmService);
+        when(realmService.getTenantUserRealm(Matchers.anyInt())).thenReturn(userRealm);
+        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+    }
+
+    /**
+     * Build user claims information map
+     *
+     * @return User claims
+     */
+    private HashMap<String, String> buildUserClaimsMap() {
+
+        HashMap<String, String> userClaims = new HashMap<>();
+        userClaims.put(UserProfile.EMAIL_ADDRESS.getKey(), UserProfile.EMAIL_ADDRESS.getValue());
+        userClaims.put(UserProfile.MOBILE.getKey(), UserProfile.MOBILE.getValue());
+        userClaims.put(UserProfile.PREFERRED_CHANNEL.getKey(), UserProfile.PREFERRED_CHANNEL.getValue());
+        userClaims.put(UserProfile.EMAIL_VERIFIED.getKey(), UserProfile.EMAIL_VERIFIED.getValue());
+        userClaims.put(UserProfile.PHONE_VERIFIED.getKey(), UserProfile.PHONE_VERIFIED.getValue());
+        userClaims.put(UserProfile.USER_ROLE.getKey(), UserProfile.USER_ROLE.getValue());
+        return userClaims;
+    }
+
+    /**
+     * Enum contains the status codes and status messages for successful user self registration scenarios.
+     */
+    public enum UserProfile {
+
+        USERNAME("Username", "sominda1"),
+        EMAIL_ADDRESS(NotificationChannels.EMAIL_CHANNEL.getClaimUri(), "sominda@gmail.com"),
+        MOBILE(NotificationChannels.SMS_CHANNEL.getClaimUri(), "1234567890"),
+        PREFERRED_CHANNEL(IdentityRecoveryConstants.PREFERRED_CHANNEL_CLAIM, "EMAIL"),
+        EMAIL_VERIFIED(NotificationChannels.EMAIL_CHANNEL.getVerifiedClaimUrl(), "TRUE"),
+        PHONE_VERIFIED(NotificationChannels.SMS_CHANNEL.getVerifiedClaimUrl(), "TRUE"),
+        USER_ROLE(IdentityRecoveryConstants.USER_ROLES_CLAIM, IdentityRecoveryConstants.SELF_SIGNUP_ROLE);
+
+        private final String key;
+        private final String value;
+
+        UserProfile(String key, String value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        /**
+         * Get the key of the claim.
+         *
+         * @return Code
+         */
+        public String getKey() {
+            return key;
+        }
+
+        /**
+         * Get the value of the claim.
+         *
+         * @return Message
+         */
+        public String getValue() {
+            return value;
+        }}
+}

--- a/components/org.wso2.carbon.identity.recovery/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.recovery/src/test/resources/testng.xml
@@ -25,6 +25,7 @@
             <class name="org.wso2.carbon.identity.recovery.connector.SelfRegistrationConfigImplTest" />
             <class name="org.wso2.carbon.identity.recovery.connector.UserEmailVerificationConfigImplTest" />
             <class name="org.wso2.carbon.identity.recovery.signup.UserSelfRegistrationManagerTest"/>
+            <class name="org.wso2.carbon.identity.recovery.internal.service.impl.UserAccountRecoveryManagerTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
### Purpose
Introducing new APIs for username recovery and password recovery which supports notification sending via user-preferred communication channel.

Related Issues: wso2/product-is#6343

## Related PRs
- https://github.com/wso2/identity-rest-dispatcher/pull/106
- https://github.com/wso2/identity-api-user/pull/78
- https://github.com/wso2/carbon-identity-framework/pull/2662

## When should this PR be merged
- This PR should be merged after https://github.com/wso2/carbon-identity-framework/pull/2662

## Follow up actions
- After merging the PR, merge https://github.com/wso2/identity-api-user/pull/78 after updating the new governance version.