### PR TITLE
FIX missing error code delimiter

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityMgtConstants.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityMgtConstants.java
@@ -24,6 +24,7 @@ public class IdentityMgtConstants {
     private IdentityMgtConstants(){}
 
     public static final String USER_IDENTITY_CLAIMS = "UserIdentityClaims";
+    public static final String ERROR_CODE_DELIMITER = "-";
 
     /**
      * Class that contains the error scenarios.

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/exceptions/notiification/NotificationChannelManagerClientException.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/exceptions/notiification/NotificationChannelManagerClientException.java
@@ -83,8 +83,10 @@ public class NotificationChannelManagerClientException extends NotificationChann
 
         String errorCode = super.getErrorCode();
         if (StringUtils.isEmpty(errorCode)) {
-            errorCode = IdentityMgtConstants.Error_Scenario.NOTIFICATION_CHANNEL_MANAGER
-                    + IdentityMgtConstants.ErrorMessages.ERROR_CODE_DEFAULT_BAD_REQUEST.getCode();
+            errorCode =
+                    IdentityMgtConstants.Error_Scenario.NOTIFICATION_CHANNEL_MANAGER +
+                            IdentityMgtConstants.ERROR_CODE_DELIMITER
+                            + IdentityMgtConstants.ErrorMessages.ERROR_CODE_DEFAULT_BAD_REQUEST.getCode();
         }
         return errorCode;
     }

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/exceptions/notiification/NotificationChannelManagerException.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/exceptions/notiification/NotificationChannelManagerException.java
@@ -86,7 +86,8 @@ public class NotificationChannelManagerException extends IdentityException {
 
         String errorCode = super.getErrorCode();
         if (StringUtils.isEmpty(errorCode)) {
-            errorCode = IdentityMgtConstants.Error_Scenario.NOTIFICATION_CHANNEL_MANAGER
+            errorCode = IdentityMgtConstants.Error_Scenario.NOTIFICATION_CHANNEL_MANAGER +
+                    IdentityMgtConstants.ERROR_CODE_DELIMITER
                     + IdentityMgtConstants.ErrorMessages.ERROR_CODE_DEFAULT_UNEXPECTED_ERROR.getCode();
         }
         return errorCode;

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/exceptions/notiification/NotificationChannelManagerServerException.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/exceptions/notiification/NotificationChannelManagerServerException.java
@@ -82,7 +82,8 @@ public class NotificationChannelManagerServerException extends NotificationChann
 
         String errorCode = super.getErrorCode();
         if (StringUtils.isEmpty(errorCode)) {
-            errorCode = IdentityMgtConstants.Error_Scenario.NOTIFICATION_CHANNEL_MANAGER
+            errorCode = IdentityMgtConstants.Error_Scenario.NOTIFICATION_CHANNEL_MANAGER +
+                    IdentityMgtConstants.ERROR_CODE_DELIMITER
                     + IdentityMgtConstants.ErrorMessages.ERROR_CODE_DEFAULT_SERVER_ERROR.getCode();
         }
         return errorCode;

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/exceptions/notiification/NotificationTemplateManagerClientException.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/exceptions/notiification/NotificationTemplateManagerClientException.java
@@ -77,8 +77,10 @@ public class NotificationTemplateManagerClientException extends NotificationTemp
 
         String errorCode = super.getErrorCode();
         if (StringUtils.isEmpty(errorCode)) {
-            errorCode = IdentityMgtConstants.Error_Scenario.NOTIFICATION_TEMPLATE_MANAGER
-                    + IdentityMgtConstants.ErrorMessages.ERROR_CODE_DEFAULT_BAD_REQUEST.getCode();
+            errorCode =
+                    IdentityMgtConstants.Error_Scenario.NOTIFICATION_TEMPLATE_MANAGER +
+                            IdentityMgtConstants.ERROR_CODE_DELIMITER
+                            + IdentityMgtConstants.ErrorMessages.ERROR_CODE_DEFAULT_BAD_REQUEST.getCode();
         }
         return errorCode;
     }

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/exceptions/notiification/NotificationTemplateManagerException.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/exceptions/notiification/NotificationTemplateManagerException.java
@@ -83,7 +83,8 @@ public class NotificationTemplateManagerException extends IdentityException {
 
         String errorCode = super.getErrorCode();
         if (StringUtils.isEmpty(errorCode)) {
-            errorCode = IdentityMgtConstants.Error_Scenario.NOTIFICATION_TEMPLATE_MANAGER
+            errorCode = IdentityMgtConstants.Error_Scenario.NOTIFICATION_TEMPLATE_MANAGER +
+                    IdentityMgtConstants.ERROR_CODE_DELIMITER
                     + IdentityMgtConstants.ErrorMessages.ERROR_CODE_DEFAULT_UNEXPECTED_ERROR.getCode();
         }
         return errorCode;

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/exceptions/notiification/NotificationTemplateManagerServerException.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/exceptions/notiification/NotificationTemplateManagerServerException.java
@@ -80,7 +80,8 @@ public class NotificationTemplateManagerServerException extends NotificationTemp
 
         String errorCode = super.getErrorCode();
         if (StringUtils.isEmpty(errorCode)) {
-            errorCode = IdentityMgtConstants.Error_Scenario.NOTIFICATION_TEMPLATE_MANAGER
+            errorCode = IdentityMgtConstants.Error_Scenario.NOTIFICATION_TEMPLATE_MANAGER +
+                    IdentityMgtConstants.ERROR_CODE_DELIMITER
                     + IdentityMgtConstants.ErrorMessages.ERROR_CODE_DEFAULT_SERVER_ERROR.getCode();
         }
         return errorCode;


### PR DESCRIPTION
### Proposed changes in this pull request

The error codes thrown by the APIs should be in the `<scenario>-<code>` format. Example : `UNR-15004`.
This PR fixes missing error code delimiter in several exception types.