### PR TITLE
Fix issue of error code 17001 not returning for non existing users

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
+import org.wso2.carbon.identity.core.model.IdentityErrorMsgContext;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
@@ -117,6 +118,11 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
                 log.debug("IdentityMgtEventListener returns since user: " + userName + " not available in current " +
                         "user store domain: " + userStoreManager.getRealmConfiguration().getUserStoreProperty
                         (UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME));
+            }
+            if (isAuthPolicyAccountExistCheck()) {
+                IdentityErrorMsgContext customErrorMessageContext = new IdentityErrorMsgContext(UserCoreConstants
+                        .ErrorCode.USER_DOES_NOT_EXIST);
+                IdentityUtil.setIdentityErrorMsg(customErrorMessageContext);
             }
             return true;
         }
@@ -1725,4 +1731,10 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
         }
         return isExists;
     }
+
+    private boolean isAuthPolicyAccountExistCheck() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty("AuthenticationPolicy.CheckAccountExist"));
+    }
+
 }


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/8566

Due to a previous fix in the AccountConfirmationValidationHandler, [1] is not reachable in pre-authentication when trying to authenticate with a non-existing user. Therefore the error code 17001 is not getting set to the IdentityError ThreadLocal. Since user existence check is done in the post-authentication of the IdentityMgtEventListener[2], the error code also can be set from there in the post-authentication. 

[1] https://github.com/wso2-extensions/identity-governance/blob/fe0e3644d8d264c39aeaafa037ccf5ed976ea25a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AccountConfirmationValidationHandler.java#L92
[2] https://github.com/wso2-extensions/identity-governance/blob/fe0e3644d8d264c39aeaafa037ccf5ed976ea25a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java#L115