### PR TITLE
Introduce separate handler for lite user registration.

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -56,6 +56,7 @@ public class IdentityRecoveryConstants {
     public static final String ACCOUNT_LOCKED_CLAIM = "http://wso2.org/claims/identity/accountLocked";
     public static final String ACCOUNT_UNLOCK_TIME_CLAIM = "http://wso2.org/claims/identity/unlockTime";
     public static final String ACCOUNT_DISABLED_CLAIM = "http://wso2.org/claims/identity/accountDisabled";
+    public static final String LITE_USER_CLAIM = "http://wso2.org/claims/identity/isLiteUser";
     public static final String FAILED_LOGIN_LOCKOUT_COUNT_CLAIM =
             "http://wso2.org/claims/identity/failedLoginLockoutCount";
 
@@ -79,6 +80,7 @@ public class IdentityRecoveryConstants {
     public static final String DEFAULT_CHALLENGE_QUESTION_SEPARATOR = "!";
     public static final String ACCOUNT_STATE_CLAIM_URI = "http://wso2.org/claims/identity/accountState";
     public static final String PENDING_SELF_REGISTRATION = "PENDING_SR";
+    public static final String PENDING_LITE_REGISTRATION = "PENDING_LR";
     public static final String PENDING_ASK_PASSWORD = "PENDING_AP";
     public static final String PENDING_EMAIL_VERIFICATION = "PENDING_EV";
     public static final String ACCOUNT_STATE_UNLOCKED = "UNLOCKED";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/LiteUserRegistrationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/LiteUserRegistrationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.wso2.carbon.identity.governance.exceptions.notiification.Notification
 import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationChannelManagerException;
 import org.wso2.carbon.identity.governance.service.notification.NotificationChannelManager;
 import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
+import org.wso2.carbon.identity.mgt.IdentityMgtConfig;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
@@ -57,16 +58,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class UserSelfRegistrationHandler extends AbstractEventHandler {
+public class LiteUserRegistrationHandler extends AbstractEventHandler {
 
-    private static final Log log = LogFactory.getLog(UserSelfRegistrationHandler.class);
+    private static final Log log = LogFactory.getLog(LiteUserRegistrationHandler.class);
 
     public String getName() {
-        return "userSelfRegistration";
+        return "liteUserRegistration";
     }
 
     public String getFriendlyName() {
-        return "User Self Registration";
+        return "Lite User Registration";
     }
 
     @Override
@@ -79,7 +80,14 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
         String tenantDomain = (String) eventProperties.get(IdentityEventConstants.EventProperty.TENANT_DOMAIN);
         String domainName = userStoreManager.getRealmConfiguration().getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
 
-        String[] roleList = (String[]) eventProperties.get(IdentityEventConstants.EventProperty.ROLE_LIST);
+        boolean isLiteSignUp = Utils.isLiteSignUp(Utils.getArbitraryProperties());
+        if (!isLiteSignUp) {
+            //Lite sign up feature is disabled
+            if (log.isDebugEnabled()) {
+                log.debug("Not lite sign up flow for the user.");
+            }
+            return; //this handler will not do anything. just return
+        }
 
         User user = new User();
         user.setUserName(userName);
@@ -87,32 +95,22 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
         user.setUserStoreDomain(domainName);
 
         boolean enable = Boolean.parseBoolean(Utils.getConnectorConfig(
-                IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP, user.getTenantDomain()));
+                IdentityRecoveryConstants.ConnectorConfig.ENABLE_LITE_SIGN_UP, user.getTenantDomain()));
 
         if (!enable) {
-            //Self signup feature is disabled
-
+            //Lite sign up feature is disabled
             if (log.isDebugEnabled()) {
-                log.debug("Self signup feature is disabled in tenant: " + tenantDomain);
+                log.debug("Lite sign up feature is disabled in tenant: " + tenantDomain);
             }
-            return;
-        }
-
-        //Check selfSignupRole is in the request. If it is not there, this handler will not do anything. just retrun
-        if (roleList == null) {
-            return;
-        } else {
-            List<String> roles = Arrays.asList(roleList);
-            if (!roles.contains(IdentityRecoveryConstants.SELF_SIGNUP_ROLE)) {
-                return;
-            }
+            return; //this handler will not do anything. just return
         }
 
         boolean isAccountLockOnCreation = Boolean.parseBoolean(Utils.getConnectorConfig
-                (IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION, user.getTenantDomain()));
+                (IdentityRecoveryConstants.ConnectorConfig.LITE_ACCOUNT_LOCK_ON_CREATION, user.getTenantDomain()));
 
         boolean isNotificationInternallyManage = Boolean.parseBoolean(Utils.getConnectorConfig
-                (IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE, user.getTenantDomain()));
+                (IdentityRecoveryConstants.ConnectorConfig.LITE_SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
+                        user.getTenantDomain()));
 
         if (IdentityEventConstants.Event.POST_ADD_USER.equals(event.getEventName())) {
             UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
@@ -140,7 +138,7 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
                     String eventName = resolveEventName(preferredChannel, userName, domainName, tenantDomain);
 
                     UserRecoveryData recoveryDataDO = new UserRecoveryData(user, secretKey,
-                            RecoveryScenarios.SELF_SIGN_UP, RecoverySteps.CONFIRM_SIGN_UP);
+                            RecoveryScenarios.LITE_SIGN_UP, RecoverySteps.CONFIRM_LITE_SIGN_UP);
 
                     // Notified channel is stored in remaining setIds for recovery purposes.
                     recoveryDataDO.setRemainingSetIds(preferredChannel);
