### PR TITLE
Removing NULL API response attribute from self-registration API

### DIFF
--- a/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/SuccessfulUserCreationDTO.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/SuccessfulUserCreationDTO.java
@@ -1,95 +1,86 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.wso2.carbon.identity.user.endpoint.dto;
-
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
-
-
-
+import javax.validation.constraints.Pattern;
 
 @ApiModel(description = "")
-public class SuccessfulUserCreationDTO  {
-  
-  
-  
-  private String code = null;
-  
-  
-  private String message = null;
-  
-  
-  private String notificationChannel = null;
-  
-  
-  private String confirmationCode = null;
+public class SuccessfulUserCreationDTO {
 
-  
-  /**
-   * Status code of the operation.
-   **/
-  @ApiModelProperty(value = "Status code of the operation.")
-  @JsonProperty("code")
-  public String getCode() {
-    return code;
-  }
-  public void setCode(String code) {
-    this.code = code;
-  }
+    @Valid 
+    private String code = null;
 
-  
-  /**
-   * Descriptive message regarding the operation.
-   **/
-  @ApiModelProperty(value = "Descriptive message regarding the operation.")
-  @JsonProperty("message")
-  public String getMessage() {
-    return message;
-  }
-  public void setMessage(String message) {
-    this.message = message;
-  }
+    @Valid 
+    private String message = null;
 
-  
-  /**
-   * Account confirmation notification sent channel.
-   **/
-  @ApiModelProperty(value = "Account confirmation notification sent channel.")
-  @JsonProperty("notificationChannel")
-  public String getNotificationChannel() {
-    return notificationChannel;
-  }
-  public void setNotificationChannel(String notificationChannel) {
-    this.notificationChannel = notificationChannel;
-  }
+    @Valid 
+    private String notificationChannel = null;
 
-  
-  /**
-   * Confirmation code to verify the user, when notifications are externally managed. In this scenario, *notificationChannel* will be *EXTERNAL*. Use the confirmation code for confirm the user accounut.
-   **/
-  @ApiModelProperty(value = "Confirmation code to verify the user, when notifications are externally managed. In this scenario, *notificationChannel* will be *EXTERNAL*. Use the confirmation code for confirm the user accounut.")
-  @JsonProperty("confirmationCode")
-  public String getConfirmationCode() {
-    return confirmationCode;
-  }
-  public void setConfirmationCode(String confirmationCode) {
-    this.confirmationCode = confirmationCode;
-  }
+    /**
+    * Status code of the operation.
+    **/
+    @ApiModelProperty(value = "Status code of the operation.")
+    @JsonProperty("code")
+    public String getCode() {
+        return code;
+    }
+    public void setCode(String code) {
+        this.code = code;
+    }
 
-  
+    /**
+    * Descriptive message regarding the operation.
+    **/
+    @ApiModelProperty(value = "Descriptive message regarding the operation.")
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+    public void setMessage(String message) {
+        this.message = message;
+    }
 
-  @Override
-  public String toString()  {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class SuccessfulUserCreationDTO {\n");
-    
-    sb.append("  code: ").append(code).append("\n");
-    sb.append("  message: ").append(message).append("\n");
-    sb.append("  notificationChannel: ").append(notificationChannel).append("\n");
-    sb.append("  confirmationCode: ").append(confirmationCode).append("\n");
-    sb.append("}\n");
-    return sb.toString();
-  }
+    /**
+    * Account confirmation notification sent channel.
+    **/
+    @ApiModelProperty(value = "Account confirmation notification sent channel.")
+    @JsonProperty("notificationChannel")
+    public String getNotificationChannel() {
+        return notificationChannel;
+    }
+    public void setNotificationChannel(String notificationChannel) {
+        this.notificationChannel = notificationChannel;
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class SuccessfulUserCreationDTO {\n");
+        
+        sb.append("    code: ").append(code).append("\n");
+        sb.append("    message: ").append(message).append("\n");
+        sb.append("    notificationChannel: ").append(notificationChannel).append("\n");
+        
+        sb.append("}\n");
+        return sb.toString();
+    }
 }

--- a/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/SuccessfulUserCreationExternalResponseDTO.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/SuccessfulUserCreationExternalResponseDTO.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.identity.user.endpoint.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+
+/**
+ * DTO which holds the attributes of the response for successful user self-registration via external channel.
+ */
+public class SuccessfulUserCreationExternalResponseDTO extends SuccessfulUserCreationDTO {
+
+    @Valid
+    private String confirmationCode = null;
+
+    /**
+     * Confirmation code to verify the user, when notifications are externally managed. In this scenario,
+     * *notificationChannel* will be *EXTERNAL*. Use the confirmation code for confirm the user account.
+     **/
+    @ApiModelProperty(value = "Confirmation code to verify the user, when notifications are externally managed. " +
+            "In this scenario, *notificationChannel* will be *EXTERNAL*. Use the confirmation code for confirm the " +
+            "user account.")
+    @JsonProperty("confirmationCode")
+    public String getConfirmationCode() {
+
+        return confirmationCode;
+    }
+
+    /**
+     * Set the confirmation code to confirm the self registration flow externally.
+     *
+     * @param confirmationCode Confirmation code
+     */
+    public void setConfirmationCode(String confirmationCode) {
+
+        this.confirmationCode = confirmationCode;
+    }
+}

--- a/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/Constants.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/Constants.java
@@ -47,6 +47,4 @@ public final class Constants {
     public static final String ENABLE_DETAILED_API_RESPONSE =
             "SelfRegistration.API.EnableDetailedResponseBody";
 
-    public static final String EXTERNAL_NOTIFICATION_CHANNEL = "EXTERNAL";
-
 }

--- a/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/MeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/MeApiServiceImpl.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
@@ -31,6 +32,7 @@ import org.wso2.carbon.identity.user.endpoint.Constants;
 import org.wso2.carbon.identity.user.endpoint.MeApiService;
 import org.wso2.carbon.identity.user.endpoint.dto.SelfUserRegistrationRequestDTO;
 import org.wso2.carbon.identity.user.endpoint.dto.SuccessfulUserCreationDTO;
+import org.wso2.carbon.identity.user.endpoint.dto.SuccessfulUserCreationExternalResponseDTO;
 import org.wso2.carbon.identity.user.endpoint.util.Utils;
 import org.wso2.carbon.identity.user.export.core.UserExportException;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
@@ -38,6 +40,9 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 import java.util.Map;
 import javax.ws.rs.core.Response;
 
+/**
+ * Class which contains the implementation of MeApiService.
+ */
 public class MeApiServiceImpl extends MeApiService {
 
     private static final Log LOG = LogFactory.getLog(MeApiServiceImpl.class);
@@ -112,7 +117,16 @@ public class MeApiServiceImpl extends MeApiService {
 
         // Check whether detailed api responses are enabled.
         if (isDetailedResponseBodyEnabled()) {
-            SuccessfulUserCreationDTO successfulUserCreationDTO = buildSuccessResponse(notificationResponseBean);
+            String notificationChannel = notificationResponseBean.getNotificationChannel();
+            if (StringUtils.isNotEmpty(notificationChannel) && notificationChannel
+                    .equals(NotificationChannels.EXTERNAL_CHANNEL.getChannelType())) {
+                // Handle response when the notifications are externally managed.
+                SuccessfulUserCreationExternalResponseDTO successfulUserCreationDTO =
+                        buildSuccessResponseForExternalChannel(notificationResponseBean);
+                return Response.status(Response.Status.CREATED).entity(successfulUserCreationDTO).build();
+            }
+            SuccessfulUserCreationDTO successfulUserCreationDTO =
+                    buildSuccessResponseForInternalChannels(notificationResponseBean);
             return Response.status(Response.Status.CREATED).entity(successfulUserCreationDTO).build();
         } else {
             if (notificationResponseBean != null) {
@@ -120,7 +134,7 @@ public class MeApiServiceImpl extends MeApiService {
                 // If the notifications are required in the form of legacy response, and notifications are externally
                 // managed, the recoveryId should be in the response as text.
                 if (StringUtils.isNotEmpty(notificationChannel) && notificationChannel
-                        .equals(Constants.EXTERNAL_NOTIFICATION_CHANNEL)) {
+                        .equals(NotificationChannels.EXTERNAL_CHANNEL.getChannelType())) {
                     return Response.status(Response.Status.CREATED).entity(notificationResponseBean.getRecoveryId())
                             .build();
                 }
@@ -130,14 +144,33 @@ public class MeApiServiceImpl extends MeApiService {
     }
 
     /**
-     * Build the successResponseDTO for successful user identification and channel retrieve.
+     * Build the successResponseDTO for successful user identification and channel retrieve when the notifications
+     * are managed internally.
      *
      * @param notificationResponseBean NotificationResponseBean
      * @return SuccessfulUserCreationDTO
      */
-    private SuccessfulUserCreationDTO buildSuccessResponse(NotificationResponseBean notificationResponseBean) {
+    private SuccessfulUserCreationDTO buildSuccessResponseForInternalChannels(
+            NotificationResponseBean notificationResponseBean) {
 
         SuccessfulUserCreationDTO successDTO = new SuccessfulUserCreationDTO();
+        successDTO.setCode(notificationResponseBean.getCode());
+        successDTO.setMessage(notificationResponseBean.getMessage());
+        successDTO.setNotificationChannel(notificationResponseBean.getNotificationChannel());
+        return successDTO;
+    }
+
+    /**
+     * Build the successResponseDTO for successful user identification and channel retrieve when the notifications
+     * are managed externally.
+     *
+     * @param notificationResponseBean NotificationResponseBean
+     * @return SuccessfulUserCreationExternalResponseDTO
+     */
+    private SuccessfulUserCreationExternalResponseDTO buildSuccessResponseForExternalChannel(
+            NotificationResponseBean notificationResponseBean) {
+
+        SuccessfulUserCreationExternalResponseDTO successDTO = new SuccessfulUserCreationExternalResponseDTO();
         successDTO.setCode(notificationResponseBean.getCode());
         successDTO.setMessage(notificationResponseBean.getMessage());
         successDTO.setNotificationChannel(notificationResponseBean.getNotificationChannel());
@@ -152,12 +185,12 @@ public class MeApiServiceImpl extends MeApiService {
      */
     private boolean isDetailedResponseBodyEnabled() {
 
-        String enableDetailedResponseConfig= IdentityUtil
+        String enableDetailedResponseConfig = IdentityUtil
                 .getProperty(Constants.ENABLE_DETAILED_API_RESPONSE);
-        if(StringUtils.isEmpty(enableDetailedResponseConfig)){
+        if (StringUtils.isEmpty(enableDetailedResponseConfig)) {
             // Return false if the user has not enabled the detailed response body.
             return ENABLE_DETAILED_API_RESPONSE;
-        } else  {
+        } else {
             return Boolean.parseBoolean(enableDetailedResponseConfig);
         }
     }

--- a/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/MeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/MeApiServiceImpl.java
@@ -118,8 +118,7 @@ public class MeApiServiceImpl extends MeApiService {
         // Check whether detailed api responses are enabled.
         if (isDetailedResponseBodyEnabled()) {
             String notificationChannel = notificationResponseBean.getNotificationChannel();
-            if (StringUtils.isNotEmpty(notificationChannel) && notificationChannel
-                    .equals(NotificationChannels.EXTERNAL_CHANNEL.getChannelType())) {
+            if (NotificationChannels.EXTERNAL_CHANNEL.getChannelType().equals(notificationChannel)) {
                 // Handle response when the notifications are externally managed.
                 SuccessfulUserCreationExternalResponseDTO successfulUserCreationDTO =
                         buildSuccessResponseForExternalChannel(notificationResponseBean);
@@ -131,10 +130,9 @@ public class MeApiServiceImpl extends MeApiService {
         } else {
             if (notificationResponseBean != null) {
                 String notificationChannel = notificationResponseBean.getNotificationChannel();
-                // If the notifications are required in the form of legacy response, and notifications are externally
-                // managed, the recoveryId should be in the response as text.
-                if (StringUtils.isNotEmpty(notificationChannel) && notificationChannel
-                        .equals(NotificationChannels.EXTERNAL_CHANNEL.getChannelType())) {
+                /*If the notifications are required in the form of legacy response, and notifications are externally
+                 managed, the recoveryId should be in the response as text*/
+                if (NotificationChannels.EXTERNAL_CHANNEL.getChannelType().equals(notificationChannel)) {
                     return Response.status(Response.Status.CREATED).entity(notificationResponseBean.getRecoveryId())
                             .build();
                 }

--- a/components/org.wso2.carbon.identity.user.endpoint/src/main/resources/api.identity.user.yaml
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/main/resources/api.identity.user.yaml
@@ -375,10 +375,6 @@ definitions:
         type: string
         example: "EMAIL"
         description: Account confirmation notification sent channel.
-      confirmationCode:
-        type: string
-        example: ""
-        description: Confirmation code to verify the user, when notifications are externally managed. In this scenario, *notificationChannel* will be *EXTERNAL*. Use the confirmation code for confirm the user accounut.
 
   #-----------------------------------------------------
   # The SelfRegistrationUser  Object

--- a/components/org.wso2.carbon.identity.user.endpoint/src/test/java/org.wso2.carbon.identity.user.endpoint.Util/HandleExceptionsTest.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/test/java/org.wso2.carbon.identity.user.endpoint.Util/HandleExceptionsTest.java
@@ -68,32 +68,32 @@ public class HandleExceptionsTest {
     }
 
     @Test
-    public void testHandleConflictException(){
+    public void testHandleConflictException() {
 
         ConflictException conflictException = new ConflictException();
-        assertEquals(conflictException.getResponse().getStatus(),409);
-        String errorCode = "UNR-10002";
+        assertEquals(conflictException.getResponse().getStatus(), 409);
+        String errorCode = "Test Code";
         String errorMessage = "Test Error";
         try {
             Utils.handleConflict(errorMessage, errorCode);
         } catch (ConflictException exception) {
-            assertEquals(exception.getResponse().getStatus(),409);
-            assertEquals(exception.getMessage(),errorMessage);
+            assertEquals(exception.getResponse().getStatus(), 409);
+            assertEquals(exception.getMessage(), errorMessage);
         }
     }
 
     @Test
-    public void testHandleNotAcceptableException(){
+    public void testHandleNotAcceptableException() {
 
         NotAcceptableException notAcceptableException = new NotAcceptableException();
-        assertEquals(notAcceptableException.getResponse().getStatus(),406);
-        String errorCode = "UNR-10002";
+        assertEquals(notAcceptableException.getResponse().getStatus(), 406);
+        String errorCode = "Test Code";
         String errorMessage = "Test Error";
         try {
             Utils.handleNotAcceptable(errorMessage, errorCode);
         } catch (NotAcceptableException exception) {
-            assertEquals(exception.getResponse().getStatus(),406);
-            assertEquals(exception.getMessage(),errorMessage);
+            assertEquals(exception.getResponse().getStatus(), 406);
+            assertEquals(exception.getMessage(), errorMessage);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.user.endpoint/src/test/java/org.wso2.carbon.identity.user.endpoint.Util/HandleExceptionsTest.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/test/java/org.wso2.carbon.identity.user.endpoint.Util/HandleExceptionsTest.java
@@ -22,7 +22,9 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.identity.user.endpoint.exceptions.BadRequestException;
 import org.wso2.carbon.identity.user.endpoint.exceptions.ConflictException;
 import org.wso2.carbon.identity.user.endpoint.exceptions.InternalServerErrorException;
+import org.wso2.carbon.identity.user.endpoint.exceptions.NotAcceptableException;
 import org.wso2.carbon.identity.user.endpoint.exceptions.UserEndpointExceptionMapper;
+import org.wso2.carbon.identity.user.endpoint.util.Utils;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -65,6 +67,33 @@ public class HandleExceptionsTest {
         assertEquals(conflictException.getResponse().getStatus(), 409);
     }
 
+    @Test
+    public void testHandleConflictException(){
 
+        ConflictException conflictException = new ConflictException();
+        assertEquals(conflictException.getResponse().getStatus(),409);
+        String errorCode = "UNR-10002";
+        String errorMessage = "Test Error";
+        try {
+            Utils.handleConflict(errorMessage, errorCode);
+        } catch (ConflictException exception) {
+            assertEquals(exception.getResponse().getStatus(),409);
+            assertEquals(exception.getMessage(),errorMessage);
+        }
+    }
+
+    @Test
+    public void testHandleNotAcceptableException(){
+
+        NotAcceptableException notAcceptableException = new NotAcceptableException();
+        assertEquals(notAcceptableException.getResponse().getStatus(),406);
+        String errorCode = "UNR-10002";
+        String errorMessage = "Test Error";
+        try {
+            Utils.handleNotAcceptable(errorMessage, errorCode);
+        } catch (NotAcceptableException exception) {
+            assertEquals(exception.getResponse().getStatus(),406);
+            assertEquals(exception.getMessage(),errorMessage);
+        }
+    }
 }
-


### PR DESCRIPTION
### Proposed changes in this pull request

Resolves https://github.com/wso2/product-is/issues/7262

Changed the API response when the notification channel is either `SMS` or `EMAIL`.
```
{
"code": "USR-02001",
"message": "Successful user self registration. Pending account verification",
"notificationChannel": "EMAIL",
}
```