### PR TITLE
Support checkUserValidityForAccountRecovery functionality

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -267,6 +267,8 @@ public class IdentityRecoveryConstants {
         ERROR_CODE_USERNAME_RECOVERY_NOT_ENABLED("UNR-10001", "Username recovery is not enabled"),
         ERROR_CODE_USERNAME_RECOVERY_EMPTY_TENANT_DOMAIN("UNR-10002", "Empty tenant domain in username "
                 + "recovery request"),
+        ERROR_CODE_USERNAME_RECOVERY_VALIDATION_FAILED("UNR-10003",
+                "Username recovery validation failed for user account : '%s'"),
 
         // UAR - User Account Recovery.
         ERROR_CODE_INVALID_RECOVERY_CODE("UAR-10001", "Invalid recoveryCode : '%s'"),
@@ -285,6 +287,8 @@ public class IdentityRecoveryConstants {
         ERROR_CODE_INVALID_RECOVERY_SCENARIO("UAR-10011", "Invalid recovery scenario : '%s'"),
         ERROR_CODE_INVALID_RESEND_CODE("UAR-10012", "Invalid resend code : '%s'"),
         ERROR_CODE_EXPIRED_RECOVERY_CODE("UAR-10013", "Invalid recovery code : '%s'"),
+        ERROR_CODE_USER_ACCOUNT_RECOVERY_VALIDATION_FAILED("UAR-10014",
+                "User account recovery validation failed for user account : '%s'"),
         ERROR_CODE_ERROR_STORING_RECOVERY_DATA("UAR-15001", "Error storing user recovery data"),
         ERROR_CODE_ERROR_GETTING_USERSTORE_MANAGER("UAR-15002", "Error getting userstore manager"),
         ERROR_CODE_ERROR_RETRIEVING_USER_CLAIM("UAR-15003", "Error getting the claims : '%s' "
@@ -309,6 +313,8 @@ public class IdentityRecoveryConstants {
                 "reset request"),
         ERROR_CODE_PASSWORD_RECOVERY_EMPTY_TENANT_DOMAIN("PWR-10008", "Empty tenant domain in password "
                 + "recovery request"),
+        ERROR_CODE_PASSWORD_RECOVERY_VALIDATION_FAILED("PWR-10009",
+                "Password recovery validation failed for user account : '%s'"),
         ERROR_CODE_UNEXPECTED_ERROR_PASSWORD_RESET("PWR-15001", "Unexpected error during "
                 + "password reset"),
         ERROR_CODE_UNSUPPORTED_SMS_OTP_REGEX("PWR-15008", "SMS OTP regex pattern is not supported."),

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -121,8 +121,7 @@ public class UserAccountRecoveryManager {
                 notificationChannels = getExternalNotificationChannelList();
             }
             // Validate whether the user account is eligible for account recovery.
-            checkUserValidityForAccountRecovery(IdentityEventConstants.Event.PRE_ACCOUNT_RECOVERY, user,
-                    recoveryScenario, notificationChannels, properties);
+            checkUserValidityForAccountRecovery(user, recoveryScenario, notificationChannels, properties);
             // This flow will be initiated only if the user has any verified channels.
             String recoveryCode = UUIDGenerator.generateUUID();
             return buildUserRecoveryInformationResponseDTO(username, recoveryCode,
@@ -163,14 +162,13 @@ public class UserAccountRecoveryManager {
     /**
      * Check whether the user account is eligible for account recovery.
      *
-     * @param eventName                    Name of the event.
      * @param user                         The user.
      * @param recoveryScenario             Account recovery scenario.
      * @param recoveryNotificationChannels Notification channel.
      * @param metaProperties               Meta details.
      * @throws IdentityRecoveryException If account doesn't satisfy the conditions to recover.
      */
-    private void checkUserValidityForAccountRecovery(String eventName, User user, RecoveryScenarios recoveryScenario,
+    private void checkUserValidityForAccountRecovery(User user, RecoveryScenarios recoveryScenario,
                                                      List<NotificationChannel> recoveryNotificationChannels,
                                                      Map<String, String> metaProperties)
             throws IdentityRecoveryException {
@@ -188,7 +186,7 @@ public class UserAccountRecoveryManager {
                 }
             }
         }
-        Event identityMgtEvent = new Event(eventName, properties);
+        Event identityMgtEvent = new Event(IdentityEventConstants.Event.PRE_ACCOUNT_RECOVERY, properties);
         try {
             IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);
         } catch (IdentityEventException e) {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -26,6 +26,9 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
@@ -43,14 +46,20 @@ import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.util.Utils;
 
 import org.wso2.carbon.registry.core.utils.UUIDGenerator;
+import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.wso2.carbon.identity.recovery.RecoveryScenarios.NOTIFICATION_BASED_PW_RECOVERY;
+import static org.wso2.carbon.identity.recovery.RecoveryScenarios.QUESTION_BASED_PWD_RECOVERY;
+import static org.wso2.carbon.identity.recovery.RecoveryScenarios.USERNAME_RECOVERY;
 
 /**
  * Manager class which can be used to recover user account with available verified communication channels for a user.
@@ -97,9 +106,9 @@ public class UserAccountRecoveryManager {
         // Retrieve the user who matches the given set of claims.
         String username = getUsernameByClaims(claims, tenantDomain);
         if (StringUtils.isNotEmpty(username)) {
-
+            User user = Utils.buildUser(username, tenantDomain);
             // If the account is locked or disabled, do not let the user to recover the account.
-            checkAccountLockedStatus(Utils.buildUser(username, tenantDomain));
+            checkAccountLockedStatus(user);
             List<NotificationChannel> notificationChannels;
             // Get the notification management mechanism.
             boolean isNotificationsInternallyManaged = Utils.isNotificationsInternallyManaged(tenantDomain, properties);
@@ -111,6 +120,9 @@ public class UserAccountRecoveryManager {
             } else {
                 notificationChannels = getExternalNotificationChannelList();
             }
+            // Validate whether the user account is eligible for account recovery.
+            checkUserValidityForAccountRecovery(IdentityEventConstants.Event.PRE_ACCOUNT_RECOVERY, user,
+                    recoveryScenario, notificationChannels, properties);
             // This flow will be initiated only if the user has any verified channels.
             String recoveryCode = UUIDGenerator.generateUUID();
             return buildUserRecoveryInformationResponseDTO(username, recoveryCode,
@@ -145,6 +157,57 @@ public class UserAccountRecoveryManager {
                     IdentityRecoveryConstants.USER_ACCOUNT_RECOVERY);
             throw Utils.handleClientException(errorCode,
                     IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_LOCKED_ACCOUNT.getMessage(), user.getUserName());
+        }
+    }
+
+    /**
+     * Check whether the user account is eligible for account recovery.
+     *
+     * @param eventName                    Name of the event.
+     * @param user                         The user.
+     * @param recoveryScenario             Account recovery scenario.
+     * @param recoveryNotificationChannels Notification channel.
+     * @param metaProperties               Meta details.
+     * @throws IdentityRecoveryException If account doesn't satisfy the conditions to recover.
+     */
+    private void checkUserValidityForAccountRecovery(String eventName, User user, RecoveryScenarios recoveryScenario,
+                                                     List<NotificationChannel> recoveryNotificationChannels,
+                                                     Map<String, String> metaProperties)
+            throws IdentityRecoveryException {
+
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put(IdentityEventConstants.EventProperty.USER, user);
+        properties.put(IdentityEventConstants.EventProperty.USER_STORE_MANAGER, getUserStoreManager(user));
+        properties.put(IdentityEventConstants.EventProperty.RECOVERY_SCENARIO, recoveryScenario);
+        properties.put(IdentityEventConstants.EventProperty.NOTIFICATION_CHANNEL, recoveryNotificationChannels);
+
+        if (MapUtils.isNotEmpty(metaProperties)) {
+            for (Map.Entry<String, String> metaProperty : metaProperties.entrySet()) {
+                if (StringUtils.isNotBlank(metaProperty.getValue()) && StringUtils.isNotBlank(metaProperty.getKey())) {
+                    properties.put(metaProperty.getKey(), metaProperty.getValue());
+                }
+            }
+        }
+        Event identityMgtEvent = new Event(eventName, properties);
+        try {
+            IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);
+        } catch (IdentityEventException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error occurred while validating user account " + user.getUserName() +
+                        " for account recovery.");
+            }
+            String errorMessage = e.getMessage();
+            String errorCode = IdentityRecoveryConstants.ErrorMessages.
+                    ERROR_CODE_USER_ACCOUNT_RECOVERY_VALIDATION_FAILED.getCode();
+            if (USERNAME_RECOVERY.equals(recoveryScenario)) {
+                errorCode = IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_USERNAME_RECOVERY_VALIDATION_FAILED
+                        .getCode();
+            } else if (NOTIFICATION_BASED_PW_RECOVERY.equals(recoveryScenario) ||
+                    QUESTION_BASED_PWD_RECOVERY.equals(recoveryScenario)) {
+                errorCode = IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PASSWORD_RECOVERY_VALIDATION_FAILED
+                        .getCode();
+            }
+            throw Utils.handleClientException(errorCode, errorMessage, user.getUserName());
         }
     }
 
@@ -440,6 +503,35 @@ public class UserAccountRecoveryManager {
                     IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_ERROR_GETTING_USERSTORE_MANAGER, null, e);
         }
         return userStoreManager;
+    }
+
+    /**
+     * Get the userstore manager for the user.
+     *
+     * @param user User.
+     * @return Userstore manager.
+     * @throws IdentityRecoveryException Error getting the userstore manager.
+     */
+    private UserStoreManager getUserStoreManager(User user) throws IdentityRecoveryException {
+
+        RealmService realmService = IdentityRecoveryServiceDataHolder.getInstance().getRealmService();
+        try {
+            UserRealm tenantUserRealm = realmService.getTenantUserRealm(IdentityTenantUtil.
+                    getTenantId(user.getTenantDomain()));
+            if (IdentityUtil.getPrimaryDomainName().equals(user.getUserStoreDomain())) {
+                return (UserStoreManager) tenantUserRealm.getUserStoreManager();
+            }
+            return ((UserStoreManager) tenantUserRealm.getUserStoreManager())
+                    .getSecondaryUserStoreManager(user.getUserStoreDomain());
+        } catch (UserStoreException e) {
+            if (log.isDebugEnabled()) {
+                String error = String.format("Error retrieving the user store manager for the user : %s",
+                        user.getUserName());
+                log.debug(error, e);
+            }
+            throw Utils.handleServerException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_ERROR_GETTING_USERSTORE_MANAGER, null, e);
+        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
@@ -78,6 +79,9 @@ public class UserAccountRecoveryManagerTest {
 
     @Mock
     UserRecoveryDataStore userRecoveryDataStore;
+    
+    @Mock
+    IdentityEventService identityEventService;
 
     @ObjectFactory
     public IObjectFactory getObjectFactory() {
@@ -124,6 +128,7 @@ public class UserAccountRecoveryManagerTest {
         mockRecoveryConfigs(true);
         mockUserstoreManager();
         mockJDBCRecoveryDataStore();
+        mockBuildUser();
         // Test when the user is self-registered.
         testGetSelfSignUpUsers();
         // Test when the user is not self registered.
@@ -210,6 +215,8 @@ public class UserAccountRecoveryManagerTest {
         mockGetUserList(new String[]{UserProfile.USERNAME.getValue()});
         mockRecoveryConfigs(false);
         mockJDBCRecoveryDataStore();
+        mockIdentityEventService();
+        mockBuildUser();
         RecoveryChannelInfoDTO recoveryChannelInfoDTO = userAccountRecoveryManager
                 .retrieveUserRecoveryInformation(userClaims, StringUtils.EMPTY, RecoveryScenarios.USERNAME_RECOVERY,
                         null);
@@ -265,6 +272,7 @@ public class UserAccountRecoveryManagerTest {
 
         mockStatic(IdentityUtil.class);
         when(IdentityUtil.extractDomainFromName(Matchers.anyString())).thenReturn("PRIMARY");
+        when(IdentityUtil.getPrimaryDomainName()).thenReturn("PRIMARY");
         mockStatic(Utils.class);
         when(Utils.isAccountDisabled(Matchers.any(User.class))).thenReturn(false);
         when(Utils.isAccountLocked(Matchers.any(User.class))).thenReturn(false);
@@ -414,6 +422,21 @@ public class UserAccountRecoveryManagerTest {
         when(identityRecoveryServiceDataHolder.getRealmService()).thenReturn(realmService);
         when(realmService.getTenantUserRealm(Matchers.anyInt())).thenReturn(userRealm);
         when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+    }
+
+    private void mockBuildUser() {
+
+        User user = new User();
+        user.setUserName(UserProfile.USERNAME.value);
+        user.setUserStoreDomain("PRIMARY");
+        when(Utils.buildUser(Matchers.anyString(), Matchers.anyString())).thenReturn(user);
+    }
+
+    private void mockIdentityEventService() {
+
+        mockStatic(IdentityRecoveryServiceDataHolder.class);
+        when(IdentityRecoveryServiceDataHolder.getInstance()).thenReturn(identityRecoveryServiceDataHolder);
+        when(identityRecoveryServiceDataHolder.getIdentityEventService()).thenReturn(identityEventService);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -158,6 +158,12 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.mgt.endpoint.util</artifactId>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.governance</groupId>

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -158,12 +158,6 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.mgt.endpoint.util</artifactId>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.ws.rs</groupId>
-                    <artifactId>jsr311-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.governance</groupId>


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/9147
Depends on https://github.com/wso2/carbon-identity-framework/pull/3073

This PR is to support the functionality of checking user account validity for account recovery.
