### PR TITLE
Implement Password History Data deletion on tenant deletion

### DIFF
--- a/components/org.wso2.carbon.identity.password.history/pom.xml
+++ b/components/org.wso2.carbon.identity.password.history/pom.xml
@@ -97,7 +97,8 @@
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
                             org.wso2.carbon.idp.mgt;version="${carbon.identity.framework.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.governance;version="${identity.governance.imp.pkg.version.range}"
+                            org.wso2.carbon.identity.governance;version="${identity.governance.imp.pkg.version.range}",
+                            org.wso2.carbon.stratos.common.*;version="${carbon.commons.imp.pkg.version}",
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>

--- a/components/org.wso2.carbon.identity.password.history/src/main/java/org/wso2/carbon/identity/password/history/constants/PasswordHistoryConstants.java
+++ b/components/org.wso2.carbon.identity.password.history/src/main/java/org/wso2/carbon/identity/password/history/constants/PasswordHistoryConstants.java
@@ -37,6 +37,9 @@ public class PasswordHistoryConstants {
         public static final String DELETE_USER_HISTORY = "DELETE FROM IDN_PASSWORD_HISTORY_DATA WHERE USER_NAME = ? " +
                 "AND USER_DOMAIN =? AND TENANT_ID =?";
 
+        public static final String DELETE_PASSWORD_HISTORY_DATA_BY_TENANT_ID = "DELETE FROM " +
+                "IDN_PASSWORD_HISTORY_DATA WHERE TENANT_ID = ?";
+
     }
 
     public enum ErrorMessages {

--- a/components/org.wso2.carbon.identity.password.history/src/main/java/org/wso2/carbon/identity/password/history/internal/IdentityPasswordHistoryServiceComponent.java
+++ b/components/org.wso2.carbon.identity.password.history/src/main/java/org/wso2/carbon/identity/password/history/internal/IdentityPasswordHistoryServiceComponent.java
@@ -28,6 +28,8 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.password.history.listener.PasswordHistoryTenantMgtListener;
+import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
 
 @Component(
         name = "org.wso2.carbon.identity.password.history.internal.IdentityPasswordHistoryServiceComponent",
@@ -47,6 +49,8 @@ public class IdentityPasswordHistoryServiceComponent {
             IdentityPasswordHistoryServiceDataHolder.getInstance().setBundleContext(bundleContext);
             PasswordHistoryValidationHandler handler = new PasswordHistoryValidationHandler();
             context.getBundleContext().registerService(AbstractEventHandler.class.getName(), handler, null);
+            context.getBundleContext().registerService(TenantMgtListener.class.getName(),
+                    new PasswordHistoryTenantMgtListener(), null);
         } catch (Exception e) {
             log.error("Error while activating identity governance component.", e);
         }

--- a/components/org.wso2.carbon.identity.password.history/src/main/java/org/wso2/carbon/identity/password/history/listener/PasswordHistoryTenantMgtListener.java
+++ b/components/org.wso2.carbon.identity.password.history/src/main/java/org/wso2/carbon/identity/password/history/listener/PasswordHistoryTenantMgtListener.java
@@ -1,0 +1,67 @@
+package org.wso2.carbon.identity.password.history.listener;
+
+import org.wso2.carbon.identity.password.history.exeption.IdentityPasswordHistoryException;
+import org.wso2.carbon.identity.password.history.store.Impl.DefaultPasswordHistoryDataStore;
+import org.wso2.carbon.stratos.common.beans.TenantInfoBean;
+import org.wso2.carbon.stratos.common.exception.StratosException;
+import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
+
+public class PasswordHistoryTenantMgtListener implements TenantMgtListener {
+    private static final int EXEC_ORDER = 41;
+
+    @Override
+    public void onTenantCreate(TenantInfoBean tenantInfoBean) throws StratosException {
+
+    }
+
+    @Override
+    public void onTenantUpdate(TenantInfoBean tenantInfoBean) throws StratosException {
+
+    }
+
+    @Override
+    public void onTenantDelete(int i) {
+
+    }
+
+    @Override
+    public void onTenantRename(int i, String s, String s2) throws StratosException {
+
+    }
+
+    @Override
+    public void onTenantInitialActivation(int i) throws StratosException {
+
+    }
+
+    @Override
+    public void onTenantActivation(int i) throws StratosException {
+
+    }
+
+    @Override
+    public void onTenantDeactivation(int i) throws StratosException {
+
+    }
+
+    @Override
+    public void onSubscriptionPlanChange(int i, String s, String s2) throws StratosException {
+
+    }
+
+    @Override
+    public int getListenerOrder() {
+        return EXEC_ORDER;
+    }
+
+    @Override
+    public void onPreDelete(int tenantId) throws StratosException {
+
+        DefaultPasswordHistoryDataStore defaultPasswordHistoryDataStore = new DefaultPasswordHistoryDataStore();
+        try {
+            defaultPasswordHistoryDataStore.deletePasswordHistoryData(tenantId);
+        } catch (IdentityPasswordHistoryException e) {
+            throw new StratosException("Error in deleting password history data of the tenant: " + tenantId, e);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.password.history/src/main/java/org/wso2/carbon/identity/password/history/listener/PasswordHistoryTenantMgtListener.java
+++ b/components/org.wso2.carbon.identity.password.history/src/main/java/org/wso2/carbon/identity/password/history/listener/PasswordHistoryTenantMgtListener.java
@@ -1,59 +1,48 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.wso2.carbon.identity.password.history.listener;
 
+import org.wso2.carbon.identity.core.AbstractIdentityTenantMgtListener;
 import org.wso2.carbon.identity.password.history.exeption.IdentityPasswordHistoryException;
 import org.wso2.carbon.identity.password.history.store.Impl.DefaultPasswordHistoryDataStore;
-import org.wso2.carbon.stratos.common.beans.TenantInfoBean;
 import org.wso2.carbon.stratos.common.exception.StratosException;
-import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
 
-public class PasswordHistoryTenantMgtListener implements TenantMgtListener {
+/**
+ * Password History Tenant Management Listener.
+ */
+public class PasswordHistoryTenantMgtListener extends AbstractIdentityTenantMgtListener {
     private static final int EXEC_ORDER = 41;
 
-    @Override
-    public void onTenantCreate(TenantInfoBean tenantInfoBean) throws StratosException {
-
-    }
-
-    @Override
-    public void onTenantUpdate(TenantInfoBean tenantInfoBean) throws StratosException {
-
-    }
-
-    @Override
-    public void onTenantDelete(int i) {
-
-    }
-
-    @Override
-    public void onTenantRename(int i, String s, String s2) throws StratosException {
-
-    }
-
-    @Override
-    public void onTenantInitialActivation(int i) throws StratosException {
-
-    }
-
-    @Override
-    public void onTenantActivation(int i) throws StratosException {
-
-    }
-
-    @Override
-    public void onTenantDeactivation(int i) throws StratosException {
-
-    }
-
-    @Override
-    public void onSubscriptionPlanChange(int i, String s, String s2) throws StratosException {
-
-    }
-
+    /**
+     * Get listener order.
+     *
+     * @return
+     */
     @Override
     public int getListenerOrder() {
         return EXEC_ORDER;
     }
 
+    /**
+     * Delete password history data before tenant deletion.
+     *
+     * @param tenantId Id of the tenant
+     * @throws StratosException
+     */
     @Override
     public void onPreDelete(int tenantId) throws StratosException {
 

--- a/components/org.wso2.carbon.identity.password.history/src/main/java/org/wso2/carbon/identity/password/history/store/Impl/DefaultPasswordHistoryDataStore.java
+++ b/components/org.wso2.carbon.identity.password.history/src/main/java/org/wso2/carbon/identity/password/history/store/Impl/DefaultPasswordHistoryDataStore.java
@@ -49,6 +49,10 @@ public class DefaultPasswordHistoryDataStore implements PasswordHistoryDataStore
         this.maxHistoryCount = maxHistoryCount;
     }
 
+    public DefaultPasswordHistoryDataStore() {
+
+    }
+
     @Override
     public void store(User user, Object credential) throws
             IdentityPasswordHistoryException {
@@ -133,6 +137,38 @@ public class DefaultPasswordHistoryDataStore implements PasswordHistoryDataStore
             IdentityDatabaseUtil.closeConnection(connection);
         }
 
+    }
+
+    /**
+     * Delete password history data of a tenant.
+     *
+     * @param tenantId Id of the tenant
+     * @throws IdentityPasswordHistoryException
+     */
+    @Override
+    public void deletePasswordHistoryData(int tenantId) throws IdentityPasswordHistoryException {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Deleting all password history data of the tenant: " + tenantId);
+        }
+
+        Connection connection = IdentityDatabaseUtil.getDBConnection(false);
+        PreparedStatement prepStmt = null;
+
+        try {
+            prepStmt = connection.prepareStatement(PasswordHistoryConstants.SQLQueries
+                    .DELETE_PASSWORD_HISTORY_DATA_BY_TENANT_ID);
+            prepStmt.setInt(1, tenantId);
+            prepStmt.execute();
+            IdentityDatabaseUtil.commitTransaction(connection);
+        } catch (SQLException e) {
+            IdentityDatabaseUtil.rollbackTransaction(connection);
+            throw new IdentityPasswordHistoryException(
+                    "Error while deleting password history data of tenant" + tenantId, e);
+        } finally {
+            IdentityDatabaseUtil.closeStatement(prepStmt);
+            IdentityDatabaseUtil.closeConnection(connection);
+        }
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.password.history/src/main/java/org/wso2/carbon/identity/password/history/store/PasswordHistoryDataStore.java
+++ b/components/org.wso2.carbon.identity.password.history/src/main/java/org/wso2/carbon/identity/password/history/store/PasswordHistoryDataStore.java
@@ -40,6 +40,16 @@ public interface PasswordHistoryDataStore {
     void remove(User user) throws IdentityPasswordHistoryException;
 
     /**
+     * Delete password history data of a tenant.
+     *
+     * @param tenantId Id of the tenant
+     * @throws IdentityPasswordHistoryException
+     */
+    default void deletePasswordHistoryData(int tenantId) throws IdentityPasswordHistoryException {
+
+    }
+
+    /**
      * validate
      *
      * @param user,credential

--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,11 @@
                 <artifactId>org.wso2.carbon.identity.application.common</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.commons</groupId>
+                <artifactId>org.wso2.carbon.tenant.common</artifactId>
+                <version>${carbon.commons.version}</version>
+            </dependency>
 
             <!--Carbon Identity Extension Dependencies-->
             <dependency>
@@ -640,6 +645,10 @@
 
         <carbon.multitenancy.version>4.7.11</carbon.multitenancy.version>
         <carbon.multitenancy.imp.pkg.version.range>[4.7.4, 5.0.0)</carbon.multitenancy.imp.pkg.version.range>
+
+        <!--Carbon commons version-->
+        <carbon.commons.version>4.7.18</carbon.commons.version>
+        <carbon.commons.imp.pkg.version>[4.7.2, 5.0.0)</carbon.commons.imp.pkg.version>
 
         <!--Maven Plugin Version-->
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>


### PR DESCRIPTION
### Proposed changes in this pull request

Implement the deletion of Password History Data in the tenant deletion process.

Fixes: #386
