### PR TITLE
Add unit test for User Claim Update connector.

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/AdminForcedPasswordResetConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/AdminForcedPasswordResetConfigImplTest.java
@@ -30,8 +30,8 @@ import java.util.Properties;
 
 import static org.testng.Assert.assertEquals;
 
-/***
- *This class does unit test coverage for AdminForcedPasswordResetConfigImpl class
+/**
+ * This class does unit test coverage for AdminForcedPasswordResetConfigImpl class.
  */
 public class AdminForcedPasswordResetConfigImplTest {
 
@@ -39,36 +39,43 @@ public class AdminForcedPasswordResetConfigImplTest {
 
     @BeforeTest
     public void init() {
+
         adminForcedPasswordResetConfigIml = new AdminForcedPasswordResetConfigImpl();
     }
 
     @Test
     public void testGetName() throws IdentityGovernanceException {
+
         assertEquals(adminForcedPasswordResetConfigIml.getName(), "admin-forced-password-reset");
     }
 
     @Test
     public void testGetFriendlyName() throws IdentityGovernanceException {
+
         assertEquals(adminForcedPasswordResetConfigIml.getFriendlyName(), "Password Reset");
     }
 
     @Test
     public void testGetCategory() throws IdentityGovernanceException {
+
         assertEquals(adminForcedPasswordResetConfigIml.getCategory(), "Account Management Policies");
     }
 
     @Test
     public void testGetSubCategory() throws IdentityGovernanceException {
+
         assertEquals(adminForcedPasswordResetConfigIml.getSubCategory(), "DEFAULT");
     }
 
     @Test
     public void testGetOrder() throws IdentityGovernanceException {
+
         assertEquals(adminForcedPasswordResetConfigIml.getOrder(), 0);
     }
 
     @Test
     public void testGetPropertyNameMapping() throws IdentityGovernanceException {
+
         Map<String, String> nameMappingExpected = new HashMap<>();
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_ADMIN_PASSWORD_RESET_WITH_RECOVERY_LINK,
                 "Enable Password Reset via Recovery Email");
@@ -83,6 +90,7 @@ public class AdminForcedPasswordResetConfigImplTest {
 
     @Test
     public void testGetPropertyDescriptionMapping() throws IdentityGovernanceException {
+
         Map<String, String> descriptionMappingExpected = new HashMap<>();
         descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_ADMIN_PASSWORD_RESET_WITH_RECOVERY_LINK,
                 "User gets notified with a link to reset password");
@@ -97,6 +105,7 @@ public class AdminForcedPasswordResetConfigImplTest {
 
     @Test
     public void testGetPropertyNames() throws IdentityGovernanceException {
+
         List<String> propertiesExpected = new ArrayList<>();
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_ADMIN_PASSWORD_RESET_WITH_RECOVERY_LINK);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_ADMIN_PASSWORD_RESET_WITH_OTP);
@@ -112,6 +121,7 @@ public class AdminForcedPasswordResetConfigImplTest {
 
     @Test
     public void testGetDefaultPropertyValues() throws IdentityGovernanceException {
+
         String testEnableAdminPasswordResetWithRecoveryLink = "false";
         String testEnableAdminPasswordResetWithOTP = "false";
         String testEnableAdminPasswordResetOffline = "false";
@@ -134,6 +144,7 @@ public class AdminForcedPasswordResetConfigImplTest {
 
     @Test
     public void testGetDefaultProperties() throws IdentityGovernanceException {
+
         String tenantDomain = "admin";
         String[] propertyNames = new String[]{"property1", "property2", "property3"};
 

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImplTest.java
@@ -31,7 +31,7 @@ import java.util.Properties;
 import static org.testng.Assert.assertEquals;
 
 /**
- * This class does unit test coverage for RecoveryConfigImpl class
+ * This class does unit test coverage for RecoveryConfigImpl class.
  */
 public class RecoveryConfigImplTest {
 
@@ -39,36 +39,43 @@ public class RecoveryConfigImplTest {
 
     @BeforeTest
     public void Init() {
+
         recoveryConfigImpl = new RecoveryConfigImpl();
     }
 
     @Test
     public void testGetName() {
+
         assertEquals(recoveryConfigImpl.getName(), "account-recovery");
     }
 
     @Test
     public void testGetFriendlyName() {
+
         assertEquals(recoveryConfigImpl.getFriendlyName(), "Account Recovery");
     }
 
     @Test
     public void testGetCategory() {
+
         assertEquals(recoveryConfigImpl.getCategory(), "Account Management Policies");
     }
 
     @Test
     public void testGetSubCategory() {
+
         assertEquals(recoveryConfigImpl.getSubCategory(), "DEFAULT");
     }
 
     @Test
     public void testGetOrder() {
+
         assertEquals(recoveryConfigImpl.getOrder(), 0);
     }
 
     @Test
     public void testGetPropertyNameMapping() {
+
         Map<String, String> nameMappingExpected = new HashMap<>();
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY, "Enable " +
                 "Notification Based Password Recovery");
@@ -108,6 +115,7 @@ public class RecoveryConfigImplTest {
 
     @Test
     public void testGetPropertyDescriptionMapping() {
+
         Map<String, String> descriptionMappingExpected = new HashMap<String, String>();
         descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE,
                 "Set false if the client application handles notification sending");
@@ -126,6 +134,7 @@ public class RecoveryConfigImplTest {
 
     @Test
     public void testGetPropertyNames() {
+
         List<String> propertiesExpected = new ArrayList<>();
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_RECAPTCHA_ENABLE);
@@ -143,7 +152,7 @@ public class RecoveryConfigImplTest {
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.FORCE_ADD_PW_RECOVERY_QUESTION);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_CALLBACK_REGEX);
 
-        String[] propertiesArrayExpected = propertiesExpected.toArray(new String[propertiesExpected.size()]);
+        String[] propertiesArrayExpected = propertiesExpected.toArray(new String[0]);
 
         String[] properties = recoveryConfigImpl.getPropertyNames();
 
@@ -154,6 +163,7 @@ public class RecoveryConfigImplTest {
 
     @Test
     public void testGetDefaultPropertyValues() throws IdentityGovernanceException {
+
         String testEnableNotificationBasedPasswordRecovery = "false";
         String testEnableQuestionBasedPasswordRecovery = "false";
         String testMinimumAnswers = "2";
@@ -211,6 +221,7 @@ public class RecoveryConfigImplTest {
 
     @Test
     public void testGetDefaultProperties() throws IdentityGovernanceException {
+
         String tenantDomain = "admin";
         String[] propertyNames = new String[]{"property1", "property2", "property3"};
 

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImplTest.java
@@ -19,7 +19,6 @@ package org.wso2.carbon.identity.recovery.connector;
 
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
-import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.governance.IdentityGovernanceException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 
@@ -35,7 +34,7 @@ import java.util.Properties;
 import static org.testng.Assert.assertEquals;
 
 /**
- * This class does unit test coverage for SelfRegistrationConfigImpl class
+ * This class does unit test coverage for SelfRegistrationConfigImpl class.
  */
 public class SelfRegistrationConfigImplTest {
 
@@ -47,40 +46,48 @@ public class SelfRegistrationConfigImplTest {
     private static final String SIGNUP_PURPOSE_GROUP_TYPE = "SYSTEM";
     private static final String CALLBACK_URL = "/carbon/idpmgt/idp-mgt-edit-local.jsp?category=" + CATEGORY +
             "&subCategory=" + FRIENDLY_NAME;
-    private static String consentListURL = "/carbon/consent/list-purposes.jsp?purposeGroup=" + SYSTEM_PURPOSE_GROUP +
-            "&purposeGroupType=" + SIGNUP_PURPOSE_GROUP_TYPE;
+    private static final String CONSENT_LIST_URL = "/carbon/consent/list-purposes.jsp?purposeGroup=" +
+            SYSTEM_PURPOSE_GROUP + "&purposeGroupType=" + SIGNUP_PURPOSE_GROUP_TYPE;
+
     @BeforeTest
     public void Init() {
+
         selfRegistrationConfigImpl = new SelfRegistrationConfigImpl();
     }
 
     @Test
     public void testGetName() {
+
         assertEquals(selfRegistrationConfigImpl.getName(), "self-sign-up");
     }
 
     @Test
     public void testGetFriendlyName() {
+
         assertEquals(selfRegistrationConfigImpl.getFriendlyName(), "User Self Registration");
     }
 
     @Test
     public void testGetCategory() {
+
         assertEquals(selfRegistrationConfigImpl.getCategory(), "Account Management Policies");
     }
 
     @Test
     public void testGetSubCategory() {
+
         assertEquals(selfRegistrationConfigImpl.getSubCategory(), "DEFAULT");
     }
 
     @Test
     public void testGetOrder() {
+
         assertEquals(selfRegistrationConfigImpl.getOrder(), 0);
     }
 
     @Test
     public void testGetPropertyNameMapping() {
+
         Map<String, String> nameMappingExpected = new HashMap<String, String>();
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP,
                 "Enable Self User Registration");
@@ -104,6 +111,7 @@ public class SelfRegistrationConfigImplTest {
 
     @Test
     public void testGetPropertyDescriptionMapping() {
+
         Map<String, String> descriptionMappingExpected = new HashMap<>();
         descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP,
                 "Enable self user registration");
@@ -129,6 +137,7 @@ public class SelfRegistrationConfigImplTest {
 
     @Test
     public void testGetPropertyNames() {
+
         List<String> propertiesExpected = new ArrayList<>();
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION);
@@ -139,7 +148,7 @@ public class SelfRegistrationConfigImplTest {
         propertiesExpected
                 .add(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_CALLBACK_REGEX);
-        String[] propertiesArrayExpected = propertiesExpected.toArray(new String[propertiesExpected.size()]);
+        String[] propertiesArrayExpected = propertiesExpected.toArray(new String[0]);
 
         String[] properties = selfRegistrationConfigImpl.getPropertyNames();
 
@@ -150,6 +159,7 @@ public class SelfRegistrationConfigImplTest {
 
     @Test
     public void testGetDefaultPropertyValues() throws IdentityGovernanceException {
+
         String testEnableSelfSignUp = "false";
         String testEnableAccountLockOnCreation = "true";
         String testEnableNotificationInternallyManage = "true";
@@ -175,7 +185,7 @@ public class SelfRegistrationConfigImplTest {
         propertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_CALLBACK_REGEX,
                 selfRegistrationCallbackRegex);
         try {
-            propertiesExpected.put(LIST_PURPOSE_PROPERTY_KEY, consentListURL + "&callback=" + (URLEncoder.encode
+            propertiesExpected.put(LIST_PURPOSE_PROPERTY_KEY, CONSENT_LIST_URL + "&callback=" + (URLEncoder.encode
                     (CALLBACK_URL, StandardCharsets.UTF_8.name())));
         } catch (UnsupportedEncodingException e) {
             throw new IdentityGovernanceException("Error while encoding callback url: " + CALLBACK_URL, e);
@@ -190,6 +200,7 @@ public class SelfRegistrationConfigImplTest {
 
     @Test
     public void testGetDefaultProperties() throws IdentityGovernanceException {
+
         String tenantDomain = "admin";
         String[] propertyNames = new String[]{"property1", "property2", "property3"};
 

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImplTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.recovery.connector;
+
+import org.apache.axiom.om.OMElement;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.core.util.IdentityConfigParser;
+import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
+import org.wso2.carbon.identity.governance.IdentityGovernanceException;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
+import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.xml.namespace.QName;
+
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * This class does unit test coverage for UserClaimUpdateConfigImpl class.
+ */
+@PrepareForTest({IdentityConfigParser.class})
+public class UserClaimUpdateConfigImplTest extends PowerMockIdentityBaseTest {
+
+    private UserClaimUpdateConfigImpl userClaimUpdateConfig;
+    private static final String CONNECTOR_NAME = "user-claim-update";
+    private static final String CATEGORY = "Account Management Policies";
+    private static final String FRIENDLY_NAME = "User Claim Update";
+    private static final String SUB_CATEGORY = "DEFAULT";
+    private static final String TENANT_DOMAIN = "carbon.super";
+    private static final String USER_CLAIM_UPDATE_ELEMENT = "UserClaimUpdate";
+    private static final String ENABLE_ELEMENT = "Enable";
+    private static final String CLAIM_ELEMENT = "Claim";
+    private static final String CLAIM_URI = "uri";
+    private static final String VERIFICATION_CODE_ELEMENT = "VerificationCode";
+    private static final String EXPIRY_TIME_ELEMENT = "ExpiryTime";
+    private static final String VERIFICATION_ON_UPDATE_ELEMENT = "VerificationOnUpdate";
+
+    @BeforeTest
+    public void init() {
+
+        userClaimUpdateConfig = new UserClaimUpdateConfigImpl();
+    }
+
+    @Test
+    public void testGetName() {
+
+        assertEquals(userClaimUpdateConfig.getName(), CONNECTOR_NAME);
+    }
+
+    @Test
+    public void testGetFriendlyName() {
+
+        assertEquals(userClaimUpdateConfig.getFriendlyName(), FRIENDLY_NAME);
+    }
+
+    @Test
+    public void testGetCategory() {
+
+        assertEquals(userClaimUpdateConfig.getCategory(), CATEGORY);
+    }
+
+    @Test
+    public void testGetSubCategory() {
+
+        assertEquals(userClaimUpdateConfig.getSubCategory(), SUB_CATEGORY);
+    }
+
+    @Test
+    public void testGetOrder() {
+
+        assertEquals(userClaimUpdateConfig.getOrder(), 0);
+    }
+
+    @Test
+    public void testGetPropertyNameMapping() {
+
+        Map<String, String> nameMappingExpected = new HashMap<>();
+        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION_ON_UPDATE,
+                "Enable user email verification on update");
+        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_EXPIRY_TIME,
+                "Email verification on update link expiry time");
+        Map<String, String> nameMapping = userClaimUpdateConfig.getPropertyNameMapping();
+        assertEquals(nameMapping, nameMappingExpected, "Maps are not equal.");
+    }
+
+    @Test
+    public void testGetPropertyDescriptionMapping() {
+
+        Map<String, String> descriptionMappingExpected = new HashMap<>();
+        descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION_ON_UPDATE,
+                "Trigger a verification notification when user's email address is updated.");
+        descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig
+                .EMAIL_VERIFICATION_ON_UPDATE_EXPIRY_TIME, "Validity time of the email confirmation link in " +
+                "minutes.");
+        Map<String, String> descriptionMapping = userClaimUpdateConfig.getPropertyDescriptionMapping();
+        assertEquals(descriptionMapping, descriptionMappingExpected, "Maps are not equal.");
+    }
+
+    @Test
+    public void testGetPropertyNames() {
+
+        List<String> propertiesExpected = new ArrayList<>();
+        propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION_ON_UPDATE);
+        propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_EXPIRY_TIME);
+        String[] propertiesArrayExpected = propertiesExpected.toArray(new String[0]);
+
+        String[] properties = userClaimUpdateConfig.getPropertyNames();
+
+        for (int i = 0; i < propertiesArrayExpected.length; i++) {
+            assertEquals(properties[i], propertiesArrayExpected[i], "Properties are not equal.");
+        }
+    }
+
+    @Test
+    public void testGetDefaultPropertyValues() throws IdentityGovernanceException {
+
+        IdentityConfigParser mockConfigParser = mock(IdentityConfigParser.class);
+        mockStatic(IdentityConfigParser.class);
+        when(IdentityConfigParser.getInstance()).thenReturn(mockConfigParser);
+        OMElement mockOMElement = mock(OMElement.class);
+        when(mockConfigParser.getConfigElement(USER_CLAIM_UPDATE_ELEMENT)).thenReturn(mockOMElement);
+        ArrayList<OMElement> claimsList = new ArrayList<>();
+        claimsList.add(mockOMElement);
+        Iterator claims = claimsList.iterator();
+        when(mockOMElement.getChildrenWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                CLAIM_ELEMENT))).thenReturn(claims);
+        when(mockOMElement.getAttributeValue(new QName(CLAIM_URI))).thenReturn(IdentityRecoveryConstants
+                .EMAIL_ADDRESS_CLAIM);
+        when(mockOMElement.getFirstChildWithName(new QName(IdentityCoreConstants
+                .IDENTITY_DEFAULT_NAMESPACE, VERIFICATION_ON_UPDATE_ELEMENT))).thenReturn(mockOMElement);
+        when(mockOMElement.getFirstChildWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                ENABLE_ELEMENT))).thenReturn(mockOMElement);
+        when(mockOMElement.getFirstChildWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                VERIFICATION_CODE_ELEMENT))).thenReturn(mockOMElement);
+        when(mockOMElement.getFirstChildWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                EXPIRY_TIME_ELEMENT))).thenReturn(mockOMElement);
+
+        Properties defaultPropertyValues = userClaimUpdateConfig.getDefaultPropertyValues(TENANT_DOMAIN);
+        assertNotNull(defaultPropertyValues.getProperty(IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_EMAIL_VERIFICATION_ON_UPDATE));
+        assertNotNull(defaultPropertyValues.getProperty(IdentityRecoveryConstants.ConnectorConfig
+                .EMAIL_VERIFICATION_ON_UPDATE_EXPIRY_TIME));
+    }
+
+    @Test
+    public void testGetDefaultProperties() throws IdentityGovernanceException {
+
+        String[] propertyNames = new String[]{IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_EMAIL_VERIFICATION_ON_UPDATE, IdentityRecoveryConstants.ConnectorConfig
+                .EMAIL_VERIFICATION_ON_UPDATE_EXPIRY_TIME, "testproperty"};
+
+        IdentityConfigParser mockConfigParser = mock(IdentityConfigParser.class);
+        mockStatic(IdentityConfigParser.class);
+        when(IdentityConfigParser.getInstance()).thenReturn(mockConfigParser);
+        Map<String, String> defaultPropertyValues = userClaimUpdateConfig.getDefaultPropertyValues(propertyNames,
+                TENANT_DOMAIN);
+        assertEquals(defaultPropertyValues.size(), propertyNames.length - 1, "Maps are not equal as" +
+                " their size differs.");
+    }
+}

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImplTest.java
@@ -34,7 +34,7 @@ import java.util.Properties;
 import static org.testng.Assert.assertEquals;
 
 /**
- * This class does unit test coverage for UserEmailVerificationConfigImpl class
+ * This class does unit test coverage for UserEmailVerificationConfigImpl class.
  */
 public class UserEmailVerificationConfigImplTest {
 
@@ -57,31 +57,37 @@ public class UserEmailVerificationConfigImplTest {
 
     @Test
     public void testGetName() {
+
         assertEquals(userEmailVerificationConfig.getName(), "user-email-verification");
     }
 
     @Test
     public void testGetFriendlyName() {
+
         assertEquals(userEmailVerificationConfig.getFriendlyName(), FRIENDLY_NAME);
     }
 
     @Test
     public void testGetCategory() {
+
         assertEquals(userEmailVerificationConfig.getCategory(), CATEGORY);
     }
 
     @Test
     public void testGetSubCategory() {
+
         assertEquals(userEmailVerificationConfig.getSubCategory(), "DEFAULT");
     }
 
     @Test
     public void testGetOrder() {
+
         assertEquals(userEmailVerificationConfig.getOrder(), 0);
     }
 
     @Test
     public void testGetPropertyNameMapping() {
+
         Map<String, String> nameMappingExpected = new HashMap<>();
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMIL_VERIFICATION,
                 "Enable User Email Verification");
@@ -103,6 +109,7 @@ public class UserEmailVerificationConfigImplTest {
 
     @Test
     public void testGetPropertyDescriptionMapping() {
+
         Map<String, String> descriptionMappingExpected = new HashMap<>();
         descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMIL_VERIFICATION,
                 "Enable to trigger a verification notification during user creation");
@@ -127,13 +134,14 @@ public class UserEmailVerificationConfigImplTest {
 
     @Test
     public void testGetPropertyNames() {
+
         List<String> propertiesExpected = new ArrayList<>();
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMIL_VERIFICATION);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_ACCOUNT_LOCK_ON_CREATION);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_INTERNALLY_MANAGE);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_EXPIRY_TIME);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ASK_PASSWORD_EXPIRY_TIME);
-        String[] propertiesArrayExpected = propertiesExpected.toArray(new String[propertiesExpected.size()]);
+        String[] propertiesArrayExpected = propertiesExpected.toArray(new String[0]);
 
         String[] properties = userEmailVerificationConfig.getPropertyNames();
 
@@ -144,6 +152,7 @@ public class UserEmailVerificationConfigImplTest {
 
     @Test
     public void testGetDefaultPropertyValues() throws IdentityGovernanceException {
+
         String testEnableEmailVerification = "false";
         String testEnableEmailAccountLockOnCreation = "true";
         String testEnableNotificationInternallyManage = "true";
@@ -180,6 +189,7 @@ public class UserEmailVerificationConfigImplTest {
 
     @Test
     public void testGetDefaultProperties() throws IdentityGovernanceException {
+
         String tenantDomain = "admin";
         String[] propertyNames = new String[]{"property1", "property2", "property3"};
 

--- a/components/org.wso2.carbon.identity.recovery/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.recovery/src/test/resources/testng.xml
@@ -23,6 +23,7 @@
             <class name="org.wso2.carbon.identity.recovery.connector.AdminForcedPasswordResetConfigImplTest" />
             <class name="org.wso2.carbon.identity.recovery.connector.RecoveryConfigImplTest" />
             <class name="org.wso2.carbon.identity.recovery.connector.SelfRegistrationConfigImplTest" />
+            <class name="org.wso2.carbon.identity.recovery.connector.UserClaimUpdateConfigImplTest" />
             <class name="org.wso2.carbon.identity.recovery.connector.UserEmailVerificationConfigImplTest" />
             <class name="org.wso2.carbon.identity.recovery.signup.UserSelfRegistrationManagerTest"/>
             <class name="org.wso2.carbon.identity.recovery.internal.service.impl.UserAccountRecoveryManagerTest"/>


### PR DESCRIPTION
### Proposed changes in this pull request
This PR adds unit tests for UserClaimUpdateConfigImpl class introduced with https://github.com/wso2-extensions/identity-governance/pull/349
