### PR TITLE
Uniqueness and regex pattern validation for the challenge question answers

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -27,6 +27,7 @@ public class IdentityRecoveryConstants {
     public static final String IDENTITY_I18N_QUESTIONS =
             IDENTITY_MANAGEMENT_I18N_PATH + "/questionCollection";
     public static final String LINE_SEPARATOR = "!";
+    public static final String DEFAULT_REGEX = ".*";
     public static final String CHALLENGE_QUESTION_URI = "http://wso2.org/claims/challengeQuestionUris";
     public static final String NOTIFICATION_TYPE_PASSWORD_RESET = "passwordreset";
     public static final String NOTIFICATION_TYPE_RESEND_PASSWORD_RESET = "resendPasswordReset";
@@ -56,6 +57,9 @@ public class IdentityRecoveryConstants {
     public static final String ACCOUNT_DISABLED_CLAIM = "http://wso2.org/claims/identity/accountDisabled";
     public static final String FAILED_LOGIN_LOCKOUT_COUNT_CLAIM =
             "http://wso2.org/claims/identity/failedLoginLockoutCount";
+
+    public static final String USER_NEW_CHALLENGE_ANSWERS = "userNewChallengeAnswers";
+    public static final String USER_OLD_CHALLENGE_ANSWERS = "userOldChallengeAnswers";
 
     // Notification channel claims.
     public static final String VERIFY_EMAIL_CLIAM = "http://wso2.org/claims/identity/verifyEmail";
@@ -271,7 +275,17 @@ public class IdentityRecoveryConstants {
         ERROR_CODE_INVALID_USERNAME("PWR-10009", "Invalid username! Username should be in email format."),
 
         // Resend Account Confirmation.
-        ERROR_CODE_USER_OBJECT_NOT_FOUND("PWR-60001", "User object not found in the request");
+        ERROR_CODE_USER_OBJECT_NOT_FOUND("PWR-60001", "User object not found in the request"),
+
+        /**
+         * CQM - Challenge Question Manager.
+         *
+         * @see <href="https://github.com/wso2/identity-api-user/blob/master/components/org.wso2.carbon.identity.api.user.challenge/org.wso2.carbon.identity.api.user.challenge.common/src/main/java/org/wso2/carbon/identity/api/user/challenge/common/Constant.java">identity-api.user</>
+         */
+        ERROR_CODE_INVALID_ANSWER_FORMAT("10016", "Invalid answer format in the given answer " +
+                "for the challenge question '%s'."),
+        ERROR_CODE_NOT_UNIQUE_ANSWER("10017", "The given answer for the challenge question, " +
+                "'%s' has been used more than once.");
 
         private final String code;
         private final String message;
@@ -427,6 +441,8 @@ public class IdentityRecoveryConstants {
         public static final String PASSWORD_RECOVERY_RECAPTCHA_ENABLE = "Recovery.ReCaptcha.Password.Enable";
         public static final String USERNAME_RECOVERY_RECAPTCHA_ENABLE = "Recovery.ReCaptcha.Username.Enable";
 
+        public static final String CHALLENGE_QUESTION_ANSWER_REGEX = "Recovery.Question.Answer.Regex";
+        public static final String ENFORCE_CHALLENGE_QUESTION_ANSWER_UNIQUENESS = "Recovery.Question.Answer.Uniqueness";
     }
 
     public static class SQLQueries {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
@@ -71,6 +71,10 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
                 "reCaptcha for Password Recovery");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.QUESTION_BASED_PW_RECOVERY, "Enable Security " +
                 "Question Based Password Recovery");
+        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.CHALLENGE_QUESTION_ANSWER_REGEX,
+                "Challenge question answer regex");
+        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.ENFORCE_CHALLENGE_QUESTION_ANSWER_UNIQUENESS,
+                "Enforce challenge question answer uniqueness");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.QUESTION_MIN_NO_ANSWER, "Number Of Questions " +
                 "Required For Password Recovery");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.USERNAME_RECOVERY_ENABLE, "Enable Username Recovery");
