### PR TITLE
Import missing packages in tenant resource manager

### DIFF
--- a/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
@@ -108,6 +108,7 @@
                             org.wso2.carbon.databridge.commons; version="${carbon.analytics.common.version.range}",
                             org.wso2.carbon.event.publisher.core; version="${carbon.analytics.common.version.range}",
                             org.wso2.carbon.event.publisher.core.exception; version="${carbon.analytics.common.version.range}",
+                            org.wso2.carbon.event.stream.core.exception; version="${carbon.analytics.common.version.range}",
                             org.wso2.carbon.event.publisher.core.config; version="${carbon.analytics.common.version.range}",
                             org.wso2.carbon.event.stream.core; version="${carbon.analytics.common.version.range}",
                             org.wso2.carbon.identity.configuration.mgt.core.*; version="${carbon.identity.framework.imp.pkg.version.range}",


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/7557

This issue has occurred as the _Tenant Resource Manager Service_ does not activate properly due to missing dependencies.