### PR TITLE
Fix error messages for username recovery when NotifyUserExistence enabled

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/username/UsernameRecoveryManagerImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/username/UsernameRecoveryManagerImpl.java
@@ -104,8 +104,7 @@ public class UsernameRecoveryManagerImpl implements UsernameRecoveryManager {
                 if (Boolean.parseBoolean(
                         IdentityUtil.getProperty(IdentityRecoveryConstants.ConnectorConfig.NOTIFY_USER_EXISTENCE))) {
                     throw Utils.handleClientException(
-                            IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_USER_OR_MORE_THAN_ONE_USER_FOUND,
-                            null);
+                            IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_USER_FOUND, null);
                 }
                 return null;
             }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/username/NotificationUsernameRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/username/NotificationUsernameRecoveryManager.java
@@ -208,8 +208,7 @@ public class NotificationUsernameRecoveryManager {
                         .equals(errorCode)) {
                     if (Boolean.parseBoolean(IdentityUtil
                                     .getProperty(IdentityRecoveryConstants.ConnectorConfig.NOTIFY_USER_EXISTENCE))) {
-                        throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages
-                                .ERROR_CODE_NO_USER_OR_MORE_THAN_ONE_USER_FOUND, null);
+                        throw exception;
                     }
                     /* If the notify user is not enabled, return an NULL object so that the user is not notified with
                     an error. */


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/8048

When users not found for given claims, the error message is shown as "No user found".
When multiple users found for given claims, the error message is shown as "Multiple users found for given claims".