@@ -101,6 +105,10 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         Map<String, String> descriptionMapping = new HashMap<>();
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE,
                 "Set false if the client application handles notification sending");
+        descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.CHALLENGE_QUESTION_ANSWER_REGEX,
+                "Challenge question answer regex");
+        descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.ENFORCE_CHALLENGE_QUESTION_ANSWER_UNIQUENESS,
+                "Enforce challenge question answer uniqueness");
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_QUESTION_PASSWORD_RECAPTCHA_ENABLE,
                 "Show captcha for challenge question based password recovery");
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.FORCE_ADD_PW_RECOVERY_QUESTION,
@@ -120,6 +128,8 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         properties.add(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_RECAPTCHA_ENABLE);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.QUESTION_BASED_PW_RECOVERY);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.QUESTION_MIN_NO_ANSWER);
+        properties.add(IdentityRecoveryConstants.ConnectorConfig.CHALLENGE_QUESTION_ANSWER_REGEX);
+        properties.add(IdentityRecoveryConstants.ConnectorConfig.ENFORCE_CHALLENGE_QUESTION_ANSWER_UNIQUENESS);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_QUESTION_PASSWORD_RECAPTCHA_ENABLE);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_QUESTION_PASSWORD_RECAPTCHA_MAX_FAILED_ATTEMPTS);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.USERNAME_RECOVERY_ENABLE);
@@ -140,6 +150,8 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         String enableNotificationBasedPasswordRecovery = "false";
         String enableQuestionBasedPasswordRecovery = "false";
         String minimumAnswers = "2";
+        String challengeQuestionAnswerRegex = IdentityRecoveryConstants.DEFAULT_REGEX;
+        String enforceChallengeQuestionAnswerUniqueness = "false";
         String enableRecoveryQuestionPasswordReCaptcha = "true";
         String recoveryQuestionPasswordReCaptchaMaxFailedAttempts = "2";
         String enableUsernameRecovery = "false";
@@ -159,6 +171,10 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
                 IdentityRecoveryConstants.ConnectorConfig.QUESTION_BASED_PW_RECOVERY);
         String miniMumAnswerProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.QUESTION_MIN_NO_ANSWER);
+        String challengeQuestionAnswerRegexProperty = IdentityUtil.getProperty(
+                IdentityRecoveryConstants.ConnectorConfig.CHALLENGE_QUESTION_ANSWER_REGEX);
+        String challengeQuestionAnswerUniquenessProperty = IdentityUtil.getProperty(
+                IdentityRecoveryConstants.ConnectorConfig.ENFORCE_CHALLENGE_QUESTION_ANSWER_UNIQUENESS);
         String recoveryQuestionPasswordReCaptcha = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.RECOVERY_QUESTION_PASSWORD_RECAPTCHA_ENABLE);
         String passwordReCaptchaMaxFailedAttempts = IdentityUtil.getProperty(IdentityRecoveryConstants.
@@ -191,6 +207,12 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         }
         if (StringUtils.isNotEmpty(questionBasedPasswordRecovery)) {
             enableQuestionBasedPasswordRecovery = questionBasedPasswordRecovery;
+        }
+        if (StringUtils.isNotEmpty(challengeQuestionAnswerRegexProperty)) {
+            challengeQuestionAnswerRegex = challengeQuestionAnswerRegexProperty;
+        }
+        if (StringUtils.isNotEmpty(challengeQuestionAnswerUniquenessProperty)) {
+            enforceChallengeQuestionAnswerUniqueness = challengeQuestionAnswerUniquenessProperty;
         }
         if (StringUtils.isNotEmpty(notificationInternallyManged)) {
             enableNotificationInternallyManage = notificationInternallyManged;
@@ -238,6 +260,10 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
                 enableQuestionBasedPasswordRecovery);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.QUESTION_MIN_NO_ANSWER,
                 minimumAnswers);