@@ -148,7 +146,7 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
                     triggerNotification(user, preferredChannel, secretKey, Utils.getArbitraryProperties(), eventName);
                 }
             } catch (IdentityRecoveryException e) {
-                throw new IdentityEventException("Error while sending self sign up notification ", e);
+                throw new IdentityEventException("Error while sending lite sign up notification ", e);
             }
             if (isAccountLockOnCreation) {
                 HashMap<String, String> userClaims = new HashMap<>();
@@ -156,7 +154,7 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
                 userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
                 if (Utils.isAccountStateClaimExisting(tenantDomain)) {
                     userClaims.put(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI,
-                            IdentityRecoveryConstants.PENDING_SELF_REGISTRATION);
+                            IdentityRecoveryConstants.PENDING_LITE_REGISTRATION);
                 }
                 try {
                     userStoreManager.setUserClaimValues(user.getUserName() , userClaims, null);
@@ -400,7 +398,7 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
             String eventName) throws IdentityRecoveryException {
 
         if (log.isDebugEnabled()) {
-            log.debug("Sending self user registration notification user: " + user.getUserName());
+            log.debug("Sending lite user registration notification user: " + user.getUserName());
         }
         HashMap<String, Object> properties = new HashMap<>();
         properties.put(IdentityEventConstants.EventProperty.USER_NAME, user.getUserName());
@@ -416,8 +414,11 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
         if (StringUtils.isNotBlank(code)) {
             properties.put(IdentityRecoveryConstants.CONFIRMATION_CODE, code);
         }
+
         properties.put(IdentityRecoveryConstants.TEMPLATE_TYPE,
-                    IdentityRecoveryConstants.NOTIFICATION_TYPE_ACCOUNT_CONFIRM);
+                IdentityRecoveryConstants.NOTIFICATION_TYPE_LITE_USER_EMAIL_CONFIRM);
+
+
         Event identityMgtEvent = new Event(eventName, properties);
         try {
             IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
@@ -43,6 +43,7 @@ import org.wso2.carbon.identity.recovery.handler.ChallengeAnswerValidationHandle
 import org.wso2.carbon.identity.recovery.handler.CodeInvalidationHandler;
 import org.wso2.carbon.identity.recovery.handler.TenantRegistrationVerificationHandler;
 import org.wso2.carbon.identity.recovery.handler.UserEmailVerificationHandler;
+import org.wso2.carbon.identity.recovery.handler.LiteUserRegistrationHandler;
 import org.wso2.carbon.identity.recovery.handler.UserSelfRegistrationHandler;
 import org.wso2.carbon.identity.recovery.handler.request.PostAuthnMissingChallengeQuestionsHandler;
 import org.wso2.carbon.identity.recovery.internal.service.impl.password.PasswordRecoveryManagerImpl;
@@ -94,6 +95,8 @@ public class IdentityRecoveryServiceComponent {
             bundleContext.registerService(AbstractEventHandler.class.getName(), new
                     AccountConfirmationValidationHandler(), null);
             bundleContext.registerService(AbstractEventHandler.class.getName(), new UserSelfRegistrationHandler(),
+                    null);
+            bundleContext.registerService(AbstractEventHandler.class.getName(), new LiteUserRegistrationHandler(),
                     null);
             bundleContext.registerService(AbstractEventHandler.class.getName(), new UserEmailVerificationHandler(),
                     null);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -1295,7 +1295,7 @@ public class UserSelfRegistrationManager {
                 IdentityRecoveryConstants.ConnectorConfig.ENABLE_LITE_SIGN_UP, user.getTenantDomain()));
 
         if (!enable) {
-            throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_DISABLE_SELF_SIGN_UP, user
+            throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_DISABLE_LITE_SIGN_UP, user
                     .getUserName());
         }
         NotificationResponseBean notificationResponseBean;
