### PR TITLE
Implement User Recovery Data deletion on Tenant Deletion

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -203,6 +203,7 @@ public class IdentityRecoveryConstants {
                 "challenge question of locale %s in set %s"),
         ERROR_CODE_REGISTRY_EXCEPTION_DELETE_CHALLENGE_QUESTION("20059", "Registry exception while deleting challenge" +
                 " question %s of the set %s"),
+        ERROR_CODE_ERROR_DELETING_RECOVERY_DATA("20060", "Error deleting user recovery data of the tenant: %s"),
         ERROR_CODE_ERROR_RETRIVING_CLAIM("18004", "Error when retrieving the locale claim of user '%s' of '%s' domain" +
                 "."),
 
@@ -452,6 +453,8 @@ public class IdentityRecoveryConstants {
 
         public static final String INVALIDATE_USER_CODES_CASE_INSENSITIVE = "DELETE FROM IDN_RECOVERY_DATA WHERE " +
                 "LOWER(USER_NAME)=LOWER(?) AND USER_DOMAIN = ? AND TENANT_ID =?";
+
+        public static final String DELETE_USER_RECOVERY_DATA_BY_TENANT_ID = "DELETE FROM IDN_RECOVERY_DATA WHERE TENANT_ID = ?";
 
         public static final String LOAD_RECOVERY_DATA_OF_USER = "SELECT "
                 + "* FROM IDN_RECOVERY_DATA WHERE USER_NAME = ? AND USER_DOMAIN = ? AND TENANT_ID = ?";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/listener/TenantManagementListener.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/listener/TenantManagementListener.java
@@ -21,6 +21,8 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.recovery.ChallengeQuestionManager;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
+import org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStore;
+import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
 import org.wso2.carbon.stratos.common.beans.TenantInfoBean;
 import org.wso2.carbon.stratos.common.exception.StratosException;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
@@ -95,7 +97,13 @@ public class TenantManagementListener implements TenantMgtListener {
     }
 
     @Override
-    public void onPreDelete(int i) throws StratosException {
+    public void onPreDelete(int tenantId) throws StratosException {
 
+        try {
+            UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
+            userRecoveryDataStore.deleteRecoveryDataByTenantId(tenantId);
+        } catch (IdentityRecoveryException e) {
+            throw new StratosException("Error in deleting recovery data of the tenant:" + tenantId, e);
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/store/JDBCRecoveryDataStore.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/store/JDBCRecoveryDataStore.java
@@ -33,7 +33,11 @@ import org.wso2.carbon.identity.recovery.RecoverySteps;
 import org.wso2.carbon.identity.recovery.model.UserRecoveryData;
 import org.wso2.carbon.identity.recovery.util.Utils;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
@@ -53,7 +57,8 @@ public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
 
     @Override
     public void store(UserRecoveryData recoveryDataDO) throws IdentityRecoveryException {
-        Connection connection = IdentityDatabaseUtil.getDBConnection();
+
+        Connection connection = IdentityDatabaseUtil.getDBConnection(true);
         PreparedStatement prepStmt = null;
         try {
             prepStmt = connection.prepareStatement(IdentityRecoveryConstants.SQLQueries.STORE_RECOVERY_DATA);
@@ -69,7 +74,8 @@ public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
             IdentityDatabaseUtil.commitTransaction(connection);
         } catch (SQLException e) {
             IdentityDatabaseUtil.rollbackTransaction(connection);
-            throw Utils.handleServerException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_STORING_RECOVERY_DATA, null, e);
+            throw Utils.handleServerException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_STORING_RECOVERY_DATA, null, e);
         } finally {
             IdentityDatabaseUtil.closeStatement(prepStmt);
             IdentityDatabaseUtil.closeConnection(connection);
@@ -77,13 +83,16 @@ public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
     }
 
     @Override
-    public UserRecoveryData load(User user, Enum recoveryScenario, Enum recoveryStep, String code) throws IdentityRecoveryException {
+    public UserRecoveryData load(User user, Enum recoveryScenario, Enum recoveryStep, String code)
+            throws IdentityRecoveryException {
+
         PreparedStatement prepStmt = null;
         ResultSet resultSet = null;
         Connection connection = IdentityDatabaseUtil.getDBConnection(false);
         String sql;
         try {
-            if (IdentityUtil.isUserStoreCaseSensitive(user.getUserStoreDomain(), IdentityTenantUtil.getTenantId(user.getTenantDomain()))) {
+            if (IdentityUtil.isUserStoreCaseSensitive(user.getUserStoreDomain(),
+                    IdentityTenantUtil.getTenantId(user.getTenantDomain()))) {
                 sql = IdentityRecoveryConstants.SQLQueries.LOAD_RECOVERY_DATA;
             } else {
                 sql = IdentityRecoveryConstants.SQLQueries.LOAD_RECOVERY_DATA_CASE_INSENSITIVE;
@@ -124,6 +133,7 @@ public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
 
     @Override
     public UserRecoveryData load(String code) throws IdentityRecoveryException {
+
         PreparedStatement prepStmt = null;
         ResultSet resultSet = null;
         Connection connection = IdentityDatabaseUtil.getDBConnection(false);
@@ -170,8 +180,9 @@ public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
 
     @Override
     public void invalidate(String code) throws IdentityRecoveryException {
+
         PreparedStatement prepStmt = null;
-        Connection connection = IdentityDatabaseUtil.getDBConnection();
+        Connection connection = IdentityDatabaseUtil.getDBConnection(true);
         try {
             String sql = IdentityRecoveryConstants.SQLQueries.INVALIDATE_CODE;
 
@@ -191,13 +202,15 @@ public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
 
     @Override
     public UserRecoveryData load(User user) throws IdentityRecoveryException {
+
         PreparedStatement prepStmt = null;
         ResultSet resultSet = null;
         Connection connection = IdentityDatabaseUtil.getDBConnection(false);
 
         try {
             String sql;
-            if (IdentityUtil.isUserStoreCaseSensitive(user.getUserStoreDomain(), IdentityTenantUtil.getTenantId(user.getTenantDomain()))) {
+            if (IdentityUtil.isUserStoreCaseSensitive(user.getUserStoreDomain(),
+                    IdentityTenantUtil.getTenantId(user.getTenantDomain()))) {
                 sql = IdentityRecoveryConstants.SQLQueries.LOAD_RECOVERY_DATA_OF_USER;
             } else {
                 sql = IdentityRecoveryConstants.SQLQueries.LOAD_RECOVERY_DATA_OF_USER_CASE_INSENSITIVE;
@@ -238,13 +251,15 @@ public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
 
     @Override
     public UserRecoveryData loadWithoutCodeExpiryValidation(User user) throws IdentityRecoveryException {
+
         PreparedStatement prepStmt = null;
         ResultSet resultSet = null;
         Connection connection = IdentityDatabaseUtil.getDBConnection(false);
 
         try {
             String sql;
-            if (IdentityUtil.isUserStoreCaseSensitive(user.getUserStoreDomain(), IdentityTenantUtil.getTenantId(user.getTenantDomain()))) {
+            if (IdentityUtil.isUserStoreCaseSensitive(user.getUserStoreDomain(),
+                    IdentityTenantUtil.getTenantId(user.getTenantDomain()))) {
                 sql = IdentityRecoveryConstants.SQLQueries.LOAD_RECOVERY_DATA_OF_USER;
             } else {
                 sql = IdentityRecoveryConstants.SQLQueries.LOAD_RECOVERY_DATA_OF_USER_CASE_INSENSITIVE;
@@ -280,11 +295,13 @@ public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
 
     @Override
     public void invalidate(User user) throws IdentityRecoveryException {
+
         PreparedStatement prepStmt = null;
-        Connection connection = IdentityDatabaseUtil.getDBConnection();
+        Connection connection = IdentityDatabaseUtil.getDBConnection(true);
         try {
             String sql;
-            if (IdentityUtil.isUserStoreCaseSensitive(user.getUserStoreDomain(), IdentityTenantUtil.getTenantId(user.getTenantDomain()))) {
+            if (IdentityUtil.isUserStoreCaseSensitive(user.getUserStoreDomain(),
+                    IdentityTenantUtil.getTenantId(user.getTenantDomain()))) {
                 sql = IdentityRecoveryConstants.SQLQueries.INVALIDATE_USER_CODES;
             } else {
                 sql = IdentityRecoveryConstants.SQLQueries.INVALIDATE_USER_CODES_CASE_INSENSITIVE;
@@ -310,6 +327,7 @@ public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
      *
      * @param tenantId Id of the tenant
      */
+    @Override
     public void deleteRecoveryDataByTenantId(int tenantId) throws IdentityRecoveryException {
 
         if (log.isDebugEnabled()) {
@@ -320,7 +338,8 @@ public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
         Connection connection = IdentityDatabaseUtil.getDBConnection(false);
 
         try {
-            prepStmt = connection.prepareStatement(IdentityRecoveryConstants.SQLQueries.DELETE_USER_RECOVERY_DATA_BY_TENANT_ID);
+            prepStmt = connection.prepareStatement(
+                    IdentityRecoveryConstants.SQLQueries.DELETE_USER_RECOVERY_DATA_BY_TENANT_ID);
             prepStmt.setInt(1, tenantId);
             prepStmt.execute();
             IdentityDatabaseUtil.commitTransaction(connection);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/store/JDBCRecoveryDataStore.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/store/JDBCRecoveryDataStore.java
@@ -306,6 +306,36 @@ public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
     }
 
     /**
+     * Delete all recovery data by tenant id
+     *
+     * @param tenantId Id of the tenant
+     */
+    public void deleteRecoveryDataByTenantId(int tenantId) throws IdentityRecoveryException {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Deleting User Recovery Data of the tenant: " + tenantId);
+        }
+
+        PreparedStatement prepStmt = null;
+        Connection connection = IdentityDatabaseUtil.getDBConnection(false);
+
+        try {
+            prepStmt = connection.prepareStatement(IdentityRecoveryConstants.SQLQueries.DELETE_USER_RECOVERY_DATA_BY_TENANT_ID);
+            prepStmt.setInt(1, tenantId);
+            prepStmt.execute();
+            IdentityDatabaseUtil.commitTransaction(connection);
+        } catch (SQLException e) {
+            IdentityDatabaseUtil.rollbackTransaction(connection);
+            throw Utils.handleServerException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_ERROR_DELETING_RECOVERY_DATA,
+                    Integer.toString(tenantId), e);
+        } finally {
+            IdentityDatabaseUtil.closeStatement(prepStmt);
+            IdentityDatabaseUtil.closeConnection(connection);
+        }
+    }
+
+    /**
      * Checks whether the code has expired or not.
      *
      * @param tenantDomain     Tenant domain

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/store/UserRecoveryDataStore.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/store/UserRecoveryDataStore.java
@@ -46,4 +46,12 @@ public interface UserRecoveryDataStore {
     void invalidate(User user) throws
             IdentityRecoveryException;
 
+    /**
+     * Delete all recovery data by tenant id
+     *
+     * @param tenantId Id of the tenant
+     */
+    default void deleteRecoveryDataByTenantId(int tenantId) throws IdentityRecoveryException {
+
+    }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

Implement the deletion of User Recovery Data in the tenant deletion process.

Fixes: #387