+        defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.CHALLENGE_QUESTION_ANSWER_REGEX,
+                challengeQuestionAnswerRegex);
+        defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.ENFORCE_CHALLENGE_QUESTION_ANSWER_UNIQUENESS,
+                enforceChallengeQuestionAnswerUniqueness);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_QUESTION_PASSWORD_RECAPTCHA_ENABLE,
                 enableRecoveryQuestionPasswordReCaptcha);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/ChallengeAnswerValidationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/ChallengeAnswerValidationHandler.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.recovery.handler;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.bean.context.MessageContext;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.IdentityEventClientException;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.IdentityEventServerException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryServerException;
+import org.wso2.carbon.identity.recovery.model.UserChallengeAnswer;
+import org.wso2.carbon.identity.recovery.util.Utils;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.UserStoreManager;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This class is used to validate the challenge question answers.
+ */
+public class ChallengeAnswerValidationHandler extends AbstractEventHandler {
+
+    private static final Log log = LogFactory.getLog(ChallengeAnswerValidationHandler.class);
+
+    public String getName() {
+
+        return "challengeAnswerValidation";
+    }
+
+    @Override
+    public int getPriority(MessageContext messageContext) {
+
+        return 50;
+    }
+
+    @Override
+    public void handleEvent(Event event) throws IdentityEventException {
+
+        String eventName = event.getEventName();
+        Map<String, Object> eventProperties = event.getEventProperties();
+        UserStoreManager userStoreManager = (UserStoreManager) eventProperties.
+                get(IdentityEventConstants.EventProperty.USER_STORE_MANAGER);
+        User user = (User) eventProperties.get(IdentityEventConstants.EventProperty.USER);
+        UserChallengeAnswer[] userChallengeAnswers = (UserChallengeAnswer[]) eventProperties.
+                get(IdentityEventConstants.EventProperty.USER_CHALLENGE_ANSWERS);
+        Map<String, String> existingQuestionAndAnswers = (Map<String, String>)
+                eventProperties.get(IdentityEventConstants.EventProperty.USER_OLD_CHALLENGE_ANSWERS);
+        user.setUserStoreDomain(userStoreManager.getRealmConfiguration().
+                getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME));
+
+        if (IdentityEventConstants.Event.PRE_SET_CHALLENGE_QUESTION_ANSWERS.equals(eventName)) {
+            try {
+                validateChallengeAnswers(user, userChallengeAnswers, existingQuestionAndAnswers);
+            } catch (IdentityRecoveryClientException e) {
+                throw new IdentityEventClientException(e.getErrorCode(), e.getMessage(), e);
+            } catch (IdentityRecoveryServerException e) {
+                throw new IdentityEventServerException(e.getErrorCode(), e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * Validate challenge answers.
+     *
+     * @param user                       User.
+     * @param userChallengeAnswers       Challenge Answers.
+     * @param existingQuestionAndAnswers Previously stored answers.
+     * @throws IdentityEventException          If an error occurred while reading the configurations.
+     * @throws IdentityRecoveryClientException If an invalid answers was given.
+     * @throws IdentityRecoveryServerException If an error occurred while hashing the answers.
+     */
+    private void validateChallengeAnswers(User user, UserChallengeAnswer[] userChallengeAnswers,
+                                          Map<String, String> existingQuestionAndAnswers)
+            throws IdentityEventException, IdentityRecoveryClientException, IdentityRecoveryServerException {
+
+        Map<String, List<UserChallengeAnswer>> challengeAnswers = filterChallengeAnswers(userChallengeAnswers,
+                existingQuestionAndAnswers);
+        List<UserChallengeAnswer> existingChallengeAnswers = challengeAnswers.
+                get(IdentityRecoveryConstants.USER_OLD_CHALLENGE_ANSWERS);
+        List<UserChallengeAnswer> newChallengeAnswers = challengeAnswers.
+                get(IdentityRecoveryConstants.USER_NEW_CHALLENGE_ANSWERS);
+        validateChallengeAnswerRegex(user.getTenantDomain(), newChallengeAnswers);
+        if (Boolean.parseBoolean(Utils.getConnectorConfig(IdentityRecoveryConstants.ConnectorConfig.
+                ENFORCE_CHALLENGE_QUESTION_ANSWER_UNIQUENESS, user.getTenantDomain()))) {
+            validateChallengeAnswerUniqueness(newChallengeAnswers, existingChallengeAnswers);
+        }
+    }
+
+    /**
+     * Filter previously stored and newly added answers of the challenge questions.
+     *
+     * @param userChallengeAnswers       List of UserChallengeAnswer objects.
+     * @param existingQuestionAndAnswers Map of existing challenge question and answers.
+     * @return Map of existing and new challenge answers.
+     */
+    private Map<String, List<UserChallengeAnswer>> filterChallengeAnswers(UserChallengeAnswer[] userChallengeAnswers,
+                                                                          Map<String, String> existingQuestionAndAnswers) {
+
+        Map<String, List<UserChallengeAnswer>> challengeAnswers = new HashMap<>();
+        List<UserChallengeAnswer> existingChallengeAnswers = new ArrayList<>();
+        List<UserChallengeAnswer> newChallengeAnswers = new ArrayList<>();
+        String separator = IdentityUtil.getProperty(IdentityRecoveryConstants.ConnectorConfig
+                .QUESTION_CHALLENGE_SEPARATOR);
+        for (UserChallengeAnswer userChallengeAnswer : userChallengeAnswers) {
+            if (StringUtils.isNotBlank(userChallengeAnswer.getQuestion().getQuestionSetId()) &&
+                    StringUtils.isNotBlank(userChallengeAnswer.getQuestion().getQuestion())
+                    && StringUtils.isNotBlank(userChallengeAnswer.getAnswer())) {
+                String oldValue = existingQuestionAndAnswers
+                        .get(userChallengeAnswer.getQuestion().getQuestionSetId().trim());
+                if (StringUtils.isNotBlank(oldValue) && oldValue.contains(separator)) {
+                    String oldAnswer = oldValue.split(separator)[1];
+                    if (oldAnswer.trim().equals(userChallengeAnswer.getAnswer().trim())) {
+                        existingChallengeAnswers.add(userChallengeAnswer);
+                    } else {
+                        newChallengeAnswers.add(userChallengeAnswer);
+                    }
+                } else {
+                    newChallengeAnswers.add(userChallengeAnswer);
+                }
+            }
+        }
+        challengeAnswers.put(IdentityRecoveryConstants.USER_OLD_CHALLENGE_ANSWERS, existingChallengeAnswers);
+        challengeAnswers.put(IdentityRecoveryConstants.USER_NEW_CHALLENGE_ANSWERS, newChallengeAnswers);
+        return challengeAnswers;
+    }
+
+    /**
+     * Validate the challenge question answer regex.
+     *
+     * @param tenantDomain        Tenant Domain.
+     * @param newChallengeAnswers Newly added challenge question answers.
+     * @throws IdentityEventException          Error while reading the configurations.
+     * @throws IdentityRecoveryClientException Error while validating the answer regex.
+     */
+    private void validateChallengeAnswerRegex(String tenantDomain,
+                                              List<UserChallengeAnswer> newChallengeAnswers)
+            throws IdentityRecoveryClientException, IdentityEventException {
+
+        for (UserChallengeAnswer userChallengeAnswer : newChallengeAnswers) {
+            if (!(userChallengeAnswer.getAnswer()).matches(Utils.getConnectorConfig(IdentityRecoveryConstants.
+                    ConnectorConfig.CHALLENGE_QUESTION_ANSWER_REGEX, tenantDomain))) {
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("The challenge question answer for the question, '%s' is not in the " +
+                            "expected format.", userChallengeAnswer.getQuestion().getQuestion()));
+                }
+                throw Utils.handleClientException(
+                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_ANSWER_FORMAT,
+                        userChallengeAnswer.getQuestion().getQuestion());
+            }
+        }
+    }
+
+    /**
+     * Validate the uniqueness of a given answer.
+     *
+     * @param newChallengeAnswers      Newly added challenge question answers.
+     * @param existingChallengeAnswers Existing challenge question answers.
+     * @throws IdentityRecoveryServerException Error while hashing the newly added answers.
+     * @throws IdentityRecoveryClientException Error while validating the answer uniqueness.
+     */
+    private void validateChallengeAnswerUniqueness(List<UserChallengeAnswer> newChallengeAnswers,
+                                                   List<UserChallengeAnswer> existingChallengeAnswers)
+            throws IdentityRecoveryServerException, IdentityRecoveryClientException {
+
+        Set<String> uniqueChallengeAnswerHashSet = new HashSet<>();
+        for (UserChallengeAnswer existingChallengeAnswer : existingChallengeAnswers) {
+            uniqueChallengeAnswerHashSet.add(existingChallengeAnswer.getAnswer().trim());
+        }
+
+        String hashedNewChallengeAnswer;
+        for (UserChallengeAnswer userChallengeAnswer : newChallengeAnswers) {
+            try {
+                hashedNewChallengeAnswer = Utils.doHash(userChallengeAnswer.getAnswer().trim().toLowerCase());
+            } catch (UserStoreException e) {
+                throw Utils.handleServerException(
+                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_HASHING_ALGO, null);
+            }
+            if (!uniqueChallengeAnswerHashSet.add(hashedNewChallengeAnswer)) {
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("The challenge question answer is not unique. The given answer for " +
+                                    "the challenge question '%s' has been used more than once.",
+                            userChallengeAnswer.getQuestion().getQuestion()));
+                }
+                throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NOT_UNIQUE_ANSWER,
+                        userChallengeAnswer.getQuestion().getQuestion());
+            }
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.identity.recovery.connector.SelfRegistrationConfigImpl;
 import org.wso2.carbon.identity.recovery.connector.UserEmailVerificationConfigImpl;
 import org.wso2.carbon.identity.recovery.handler.AccountConfirmationValidationHandler;
 import org.wso2.carbon.identity.recovery.handler.AdminForcedPasswordResetHandler;
+import org.wso2.carbon.identity.recovery.handler.ChallengeAnswerValidationHandler;
 import org.wso2.carbon.identity.recovery.handler.CodeInvalidationHandler;
 import org.wso2.carbon.identity.recovery.handler.TenantRegistrationVerificationHandler;
 import org.wso2.carbon.identity.recovery.handler.UserEmailVerificationHandler;
@@ -120,6 +121,8 @@ public class IdentityRecoveryServiceComponent {
                     .getInstance();
             bundleContext.registerService(PostAuthenticationHandler.class.getName(),
                     postAuthnMissingChallengeQuestions, null);
+            bundleContext.registerService(AbstractEventHandler.class.getName(),
+                    new ChallengeAnswerValidationHandler(), null);
         } catch (Exception e) {
             log.error("Error while activating identity governance component.", e);
         }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.recovery.util;
 
 import org.apache.axiom.om.util.Base64;
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -372,6 +373,90 @@ public class Utils {
             }
         }
 