@@ -1319,6 +1319,9 @@ public class UserSelfRegistrationManager {
                 claimsMap.put(claim.getClaimUri(), claim.getValue());
             }
 
+            //Set lite user sign up claim to indicate the profile
+            claimsMap.put(IdentityRecoveryConstants.LITE_USER_CLAIM,Boolean.TRUE.toString());
+
             //Set arbitrary properties to use in UserSelfRegistrationHandler
             Utils.setArbitraryProperties(properties);
             validateAndFilterFromReceipt(consent, claimsMap);
@@ -1326,13 +1329,7 @@ public class UserSelfRegistrationManager {
             // User preferred notification channel.
             String preferredChannel;
             try {
-
-                //TODO It is required to add this role before tenant creation. And also, this role should not not be able remove.
-                if (!userStoreManager.isExistingRole(IdentityRecoveryConstants.SELF_SIGNUP_ROLE)) {
-                    Permission permission = new Permission("/permission/admin/login", IdentityRecoveryConstants.EXECUTE_ACTION);
-                    userStoreManager.addRole(IdentityRecoveryConstants.SELF_SIGNUP_ROLE, null, new Permission[]{permission});
-                }
-                String[] userRoles = new String[]{IdentityRecoveryConstants.SELF_SIGNUP_ROLE};
+                String[] userRoles = new String[]{};
                 try {
                     NotificationChannelManager notificationChannelManager = Utils.getNotificationChannelManager();
                     preferredChannel = notificationChannelManager

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -595,12 +595,15 @@ public class UserSelfRegistrationManager {
     public void confirmUserSelfRegistration(String code, String verifiedChannelType,
             String verifiedChannelClaim, Map<String, String> properties) throws IdentityRecoveryException {
 
+        UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
         validateSelfRegistrationCode(code, verifiedChannelType, verifiedChannelClaim, properties);
+        // Invalidate code.
+        userRecoveryDataStore.invalidate(code);
     }
 
     /**
      * Introspect the user self registration by validating the confirmation code, sets externally verified claims and
-     * return the details.
+     * return the details. Does not invalidate the code.
      *
      * @param code                 Confirmation code
      * @param verifiedChannelType  Type of the verified channel (SMS or EMAIL)
@@ -667,9 +670,6 @@ public class UserSelfRegistrationManager {
 
         // Update the user claims.
         updateUserClaims(userStoreManager, user, userClaims);
-
-        // Invalidate code.
-        userRecoveryDataStore.invalidate(code);
 
         return recoveryData;
     }

--- a/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/IntrospectCodeApi.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/IntrospectCodeApi.java
@@ -1,0 +1,47 @@
+package org.wso2.carbon.identity.user.endpoint;
+
+import org.wso2.carbon.identity.user.endpoint.dto.*;
+import org.wso2.carbon.identity.user.endpoint.IntrospectCodeApiService;
+import org.wso2.carbon.identity.user.endpoint.factories.IntrospectCodeApiServiceFactory;
+
+import io.swagger.annotations.ApiParam;
+
+import org.wso2.carbon.identity.user.endpoint.dto.CodeValidationRequestDTO;
+import org.wso2.carbon.identity.user.endpoint.dto.ErrorDTO;
+import org.wso2.carbon.identity.user.endpoint.dto.CodeValidateInfoResponseDTO;
+
+import java.util.List;
+
+import java.io.InputStream;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.*;
+
+@Path("/introspect-code")
+@Consumes({ "application/json" })
+@Produces({ "application/json" })
+@io.swagger.annotations.Api(value = "/introspect-code", description = "the introspect-code API")
+public class IntrospectCodeApi  {
+
+   private final IntrospectCodeApiService delegate = IntrospectCodeApiServiceFactory.getIntrospectCodeApi();
+
+    @POST
+    
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Validate code\n", notes = "This API is used to validate the code used by self registered users and retrieve the details.\n", response = CodeValidateInfoResponseDTO.class)
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "OK"),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Bad Request"),
+        
+        @io.swagger.annotations.ApiResponse(code = 500, message = "Server Error") })
+
+    public Response introspectCodePost(@ApiParam(value = "The validation code retrieved after user self registration, and optional property parameters." ,required=true ) CodeValidationRequestDTO code)
+    {
+    return delegate.introspectCodePost(code);
+    }
+}
+

--- a/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/IntrospectCodeApiService.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/IntrospectCodeApiService.java
@@ -1,0 +1,20 @@
+package org.wso2.carbon.identity.user.endpoint;
+
+import org.wso2.carbon.identity.user.endpoint.*;
+import org.wso2.carbon.identity.user.endpoint.dto.*;
+
+import org.wso2.carbon.identity.user.endpoint.dto.CodeValidationRequestDTO;
+import org.wso2.carbon.identity.user.endpoint.dto.ErrorDTO;
+import org.wso2.carbon.identity.user.endpoint.dto.CodeValidateInfoResponseDTO;
+
+import java.util.List;
+
+import java.io.InputStream;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+
+import javax.ws.rs.core.Response;
+
+public abstract class IntrospectCodeApiService {
+    public abstract Response introspectCodePost(CodeValidationRequestDTO code);
+}
+

--- a/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/CodeValidateInfoResponseDTO.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/CodeValidateInfoResponseDTO.java
@@ -1,0 +1,76 @@
+package org.wso2.carbon.identity.user.endpoint.dto;
+
+import org.wso2.carbon.identity.user.endpoint.dto.ExtendedUserDTO;
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.constraints.NotNull;
+
+
+
+
+
+@ApiModel(description = "")
+public class CodeValidateInfoResponseDTO  {
+  
+  
+  
+  private ExtendedUserDTO user = null;
+  
+  
+  private String recoveryScenario = null;
+  
+  
+  private String recoveryStep = null;
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("user")
+  public ExtendedUserDTO getUser() {
+    return user;
+  }
+  public void setUser(ExtendedUserDTO user) {
+    this.user = user;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("recoveryScenario")
+  public String getRecoveryScenario() {
+    return recoveryScenario;
+  }
+  public void setRecoveryScenario(String recoveryScenario) {
+    this.recoveryScenario = recoveryScenario;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("recoveryStep")
+  public String getRecoveryStep() {
+    return recoveryStep;
+  }
+  public void setRecoveryStep(String recoveryStep) {
+    this.recoveryStep = recoveryStep;
+  }
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class CodeValidateInfoResponseDTO {\n");
+    
+    sb.append("  user: ").append(user).append("\n");
+    sb.append("  recoveryScenario: ").append(recoveryScenario).append("\n");
+    sb.append("  recoveryStep: ").append(recoveryStep).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/ExtendedUserDTO.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/ExtendedUserDTO.java
@@ -1,0 +1,91 @@
+package org.wso2.carbon.identity.user.endpoint.dto;
+
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.constraints.NotNull;
+
+
+
+
+
+@ApiModel(description = "")
+public class ExtendedUserDTO  {
+  
+  
+  
+  private String username = null;
+  
+  
+  private String realm = null;
+  
+  
+  private String tenant = null;
+  
+  
+  private Boolean isUsernameCaseSensitive = null;
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("username")
+  public String getUsername() {
+    return username;
+  }
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("realm")
+  public String getRealm() {
+    return realm;
+  }
+  public void setRealm(String realm) {
+    this.realm = realm;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("tenant")
+  public String getTenant() {
+    return tenant;
+  }
+  public void setTenant(String tenant) {
+    this.tenant = tenant;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("isUsernameCaseSensitive")
+  public Boolean getIsUsernameCaseSensitive() {
+    return isUsernameCaseSensitive;
+  }
+  public void setIsUsernameCaseSensitive(Boolean isUsernameCaseSensitive) {
+    this.isUsernameCaseSensitive = isUsernameCaseSensitive;
+  }
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ExtendedUserDTO {\n");
+    
+    sb.append("  username: ").append(username).append("\n");
+    sb.append("  realm: ").append(realm).append("\n");
+    sb.append("  tenant: ").append(tenant).append("\n");
+    sb.append("  isUsernameCaseSensitive: ").append(isUsernameCaseSensitive).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/SelfLiteUserRegistrationRequestDTO.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/SelfLiteUserRegistrationRequestDTO.java
@@ -1,0 +1,146 @@
+package org.wso2.carbon.identity.user.endpoint.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.user.endpoint.dto.ClaimDTO;
+import org.wso2.carbon.identity.user.endpoint.dto.PropertyDTO;
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.constraints.NotNull;
+
+
+
+
+
+@ApiModel(description = "")
+public class SelfLiteUserRegistrationRequestDTO  {
+  
+  
+  @NotNull
+  private String email = null;
+  
+  @NotNull
+  private String mobile = null;
+  
+  
+  private String realm = null;
+  
+  
+  private Boolean isTenantflow = null;
+  
+  public enum PreferredChannelEnum {
+     Mobile,  Email, 
+  };
+  
+  private PreferredChannelEnum preferredChannel = null;
+  
+  
+  private List<ClaimDTO> claims = new ArrayList<ClaimDTO>();
+  
+  
+  private List<PropertyDTO> properties = new ArrayList<PropertyDTO>();
+
+  
+  /**
+   **/
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty("email")
+  public String getEmail() {
+    return email;
+  }
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty("mobile")
+  public String getMobile() {
+    return mobile;
+  }
+  public void setMobile(String mobile) {
+    this.mobile = mobile;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("realm")
+  public String getRealm() {
+    return realm;
+  }
+  public void setRealm(String realm) {
+    this.realm = realm;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("isTenantflow")
+  public Boolean getIsTenantflow() {
+    return isTenantflow;
+  }
+  public void setIsTenantflow(Boolean isTenantflow) {
+    this.isTenantflow = isTenantflow;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("preferredChannel")
+  public PreferredChannelEnum getPreferredChannel() {
+    return preferredChannel;
+  }
+  public void setPreferredChannel(PreferredChannelEnum preferredChannel) {
+    this.preferredChannel = preferredChannel;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("claims")
+  public List<ClaimDTO> getClaims() {
+    return claims;
+  }
+  public void setClaims(List<ClaimDTO> claims) {
+    this.claims = claims;
+  }
+
+  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("properties")
+  public List<PropertyDTO> getProperties() {
+    return properties;
+  }
+  public void setProperties(List<PropertyDTO> properties) {
+    this.properties = properties;
+  }
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class SelfLiteUserRegistrationRequestDTO {\n");
+    
+    sb.append("  email: ").append(email).append("\n");
+    sb.append("  mobile: ").append(mobile).append("\n");
+    sb.append("  realm: ").append(realm).append("\n");
+    sb.append("  isTenantflow: ").append(isTenantflow).append("\n");
+    sb.append("  preferredChannel: ").append(preferredChannel).append("\n");
+    sb.append("  claims: ").append(claims).append("\n");
+    sb.append("  properties: ").append(properties).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/factories/IntrospectCodeApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/gen/java/org/wso2/carbon/identity/user/endpoint/factories/IntrospectCodeApiServiceFactory.java
@@ -1,0 +1,14 @@
+package org.wso2.carbon.identity.user.endpoint.factories;
+
+import org.wso2.carbon.identity.user.endpoint.IntrospectCodeApiService;
+import org.wso2.carbon.identity.user.endpoint.impl.IntrospectCodeApiServiceImpl;
+
+public class IntrospectCodeApiServiceFactory {
+
+   private final static IntrospectCodeApiService service = new IntrospectCodeApiServiceImpl();
+
+   public static IntrospectCodeApiService getIntrospectCodeApi()
+   {
+      return service;
+   }
+}

--- a/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/IntrospectCodeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/IntrospectCodeApiServiceImpl.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.wso2.carbon.identity.user.endpoint.impl;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
+import org.wso2.carbon.identity.recovery.model.UserRecoveryData;
+import org.wso2.carbon.identity.recovery.signup.UserSelfRegistrationManager;
+import org.wso2.carbon.identity.user.endpoint.*;
+import org.wso2.carbon.identity.user.endpoint.dto.*;
+
+
+import org.wso2.carbon.identity.user.endpoint.dto.CodeValidationRequestDTO;
+import org.wso2.carbon.identity.user.endpoint.dto.ErrorDTO;
+import org.wso2.carbon.identity.user.endpoint.dto.CodeValidateInfoResponseDTO;
+
+import java.util.HashMap;
+import java.util.List;
+
+import java.io.InputStream;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.wso2.carbon.identity.user.endpoint.util.Utils;
+
+import javax.ws.rs.core.Response;
+
+public class IntrospectCodeApiServiceImpl extends IntrospectCodeApiService {
+    private static final Log LOG = LogFactory.getLog(IntrospectCodeApiServiceImpl.class);
+
+
+    @Override
+    public Response introspectCodePost(CodeValidationRequestDTO codeValidationRequestDTO){
+        UserSelfRegistrationManager userSelfRegistrationManager = Utils.getUserSelfRegistrationManager();
+        UserRecoveryData codeDetails = null ;
+        try {
+            // Get the map of properties in the request.
+            HashMap<String, String> propertyMap = Utils.getPropertiesMap(codeValidationRequestDTO.getProperties());
+
+            // Get externally verified channel information.
+            VerifiedChannelDTO verifiedChannelDTO = codeValidationRequestDTO.getVerifiedChannel();
+            String verifiedChannelType = null;
+            String verifiedChannelClaim = null;
+
+            // Handling verified channel details not in the request.
+            if (verifiedChannelDTO != null) {
+                verifiedChannelClaim = verifiedChannelDTO.getClaim();
+                verifiedChannelType = verifiedChannelDTO.getType();
+            }
+            // Confirm code.
+            codeDetails = userSelfRegistrationManager
+                    .introspectUserSelfRegistration(codeValidationRequestDTO.getCode(), verifiedChannelType,
+                            verifiedChannelClaim, propertyMap);
+        } catch (IdentityRecoveryClientException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Client Error while confirming sent in code", e);
+            }
+            Utils.handleBadRequest(e.getMessage(), e.getErrorCode());
+        } catch (IdentityRecoveryException e) {
+            Utils.handleInternalServerError(Constants.SERVER_ERROR, e.getErrorCode(), LOG, e);
+        } catch (Throwable throwable) {
+            Utils.handleInternalServerError(Constants.SERVER_ERROR,
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_UNEXPECTED.getCode(), LOG, throwable);
+        }
+        return Response.accepted(codeDetails).build();
+    }
+}

--- a/components/org.wso2.carbon.identity.user.endpoint/src/main/resources/api.identity.user.yaml
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/main/resources/api.identity.user.yaml
@@ -213,6 +213,47 @@ paths:
       tags:
         - Self Register
 
+  #valid the code and retrieve related information.
+  /introspect-code:
+    post:
+      description: |
+        This API is used to validate the code used by self registered users and retrieve the details.
+      x-wso2-request: |
+        curl -k -v -X POST -H "Authorization: Basic YWRtaW5Ad3NvMi5jb206YWRtaW4=" -H "Content-Type: application/json" -d '{ "code": "17f00958-a1d7-47b9-8183-be99c08a800f"}' "https://localhost:9443/api/identity/user/v1.0/introspect-code"
+      x-wso2-curl: |
+        curl -k -v -X POST -H "Authorization: Basic YWRtaW5Ad3NvMi5jb206YWRtaW4=" -H "Content-Type: application/json" -d '{ "code": "17f00958-a1d7-47b9-8183-be99c08a800f"}' "https://localhost:9443/api/identity/user/v1.0/introspect-code"
+
+      x-wso2-response: |
+        "HTTP/1.1 200 OK"
+
+      summary: |
+        Validate code
+
+      # This are the post parameters:
+      parameters:
+        - name: code
+          in: body
+          description:  The validation code retrieved after user self registration, and optional property parameters.
+          required: true
+          schema:
+            $ref: '#/definitions/CodeValidationRequest'
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/CodeValidateInfoResponse'
+        400:
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Server Error
+          schema:
+            $ref: '#/definitions/Error'
+      tags:
+        - Self Register
+        - Verification
+
   /validate-username:
     post:
       description: |
@@ -537,6 +578,19 @@ definitions:
         type: 'integer'
         description: 'status code'
 
+#-----------------------------------------------------
+# Validated code information object
+#-----------------------------------------------------
+  CodeValidateInfoResponse:
+    type: object
+    properties:
+      user:
+        $ref: '#/definitions/ExtendedUser'
+      recoveryScenario:
+        type: string
+      recoveryStep:
+        type: string
+
 
 #-----------------------------------------------------
 # The SelfRegistrationUser Registration Request
@@ -573,6 +627,21 @@ definitions:
       value:
         type: string
         description: 'Claim value'
+
+#-----------------------------------------------------
+# The Extended User Object
+#-----------------------------------------------------
+  ExtendedUser:
+    type: object
+    properties:
+      username:
+        type: string
+      realm:
+        type: string
+      tenant:
+        type: string
+      isUsernameCaseSensitive:
+        type: boolean
 
 #-----------------------------------------------------
 # The Consent Receipt  object

--- a/components/org.wso2.carbon.identity.user.endpoint/src/main/webapp/WEB-INF/beans.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/main/webapp/WEB-INF/beans.xml
@@ -7,6 +7,7 @@
     <bean class="org.springframework.beans.factory.config.PreferencesPlaceholderConfigurer"/>
     <jaxrs:server id="services" address="/">
         <jaxrs:serviceBeans>
+            <bean class="org.wso2.carbon.identity.user.endpoint.IntrospectCodeApi"/>
             <bean class="org.wso2.carbon.identity.user.endpoint.LiteApi"/>
             <bean class="org.wso2.carbon.identity.user.endpoint.MeApi"/>
             <bean class="org.wso2.carbon.identity.user.endpoint.PiInfoApi"/>


### PR DESCRIPTION
### Proposed changes in this pull request

Introduce separate handler for lite user registration.
- Need to introduce new claim http://wso2.org/claims/identity/isLiteUser
- Add configuration to identity-mgt.properties file,
module.name.23=liteUserRegistration
liteUserRegistration.subscription.1=POST_ADD_USER

Currently added via deployment.toml file.