+    }
+
+    /**
+     * Get the claim values for given claim list of user.
+     *
+     * @param user       User.
+     * @param claimsList Claims list to retrieve.
+     * @return Map of claims list with corresponding values.
+     * @throws IdentityRecoveryClientException If an invalid input is detected.
+     * @throws IdentityRecoveryServerException If an error occurred while retrieving claims.
+     */
+    public static Map<String, String> getClaimListOfUser(User user, String[] claimsList)
+            throws IdentityRecoveryClientException, IdentityRecoveryServerException {
+
+        org.wso2.carbon.user.core.UserStoreManager userStoreManager = getUserStoreManager(user);
+        String userStoreQualifiedUsername = IdentityUtil.addDomainToName(user.getUserName(), user.getUserStoreDomain());
+        if (ArrayUtils.isEmpty(claimsList)) {
+            throw handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FAILED_TO_LOAD_USER_CLAIMS,
+                    null);
+        }
+        try {
+            return userStoreManager
+                    .getUserClaimValues(userStoreQualifiedUsername, claimsList, UserCoreConstants.DEFAULT_PROFILE);
+        } catch (UserStoreException e) {
+            throw handleServerException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FAILED_TO_LOAD_USER_CLAIMS,
+                    user.getUserName(), e);
+        }
+    }
+
+    /**
+     * Set user claims list.
+     *
+     * @param user      User.
+     * @param claimsMap Map of claims list to update.
+     * @throws IdentityRecoveryClientException If an invalid input is detected.
+     * @throws IdentityRecoveryServerException If an error occurred while updating user claims.
+     */
+    public static void setClaimsListOfUser(User user, Map<String, String> claimsMap)
+            throws IdentityRecoveryClientException, IdentityRecoveryServerException {
+
+        org.wso2.carbon.user.core.UserStoreManager userStoreManager = getUserStoreManager(user);
+        String userStoreQualifiedUsername = IdentityUtil.addDomainToName(user.getUserName(),
+                user.getUserStoreDomain());
+        try {
+            if (MapUtils.isNotEmpty(claimsMap)) {
+                userStoreManager.setUserClaimValues(userStoreQualifiedUsername, claimsMap,
+                        UserCoreConstants.DEFAULT_PROFILE);
+            }
+        } catch (UserStoreException e) {
+            throw handleServerException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FAILED_TO_UPDATE_USER_CLAIMS,
+                    null, e);
+        }
+    }
+
+    private static org.wso2.carbon.user.core.UserStoreManager getUserStoreManager(User user)
+            throws IdentityRecoveryClientException, IdentityRecoveryServerException {
+
+        org.wso2.carbon.user.core.UserStoreManager userStoreManager;
+
+        // Validate method inputs.
+        if (user == null) {
+            throw handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_USER,
+                    "Invalid User Data provided.");
+        }
+
+        int tenantId = IdentityTenantUtil.getTenantId(user.getTenantDomain());
+        try {
+            RealmService realmService = IdentityRecoveryServiceDataHolder.getInstance().getRealmService();
+            if (realmService == null || realmService.getTenantUserRealm(tenantId) == null) {
+                throw handleServerException(IdentityRecoveryConstants.ErrorMessages.
+                        ERROR_CODE_FAILED_TO_LOAD_REALM_SERVICE, user.getTenantDomain());
+            }
+            userStoreManager = (org.wso2.carbon.user.core.UserStoreManager) realmService.getTenantUserRealm(tenantId).
+                    getUserStoreManager();
+        } catch (UserStoreException e) {
+            throw handleServerException(IdentityRecoveryConstants.ErrorMessages.
+                    ERROR_CODE_FAILED_TO_LOAD_REALM_SERVICE, user.getTenantDomain(), e);
+        }
+
+        if (userStoreManager == null) {
+            throw handleServerException(IdentityRecoveryConstants.ErrorMessages.
+                    ERROR_CODE_FAILED_TO_LOAD_USER_STORE_MANAGER, null);
+        }
+        return userStoreManager;
     }
 
     public static String getRecoveryConfigs(String key, String tenantDomain) throws IdentityRecoveryServerException {

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImplTest.java
@@ -85,6 +85,10 @@ public class RecoveryConfigImplTest {
                 "reCaptcha for Password Recovery");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.QUESTION_BASED_PW_RECOVERY, "Enable Security " +
                 "Question Based Password Recovery");
+        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.CHALLENGE_QUESTION_ANSWER_REGEX,
+                "Challenge question answer regex");
+        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENFORCE_CHALLENGE_QUESTION_ANSWER_UNIQUENESS,
+                "Enforce challenge question answer uniqueness");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.QUESTION_MIN_NO_ANSWER, "Number Of Questions " +
                 "Required For Password Recovery");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.USERNAME_RECOVERY_ENABLE, "Enable Username Recovery");
@@ -127,6 +131,10 @@ public class RecoveryConfigImplTest {
                 "Recovery callback URL regex");
         descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_EXPIRY_TIME,
                 "Expiration time of the SMS OTP code for password recovery");
+        descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.CHALLENGE_QUESTION_ANSWER_REGEX,
+                "Challenge question answer regex");
+        descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENFORCE_CHALLENGE_QUESTION_ANSWER_UNIQUENESS,
+                "Enforce challenge question answer uniqueness");
         Map<String, String> descriptionMapping = recoveryConfigImpl.getPropertyDescriptionMapping();
 
         assertEquals(descriptionMapping, descriptionMappingExpected, "Maps are not equal");
@@ -140,6 +148,8 @@ public class RecoveryConfigImplTest {
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_RECAPTCHA_ENABLE);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.QUESTION_BASED_PW_RECOVERY);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.QUESTION_MIN_NO_ANSWER);
+        propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.CHALLENGE_QUESTION_ANSWER_REGEX);
+        propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ENFORCE_CHALLENGE_QUESTION_ANSWER_UNIQUENESS);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_QUESTION_PASSWORD_RECAPTCHA_ENABLE);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_QUESTION_PASSWORD_RECAPTCHA_MAX_FAILED_ATTEMPTS);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.USERNAME_RECOVERY_ENABLE);
@@ -179,6 +189,8 @@ public class RecoveryConfigImplTest {
         String enablePasswordRecoveryReCaptcha = "false";
         String enableUsernameRecoveryReCaptcha = "false";
         String recoveryCallbackRegex = IdentityRecoveryConstants.DEFAULT_CALLBACK_REGEX;
+        String challengeQuestionAnswerRegex = IdentityRecoveryConstants.DEFAULT_REGEX;
+        String enforceChallengeQuestionAnswerUniqueness = "false";
 
         Map<String, String> defaultPropertiesExpected = new HashMap<>();
         defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY,
@@ -211,6 +223,10 @@ public class RecoveryConfigImplTest {
                 testForceChallengeQuestions);
         defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_CALLBACK_REGEX,
                 recoveryCallbackRegex);
+        defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.CHALLENGE_QUESTION_ANSWER_REGEX,
+                challengeQuestionAnswerRegex);
+        defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.
+                ENFORCE_CHALLENGE_QUESTION_ANSWER_UNIQUENESS, enforceChallengeQuestionAnswerUniqueness);
 
         String tenantDomain = "admin";
         // Here tenantDomain parameter is not used by method itself

--- a/pom.xml
+++ b/pom.xml
@@ -626,7 +626,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.17.60</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.17.86</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.28, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request

This PR supports the following functionalities.
- Validate challenge answers using a regex pattern - This will ensure the answer is according to the
expected regex pattern
- Enforce the uniqueness of challenge question answers - This will ensure that more than one question hasn't the same answer.

**Documentation**: [Challenge Answer Validation](https://docs.google.com/document/d/1Mk0iO4b_22xuQO5A-I-iFSfgdSHnuhk-ii-z41J0bao/edit?usp=sharing) 

**Related issue**: https://github.com/wso2/product-is/issues/8247

### When should this PR be merged

This PR should be merged after https://github.com/wso2/carbon-identity-framework/pull/2919, after updating the newly released framework version in this PR.

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/2919
- https://github.com/wso2/identity-api-user/pull/102
