### PR TITLE
Enable/Disable sms-based password recovery

### DIFF
--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.governance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.governance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.history/pom.xml
+++ b/components/org.wso2.carbon.identity.password.history/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.history/pom.xml
+++ b/components/org.wso2.carbon.identity.password.history/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.policy/pom.xml
+++ b/components/org.wso2.carbon.identity.password.policy/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.policy/pom.xml
+++ b/components/org.wso2.carbon.identity.password.policy/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.piicontroller/pom.xml
+++ b/components/org.wso2.carbon.identity.piicontroller/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.piicontroller/pom.xml
+++ b/components/org.wso2.carbon.identity.piicontroller/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.ui/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.ui/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.ui/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.ui/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -16,6 +16,12 @@
 
 package org.wso2.carbon.identity.recovery;
 
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.recovery.util.Utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Identity management related constants.
  */
@@ -588,47 +594,5 @@ public class IdentityRecoveryConstants {
         /* State maintained to skip triggering an email verification when the update request contains other claims
         without the email address claim. */
         SKIP_ON_INAPPLICABLE_CLAIMS
-    }
-
-    /**
-     * Enum contains the codes and status messages for per-user functionality locking.
-     */
-    public enum RecoveryLockReasons {
-
-        PWD_RECOVERY_MAX_ATTEMPTS_EXCEEDED("FL_001", "Maximum attempts exceeded for password recovery.");
-
-        private final String functionalityLockCode;
-        private final String functionalityLockReason;
-
-        /**
-         * Per-user lock code constructor.
-         *
-         * @param functionalityLockCode   Lock reason code.
-         * @param functionalityLockReason Reason for the functionality lock.
-         */
-        RecoveryLockReasons(String functionalityLockCode, String functionalityLockReason) {
-
-            this.functionalityLockCode = functionalityLockCode;
-            this.functionalityLockReason = functionalityLockReason;
-        }
-
-        public String getFunctionalityLockReason() {
-
-            return functionalityLockReason;
-        }
-
-        public String getFunctionalityLockCode() {
-
-            return functionalityLockCode;
-        }
-    }
-
-    /**
-     * Constants used for masking the functionality types.
-     */
-    public static class FunctionalityTypes {
-
-        public static final String FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY =
-                "SecurityQuestionBasedPasswordRecovery";
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -16,9 +16,6 @@
 
 package org.wso2.carbon.identity.recovery;
 
-import org.apache.commons.lang.StringUtils;
-import org.wso2.carbon.identity.recovery.util.Utils;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -594,5 +591,90 @@ public class IdentityRecoveryConstants {
         /* State maintained to skip triggering an email verification when the update request contains other claims
         without the email address claim. */
         SKIP_ON_INAPPLICABLE_CLAIMS
+    }
+
+    /**
+     * Enum contains the codes and status messages for per-user functionality locking.
+     */
+    public enum RecoveryLockReasons {
+
+        PWD_RECOVERY_MAX_ATTEMPTS_EXCEEDED("RFL_001", "Maximum attempts exceeded for password recovery.");
+
+        private final String functionalityLockCode;
+        private final String functionalityLockReason;
+
+        /**
+         * Per-user lock code constructor.
+         *
+         * @param functionalityLockCode   Lock reason code.
+         * @param functionalityLockReason Reason for the functionality lock.
+         */
+        RecoveryLockReasons(String functionalityLockCode, String functionalityLockReason) {
+
+            this.functionalityLockCode = functionalityLockCode;
+            this.functionalityLockReason = functionalityLockReason;
+        }
+
+        public String getFunctionalityLockReason() {
+
+            return functionalityLockReason;
+        }
+
+        public String getFunctionalityLockCode() {
+
+            return functionalityLockCode;
+        }
+    }
+
+    /**
+     * Enum contains the Functionality and Functionality Identifier.
+     */
+    public enum FunctionalityTypes {
+
+        FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY("FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY",
+                "SecurityQuestionBasedPasswordRecovery"),
+        FUNCTIONALITY_NOTIFICATION_BASED_PW_RECOVERY_SMS("FUNCTIONALITY_NOTIFICATION_BASED_PW_RECOVERY_SMS",
+                "SMSBasedPasswordRecovery");
+
+        private final String functionalityName;
+        private final String functionalityIdentifier;
+        private static Map<String, FunctionalityTypes> functionalityToTypeMapping;
+
+        private FunctionalityTypes(String functionalityName, String functionalityIdentifier) {
+
+            this.functionalityName = functionalityName;
+            this.functionalityIdentifier = functionalityIdentifier;
+        }
+
+        public String getFunctionalityIdentifier() {
+
+            return this.functionalityIdentifier;
+        }
+
+        public String getDescription() {
+
+            return this.functionalityName;
+        }
+
+        public String toString() {
+
+            return this.functionalityIdentifier + " - " + this.functionalityName;
+        }
+
+        public static FunctionalityTypes getFunctionality(String functionalityName) {
+
+            if (functionalityToTypeMapping == null) {
+                initMapping();
+            }
+            return functionalityToTypeMapping.get(functionalityName);
+        }
+
+        private static void initMapping() {
+
+            functionalityToTypeMapping = new HashMap<>();
+            for (FunctionalityTypes types : values()) {
+                functionalityToTypeMapping.put(types.functionalityName, types);
+            }
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -42,6 +42,10 @@ import org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.util.Utils;
 
+import org.wso2.carbon.identity.user.functionality.mgt.UserFunctionalityManager;
+import org.wso2.carbon.identity.user.functionality.mgt.UserFunctionalityMgtConstants;
+import org.wso2.carbon.identity.user.functionality.mgt.exception.UserFunctionalityManagementException;
+import org.wso2.carbon.identity.user.functionality.mgt.model.FunctionalityLockStatus;
 import org.wso2.carbon.registry.core.utils.UUIDGenerator;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
@@ -62,6 +66,9 @@ public class UserAccountRecoveryManager {
     private static final String FORWARD_SLASH = "/";
     private static final NotificationChannels[] notificationChannels = {
             NotificationChannels.EMAIL_CHANNEL, NotificationChannels.SMS_CHANNEL};
+    private static final boolean PER_USER_FUNCTIONALITY_LOCKING_ENABLED = Utils.isPerUserFunctionalityLockingEnabled();
+    private static final String NOTIFICATION_BASED_PW_RECOVERY_SMS = "NOTIFICATION_BASED_PW_RECOVERY_SMS";
+
 
     /**
      * Constructor.
@@ -107,7 +114,8 @@ public class UserAccountRecoveryManager {
             /* If the notification is internally managed, then notification channels available for the user needs to
             be retrieved. If external notifications are enabled, external channel list should be returned.*/
             if (isNotificationsInternallyManaged) {
-                notificationChannels = getInternalNotificationChannelList(username, tenantDomain);
+                notificationChannels = getInternalNotificationChannelList(username, tenantDomain,
+                        recoveryScenario);
             } else {
                 notificationChannels = getExternalNotificationChannelList();
             }
@@ -239,7 +247,8 @@ public class UserAccountRecoveryManager {
      * @throws IdentityRecoveryClientException No notification channels available for the user.
      * @throws IdentityRecoveryException       If an error occurred while getting user claim values.
      */
-    private List<NotificationChannel> getInternalNotificationChannelList(String username, String tenantDomain)
+    private List<NotificationChannel> getInternalNotificationChannelList(String username, String tenantDomain,
+                                                                         RecoveryScenarios recoveryScenarios)
             throws IdentityRecoveryClientException, IdentityRecoveryException {
 
         // Create a list of required claims that needs to be retrieved from the user attributes.
@@ -251,7 +260,8 @@ public class UserAccountRecoveryManager {
                     IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_NOTIFICATION_CHANNELS_FOR_USER, null);
         }
         // Get the channel list with details.
-        List<NotificationChannel> notificationChannels = getNotificationChannelDetails(claimValues);
+        List<NotificationChannel> notificationChannels = getNotificationChannelDetails(username, tenantDomain,
+                claimValues, recoveryScenarios);
         if (notificationChannels.size() == 0) {
             throw Utils.handleClientException(
                     IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_VERIFIED_CHANNELS_FOR_USER, null);
@@ -289,7 +299,7 @@ public class UserAccountRecoveryManager {
      * @return NotificationChannelsResponseDTSs list.
      */
     private NotificationChannelDTO[] getNotificationChannelsResponseDTOList(String userName, String recoveryID,
-                                           String tenantDomain, List<NotificationChannel> notificationChannels,
+                                                                            String tenantDomain, List<NotificationChannel> notificationChannels,
                                                                             RecoveryScenarios recoveryScenario)
             throws IdentityRecoveryException {
 
@@ -533,7 +543,8 @@ public class UserAccountRecoveryManager {
      * @param claimValues Claim values related to the notification channels
      * @return Verified notification channels for the user.
      */
-    private List<NotificationChannel> getNotificationChannelDetails(Map<String, String> claimValues) {
+    private List<NotificationChannel> getNotificationChannelDetails(String username, String tenantDomain, Map<String,
+            String> claimValues, RecoveryScenarios recoveryScenarios) throws IdentityRecoveryServerException {
 
         // Check whether the user is self registered user.
         boolean isSelfRegisteredUser = isSelfSignUpUser(claimValues.get(IdentityRecoveryConstants.USER_ROLES_CLAIM));
@@ -542,11 +553,14 @@ public class UserAccountRecoveryManager {
         for (NotificationChannels channel : notificationChannels) {
             String channelValue = claimValues.get(channel.getClaimUri());
             boolean channelVerified = Boolean.parseBoolean(claimValues.get(channel.getVerifiedClaimUrl()));
+            boolean isFunctionalityLocked = isFunctionalityLocked(username, tenantDomain, channel.getChannelType(),
+                    recoveryScenarios);
             NotificationChannel channelDataModel = new NotificationChannel();
 
             // If the user is self registered, then user has to have the verified channel claims. Check whether channel
             // is verified and not empty.
-            if (isSelfRegisteredUser && channelVerified && StringUtils.isNotEmpty(channelValue)) {
+            if (!isFunctionalityLocked && isSelfRegisteredUser && channelVerified &&
+                    StringUtils.isNotEmpty(channelValue)) {
                 channelDataModel.setType(channel.getChannelType());
                 channelDataModel.setChannelValue(channelValue);
                 // Check whether the preferred channel matches the given channel.
@@ -554,7 +568,7 @@ public class UserAccountRecoveryManager {
                     channelDataModel.setPreferredStatus(true);
                 }
                 verifiedChannels.add(channelDataModel);
-            } else if (StringUtils.isNotEmpty(channelValue)) {
+            } else if (!isFunctionalityLocked && StringUtils.isNotEmpty(channelValue)) {
                 channelDataModel.setType(channel.getChannelType());
                 channelDataModel.setChannelValue(channelValue);
                 // Check whether the preferred channel matches the given channel.
@@ -565,6 +579,65 @@ public class UserAccountRecoveryManager {
             }
         }
         return verifiedChannels;
+    }
+
+    /**
+     * Verify whether the functionality is locked or not and return true if it is locked. Else return false.
+     *
+     * @param username          Username.
+     * @param tenantDomain      TenantDomain.
+     * @param channelType       ChannelType (SMS or EMail).
+     * @param recoveryScenarios RecoveryScenarios.
+     * @return Return true if it is locked. Else return false.
+     * @throws IdentityRecoveryServerException
+     */
+    private boolean isFunctionalityLocked(String username, String tenantDomain, String channelType,
+                                          RecoveryScenarios recoveryScenarios) throws IdentityRecoveryServerException {
+
+        if (PER_USER_FUNCTIONALITY_LOCKING_ENABLED) {
+            String functionalityType = "FUNCTIONALITY_" + recoveryScenarios.name() + "_" + channelType;
+            // Check whether the functionality is locked ot not. If it is locked, stop from sending that channel
+            // for recovery.
+            if( UserFunctionalityMgtConstants.FunctionalityTypes.getFunctionality(functionalityType) != null){
+                String functionalityIdentifier =
+                        UserFunctionalityMgtConstants.FunctionalityTypes.getFunctionality(functionalityType).getFunctionalityIdentifier();
+                FunctionalityLockStatus functionalityLockStatus = getFunctionalityStatusOfUser(username, tenantDomain,
+                        functionalityIdentifier);
+                return functionalityLockStatus.getLockStatus();
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Get the lock status of a functionality given the tenant domain, user name and the functionality identifier.
+     *
+     * @param tenantDomain            Tenant domain of the user.
+     * @param userName                Username of the user.
+     * @param functionalityIdentifier Identifier of the the functionality.
+     * @return The status of the functionality, {@link FunctionalityLockStatus}.
+     */
+    private FunctionalityLockStatus getFunctionalityStatusOfUser(String userName, String tenantDomain,
+                                                                 String functionalityIdentifier)
+            throws IdentityRecoveryServerException {
+
+        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+        String userId = Utils.getUserId(userName, tenantId);
+
+        UserFunctionalityManager userFunctionalityManager =
+                IdentityRecoveryServiceDataHolder.getInstance().getUserFunctionalityManagerService();
+
+        try {
+            return userFunctionalityManager.getLockStatus(userId, tenantId, functionalityIdentifier);
+        } catch (UserFunctionalityManagementException e) {
+            String mappedErrorCode =
+                    Utils.prependOperationScenarioToErrorCode(
+                            IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FAILED_TO_GET_LOCK_STATUS_FOR_FUNCTIONALITY
+                                    .getCode(), IdentityRecoveryConstants.PASSWORD_RECOVERY_SCENARIO);
+            String message = IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FAILED_TO_GET_LOCK_STATUS_FOR_FUNCTIONALITY
+                    .getMessage();
+            throw Utils.handleServerException(mappedErrorCode, message, null);
+        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -43,7 +43,6 @@ import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.util.Utils;
 
 import org.wso2.carbon.identity.user.functionality.mgt.UserFunctionalityManager;
-import org.wso2.carbon.identity.user.functionality.mgt.UserFunctionalityMgtConstants;
 import org.wso2.carbon.identity.user.functionality.mgt.exception.UserFunctionalityManagementException;
 import org.wso2.carbon.identity.user.functionality.mgt.model.FunctionalityLockStatus;
 import org.wso2.carbon.registry.core.utils.UUIDGenerator;
@@ -68,6 +67,7 @@ public class UserAccountRecoveryManager {
             NotificationChannels.EMAIL_CHANNEL, NotificationChannels.SMS_CHANNEL};
     private static final boolean PER_USER_FUNCTIONALITY_LOCKING_ENABLED = Utils.isPerUserFunctionalityLockingEnabled();
     private static final String NOTIFICATION_BASED_PW_RECOVERY_SMS = "NOTIFICATION_BASED_PW_RECOVERY_SMS";
+    private static final String FUNCTIONALITY_PREFIX = "FUNCTIONALITY_";
 
 
     /**
@@ -595,12 +595,12 @@ public class UserAccountRecoveryManager {
                                           RecoveryScenarios recoveryScenarios) throws IdentityRecoveryServerException {
 
         if (PER_USER_FUNCTIONALITY_LOCKING_ENABLED) {
-            String functionalityType = "FUNCTIONALITY_" + recoveryScenarios.name() + "_" + channelType;
+            String functionalityType = FUNCTIONALITY_PREFIX + recoveryScenarios.name() + "_" + channelType;
             // Check whether the functionality is locked ot not. If it is locked, stop from sending that channel
             // for recovery.
-            if( UserFunctionalityMgtConstants.FunctionalityTypes.getFunctionality(functionalityType) != null){
-                String functionalityIdentifier =
-                        UserFunctionalityMgtConstants.FunctionalityTypes.getFunctionality(functionalityType).getFunctionalityIdentifier();
+            if (IdentityRecoveryConstants.FunctionalityTypes.getFunctionality(functionalityType) != null) {
+                String functionalityIdentifier = IdentityRecoveryConstants.FunctionalityTypes.
+                        getFunctionality(functionalityType).getFunctionalityIdentifier();
                 FunctionalityLockStatus functionalityLockStatus = getFunctionalityStatusOfUser(username, tenantDomain,
                         functionalityIdentifier);
                 return functionalityLockStatus.getLockStatus();

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/password/PasswordRecoveryManagerImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/password/PasswordRecoveryManagerImpl.java
@@ -112,20 +112,12 @@ public class PasswordRecoveryManagerImpl implements PasswordRecoveryManager {
         if (isNotificationBasedRecoveryEnabled) {
             recoveryInformationDTO.setRecoveryChannelInfoDTO(recoveryChannelInfoDTO);
         }
-
-        if (isSkipRecoveryWithChallengeQuestionsForInsufficientAnswersEnabled) {
-            recoveryInformationDTO.setQuestionBasedRecoveryAllowedForUser(isQuestionBasedRecoveryEnabled &&
-                    isMinNoOfRecoveryQuestionsAnswered(username, tenantDomain));
-        } else {
-            recoveryInformationDTO.setQuestionBasedRecoveryAllowedForUser(isQuestionBasedRecoveryEnabled);
-        }
-
         // Check if question based password recovery is unlocked in per-user functionality locking mode.
         if (isPerUserFunctionalityLockingEnabled) {
             boolean isQuestionBasedRecoveryLocked = getFunctionalityStatusOfUser(tenantDomain,
                     recoveryChannelInfoDTO.getUsername(),
-                    IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY)
-                    .getLockStatus();
+                    IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY
+                            .getFunctionalityIdentifier()).getLockStatus();
             recoveryInformationDTO.setQuestionBasedRecoveryEnabled(!isQuestionBasedRecoveryLocked);
         } else {
             recoveryInformationDTO.setQuestionBasedRecoveryEnabled(isQuestionBasedRecoveryEnabled);
@@ -649,9 +641,8 @@ public class PasswordRecoveryManagerImpl implements PasswordRecoveryManager {
                                     .getMessage());
             if (isDetailedErrorMessagesEnabled) {
                 message.append(String.format("functionality: %s for %s.",
-                        UserFunctionalityMgtConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY
-                                .getFunctionalityIdentifier(),
-                        userName));
+                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY
+                                .getFunctionalityIdentifier(), userName));
             }
             throw Utils.handleServerException(mappedErrorCode, message.toString(), null);
         }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/password/PasswordRecoveryManagerImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/password/PasswordRecoveryManagerImpl.java
@@ -52,6 +52,7 @@ import org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.util.Utils;
 import org.wso2.carbon.identity.user.functionality.mgt.UserFunctionalityManager;
+import org.wso2.carbon.identity.user.functionality.mgt.UserFunctionalityMgtConstants;
 import org.wso2.carbon.identity.user.functionality.mgt.exception.UserFunctionalityManagementException;
 import org.wso2.carbon.identity.user.functionality.mgt.model.FunctionalityLockStatus;
 import org.wso2.carbon.registry.core.utils.UUIDGenerator;
@@ -116,8 +117,8 @@ public class PasswordRecoveryManagerImpl implements PasswordRecoveryManager {
         if (isPerUserFunctionalityLockingEnabled) {
             boolean isQuestionBasedRecoveryLocked = getFunctionalityStatusOfUser(tenantDomain,
                     recoveryChannelInfoDTO.getUsername(),
-                    IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY)
-                    .getLockStatus();
+                    UserFunctionalityMgtConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY
+                            .getFunctionalityIdentifier()).getLockStatus();
             recoveryInformationDTO.setQuestionBasedRecoveryEnabled(!isQuestionBasedRecoveryLocked);
         } else {
             recoveryInformationDTO.setQuestionBasedRecoveryEnabled(isQuestionBasedRecoveryEnabled);
@@ -649,7 +650,8 @@ public class PasswordRecoveryManagerImpl implements PasswordRecoveryManager {
                                     .getMessage());
             if (isDetailedErrorMessagesEnabled) {
                 message.append(String.format("functionality: %s for %s.",
-                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY,
+                        UserFunctionalityMgtConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY
+                                .getFunctionalityIdentifier(),
                         userName));
             }
             throw Utils.handleServerException(mappedErrorCode, message.toString(), null);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/SecurityQuestionPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/SecurityQuestionPasswordRecoveryManager.java
@@ -51,7 +51,6 @@ import org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.util.Utils;
 import org.wso2.carbon.identity.user.functionality.mgt.UserFunctionalityManager;
-import org.wso2.carbon.identity.user.functionality.mgt.UserFunctionalityMgtConstants;
 import org.wso2.carbon.identity.user.functionality.mgt.exception.UserFunctionalityManagementException;
 import org.wso2.carbon.identity.user.functionality.mgt.exception.UserFunctionalityManagementServerException;
 import org.wso2.carbon.identity.user.functionality.mgt.model.FunctionalityLockStatus;
@@ -208,7 +207,8 @@ public class SecurityQuestionPasswordRecoveryManager {
 
         if (isPerUserFunctionalityLockingEnabled) {
             FunctionalityLockStatus functionalityLockStatus = getFunctionalityStatusOfUser(user,
-                    getSecurityQueFunctionalityIdentifier());
+                    IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY
+                            .getFunctionalityIdentifier());
 
             if (functionalityLockStatus.getLockStatus()) {
                 StringBuilder message = new StringBuilder(
@@ -614,25 +614,31 @@ public class SecurityQuestionPasswordRecoveryManager {
         if (resetFailedLoginLockOutCount) {
             try {
                 userFunctionalityManager.unlock(userId, tenantId,
-                        getSecurityQueFunctionalityIdentifier());
+                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY
+                                .getFunctionalityIdentifier());
                 userFunctionalityManager.deleteAllPropertiesForUser(userId, tenantId,
-                        getSecurityQueFunctionalityIdentifier());
+                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY
+                                .getFunctionalityIdentifier());
             } catch (UserFunctionalityManagementException e) {
                 throw Utils.handleFunctionalityLockMgtServerException(
                         IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FAILED_TO_UNLOCK_FUNCTIONALITY_FOR_USER, userId,
-                        tenantId, getSecurityQueFunctionalityIdentifier(), isDetailedErrorMessagesEnabled);
+                        tenantId, IdentityRecoveryConstants.FunctionalityTypes.
+                                FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY.getFunctionalityIdentifier(),
+                        isDetailedErrorMessagesEnabled);
             }
         } else {
             try {
                 Map<String, String> propertiesToUpdate = new HashMap<String, String>();
                 propertiesToUpdate.put(IdentityRecoveryConstants.FUNCTION_FAILED_ATTEMPTS_PROPERTY, "0");
                 userFunctionalityManager.setProperties(userId, tenantId,
-                        getSecurityQueFunctionalityIdentifier(), propertiesToUpdate);
+                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY
+                                .getFunctionalityIdentifier(), propertiesToUpdate);
             } catch (UserFunctionalityManagementException e) {
                 throw Utils.handleFunctionalityLockMgtServerException(
                         IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FAILED_TO_UPDATE_PROPERTIES_FOR_FUNCTIONALITY,
-                        userId,
-                        tenantId, getSecurityQueFunctionalityIdentifier(), isDetailedErrorMessagesEnabled);
+                        userId, tenantId, IdentityRecoveryConstants.FunctionalityTypes.
+                                        FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY.getFunctionalityIdentifier(),
+                        isDetailedErrorMessagesEnabled);
             }
         }
     }
@@ -757,7 +763,8 @@ public class SecurityQuestionPasswordRecoveryManager {
         Map<String, String> configStoreProperties =
                 ConfigStoreFunctionalityLockPropertyHandler
                         .getInstance().getConfigStoreProperties(user.getTenantDomain(),
-                        getSecurityQueFunctionalityIdentifier());
+                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY
+                                .getFunctionalityIdentifier());
 
         validateUserFunctionalityProperties(configStoreProperties);
 
@@ -776,11 +783,14 @@ public class SecurityQuestionPasswordRecoveryManager {
         Map<String, String> functionalityLockProperties;
         try {
             functionalityLockProperties = userFunctionalityManager.getProperties(userId, tenantId,
-                    getSecurityQueFunctionalityIdentifier());
+                    IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY
+                            .getFunctionalityIdentifier());
         } catch (UserFunctionalityManagementException e) {
             throw Utils.handleFunctionalityLockMgtServerException(
-                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FAILED_TO_GET_PROPERTIES_FOR_FUNCTIONALITY, userId,
-                    tenantId, getSecurityQueFunctionalityIdentifier(), isDetailedErrorMessagesEnabled);
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FAILED_TO_GET_PROPERTIES_FOR_FUNCTIONALITY,
+                    userId, tenantId, IdentityRecoveryConstants.FunctionalityTypes.
+                            FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY.getFunctionalityIdentifier(),
+                    isDetailedErrorMessagesEnabled);
         }
         if (functionalityLockProperties.isEmpty()) {
             functionalityLockProperties.put(IdentityRecoveryConstants.FUNCTION_LOCKOUT_COUNT_PROPERTY,
@@ -791,11 +801,14 @@ public class SecurityQuestionPasswordRecoveryManager {
                     .put(IdentityRecoveryConstants.FUNCTION_MAX_ATTEMPTS_PROPERTY, String.valueOf(maxAttempts));
             try {
                 userFunctionalityManager.setProperties(userId, tenantId,
-                        getSecurityQueFunctionalityIdentifier(), functionalityLockProperties);
+                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY
+                                .getFunctionalityIdentifier(), functionalityLockProperties);
             } catch (UserFunctionalityManagementException e) {
                 throw Utils.handleFunctionalityLockMgtServerException(
-                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FAILED_TO_ADD_PROPERTIES_FOR_FUNCTIONALITY, userId,
-                        tenantId, getSecurityQueFunctionalityIdentifier(), isDetailedErrorMessagesEnabled);
+                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FAILED_TO_ADD_PROPERTIES_FOR_FUNCTIONALITY,
+                        userId, tenantId, IdentityRecoveryConstants.FunctionalityTypes.
+                                FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY.getFunctionalityIdentifier(),
+                        isDetailedErrorMessagesEnabled);
             }
         } else {
             if (NumberUtils.isNumber(
@@ -820,17 +833,20 @@ public class SecurityQuestionPasswordRecoveryManager {
                 updatedFunctionalityLockProperties.put(IdentityRecoveryConstants.FUNCTION_LOCKOUT_COUNT_PROPERTY,
                         String.valueOf(failedLoginLockoutCountValue + 1));
                 userFunctionalityManager.lock(userId, tenantId,
-                        getSecurityQueFunctionalityIdentifier(), unlockTimePropertyValue,
-                        UserFunctionalityMgtConstants.FunctionalityLockReasons.PWD_RECOVERY_MAX_ATTEMPTS_EXCEEDED
+                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY
+                                .getFunctionalityIdentifier(), unlockTimePropertyValue,
+                        IdentityRecoveryConstants.RecoveryLockReasons.PWD_RECOVERY_MAX_ATTEMPTS_EXCEEDED
                                 .getFunctionalityLockCode(),
-                        UserFunctionalityMgtConstants.FunctionalityLockReasons.PWD_RECOVERY_MAX_ATTEMPTS_EXCEEDED
+                        IdentityRecoveryConstants.RecoveryLockReasons.PWD_RECOVERY_MAX_ATTEMPTS_EXCEEDED
                                 .getFunctionalityLockReason());
                 userFunctionalityManager.setProperties(userId, tenantId,
-                       getSecurityQueFunctionalityIdentifier(), updatedFunctionalityLockProperties);
+                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY
+                                .getFunctionalityIdentifier(), updatedFunctionalityLockProperties);
             } catch (UserFunctionalityManagementServerException e) {
                 throw Utils.handleFunctionalityLockMgtServerException(
                         IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FAILED_TO_LOCK_FUNCTIONALITY_FOR_USER, userId,
-                        tenantId, getSecurityQueFunctionalityIdentifier(), isDetailedErrorMessagesEnabled);
+                        tenantId, IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY
+                                .getFunctionalityIdentifier(), isDetailedErrorMessagesEnabled);
             } catch (UserFunctionalityManagementException e) {
                 e.printStackTrace();
             }
@@ -839,7 +855,7 @@ public class SecurityQuestionPasswordRecoveryManager {
                             .getMessage());
             if (isDetailedErrorMessagesEnabled) {
                 message.append(": ")
-                        .append(UserFunctionalityMgtConstants.FunctionalityLockReasons.PWD_RECOVERY_MAX_ATTEMPTS_EXCEEDED
+                        .append(IdentityRecoveryConstants.RecoveryLockReasons.PWD_RECOVERY_MAX_ATTEMPTS_EXCEEDED
                                 .getFunctionalityLockReason());
             }
             throw IdentityException.error(IdentityRecoveryClientException.class,
@@ -852,11 +868,14 @@ public class SecurityQuestionPasswordRecoveryManager {
                 propertiesToUpdate.put(IdentityRecoveryConstants.FUNCTION_FAILED_ATTEMPTS_PROPERTY,
                         String.valueOf(currentAttempts + 1));
                 userFunctionalityManager.setProperties(userId, tenantId,
-                        getSecurityQueFunctionalityIdentifier(), propertiesToUpdate);
+                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY
+                                .getFunctionalityIdentifier(), propertiesToUpdate);
             } catch (UserFunctionalityManagementException e) {
                 throw Utils.handleFunctionalityLockMgtServerException(
                         IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FAILED_TO_UPDATE_PROPERTIES_FOR_FUNCTIONALITY,
-                        userId, tenantId, getSecurityQueFunctionalityIdentifier(), isDetailedErrorMessagesEnabled);
+                        userId, tenantId, IdentityRecoveryConstants.FunctionalityTypes.
+                                FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY.getFunctionalityIdentifier(),
+                        isDetailedErrorMessagesEnabled);
             }
         }
     }
@@ -947,15 +966,10 @@ public class SecurityQuestionPasswordRecoveryManager {
                                     .getMessage());
             if (isDetailedErrorMessagesEnabled) {
                 message.append(String.format("functionalityIdentifier: %s for %s.",
-                        getSecurityQueFunctionalityIdentifier(), user.getUserName()));
+                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY
+                                .getFunctionalityIdentifier(), user.getUserName()));
             }
             throw Utils.handleServerException(mappedErrorCode, message.toString(), null);
         }
-    }
-
-    private String getSecurityQueFunctionalityIdentifier(){
-
-        return UserFunctionalityMgtConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY
-                .getFunctionalityIdentifier();
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/SecurityQuestionPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/SecurityQuestionPasswordRecoveryManager.java
@@ -51,6 +51,7 @@ import org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.util.Utils;
 import org.wso2.carbon.identity.user.functionality.mgt.UserFunctionalityManager;
+import org.wso2.carbon.identity.user.functionality.mgt.UserFunctionalityMgtConstants;
 import org.wso2.carbon.identity.user.functionality.mgt.exception.UserFunctionalityManagementException;
 import org.wso2.carbon.identity.user.functionality.mgt.exception.UserFunctionalityManagementServerException;
 import org.wso2.carbon.identity.user.functionality.mgt.model.FunctionalityLockStatus;
@@ -207,7 +208,7 @@ public class SecurityQuestionPasswordRecoveryManager {
 
         if (isPerUserFunctionalityLockingEnabled) {
             FunctionalityLockStatus functionalityLockStatus = getFunctionalityStatusOfUser(user,
-                    IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY);
+                    getSecurityQueFunctionalityIdentifier());
 
             if (functionalityLockStatus.getLockStatus()) {
                 StringBuilder message = new StringBuilder(
@@ -613,28 +614,25 @@ public class SecurityQuestionPasswordRecoveryManager {
         if (resetFailedLoginLockOutCount) {
             try {
                 userFunctionalityManager.unlock(userId, tenantId,
-                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY);
+                        getSecurityQueFunctionalityIdentifier());
                 userFunctionalityManager.deleteAllPropertiesForUser(userId, tenantId,
-                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY);
-            } catch (UserFunctionalityManagementServerException e) {
+                        getSecurityQueFunctionalityIdentifier());
+            } catch (UserFunctionalityManagementException e) {
                 throw Utils.handleFunctionalityLockMgtServerException(
                         IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FAILED_TO_UNLOCK_FUNCTIONALITY_FOR_USER, userId,
-                        tenantId, IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY,
-                        isDetailedErrorMessagesEnabled);
+                        tenantId, getSecurityQueFunctionalityIdentifier(), isDetailedErrorMessagesEnabled);
             }
         } else {
             try {
                 Map<String, String> propertiesToUpdate = new HashMap<String, String>();
                 propertiesToUpdate.put(IdentityRecoveryConstants.FUNCTION_FAILED_ATTEMPTS_PROPERTY, "0");
                 userFunctionalityManager.setProperties(userId, tenantId,
-                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY,
-                        propertiesToUpdate);
-            } catch (UserFunctionalityManagementServerException e) {
+                        getSecurityQueFunctionalityIdentifier(), propertiesToUpdate);
+            } catch (UserFunctionalityManagementException e) {
                 throw Utils.handleFunctionalityLockMgtServerException(
                         IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FAILED_TO_UPDATE_PROPERTIES_FOR_FUNCTIONALITY,
                         userId,
-                        tenantId, IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY,
-                        isDetailedErrorMessagesEnabled);
+                        tenantId, getSecurityQueFunctionalityIdentifier(), isDetailedErrorMessagesEnabled);
             }
         }
     }
@@ -759,7 +757,7 @@ public class SecurityQuestionPasswordRecoveryManager {
         Map<String, String> configStoreProperties =
                 ConfigStoreFunctionalityLockPropertyHandler
                         .getInstance().getConfigStoreProperties(user.getTenantDomain(),
-                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY);
+                        getSecurityQueFunctionalityIdentifier());
 
         validateUserFunctionalityProperties(configStoreProperties);
 
@@ -778,12 +776,11 @@ public class SecurityQuestionPasswordRecoveryManager {
         Map<String, String> functionalityLockProperties;
         try {
             functionalityLockProperties = userFunctionalityManager.getProperties(userId, tenantId,
-                    IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY);
-        } catch (UserFunctionalityManagementServerException e) {
+                    getSecurityQueFunctionalityIdentifier());
+        } catch (UserFunctionalityManagementException e) {
             throw Utils.handleFunctionalityLockMgtServerException(
                     IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FAILED_TO_GET_PROPERTIES_FOR_FUNCTIONALITY, userId,
-                    tenantId, IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY,
-                    isDetailedErrorMessagesEnabled);
+                    tenantId, getSecurityQueFunctionalityIdentifier(), isDetailedErrorMessagesEnabled);
         }
         if (functionalityLockProperties.isEmpty()) {
             functionalityLockProperties.put(IdentityRecoveryConstants.FUNCTION_LOCKOUT_COUNT_PROPERTY,
@@ -794,13 +791,11 @@ public class SecurityQuestionPasswordRecoveryManager {
                     .put(IdentityRecoveryConstants.FUNCTION_MAX_ATTEMPTS_PROPERTY, String.valueOf(maxAttempts));
             try {
                 userFunctionalityManager.setProperties(userId, tenantId,
-                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY,
-                        functionalityLockProperties);
-            } catch (UserFunctionalityManagementServerException e) {
+                        getSecurityQueFunctionalityIdentifier(), functionalityLockProperties);
+            } catch (UserFunctionalityManagementException e) {
                 throw Utils.handleFunctionalityLockMgtServerException(
                         IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FAILED_TO_ADD_PROPERTIES_FOR_FUNCTIONALITY, userId,
-                        tenantId, IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY,
-                        isDetailedErrorMessagesEnabled);
+                        tenantId, getSecurityQueFunctionalityIdentifier(), isDetailedErrorMessagesEnabled);
             }
         } else {
             if (NumberUtils.isNumber(
@@ -825,20 +820,17 @@ public class SecurityQuestionPasswordRecoveryManager {
                 updatedFunctionalityLockProperties.put(IdentityRecoveryConstants.FUNCTION_LOCKOUT_COUNT_PROPERTY,
                         String.valueOf(failedLoginLockoutCountValue + 1));
                 userFunctionalityManager.lock(userId, tenantId,
-                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY,
-                        unlockTimePropertyValue,
-                        IdentityRecoveryConstants.RecoveryLockReasons.PWD_RECOVERY_MAX_ATTEMPTS_EXCEEDED
+                        getSecurityQueFunctionalityIdentifier(), unlockTimePropertyValue,
+                        UserFunctionalityMgtConstants.FunctionalityLockReasons.PWD_RECOVERY_MAX_ATTEMPTS_EXCEEDED
                                 .getFunctionalityLockCode(),
-                        IdentityRecoveryConstants.RecoveryLockReasons.PWD_RECOVERY_MAX_ATTEMPTS_EXCEEDED
+                        UserFunctionalityMgtConstants.FunctionalityLockReasons.PWD_RECOVERY_MAX_ATTEMPTS_EXCEEDED
                                 .getFunctionalityLockReason());
                 userFunctionalityManager.setProperties(userId, tenantId,
-                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY,
-                        updatedFunctionalityLockProperties);
+                       getSecurityQueFunctionalityIdentifier(), updatedFunctionalityLockProperties);
             } catch (UserFunctionalityManagementServerException e) {
                 throw Utils.handleFunctionalityLockMgtServerException(
                         IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FAILED_TO_LOCK_FUNCTIONALITY_FOR_USER, userId,
-                        tenantId, IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY,
-                        isDetailedErrorMessagesEnabled);
+                        tenantId, getSecurityQueFunctionalityIdentifier(), isDetailedErrorMessagesEnabled);
             } catch (UserFunctionalityManagementException e) {
                 e.printStackTrace();
             }
@@ -847,7 +839,7 @@ public class SecurityQuestionPasswordRecoveryManager {
                             .getMessage());
             if (isDetailedErrorMessagesEnabled) {
                 message.append(": ")
-                        .append(IdentityRecoveryConstants.RecoveryLockReasons.PWD_RECOVERY_MAX_ATTEMPTS_EXCEEDED
+                        .append(UserFunctionalityMgtConstants.FunctionalityLockReasons.PWD_RECOVERY_MAX_ATTEMPTS_EXCEEDED
                                 .getFunctionalityLockReason());
             }
             throw IdentityException.error(IdentityRecoveryClientException.class,
@@ -860,14 +852,11 @@ public class SecurityQuestionPasswordRecoveryManager {
                 propertiesToUpdate.put(IdentityRecoveryConstants.FUNCTION_FAILED_ATTEMPTS_PROPERTY,
                         String.valueOf(currentAttempts + 1));
                 userFunctionalityManager.setProperties(userId, tenantId,
-                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY,
-                        propertiesToUpdate);
-            } catch (UserFunctionalityManagementServerException e) {
+                        getSecurityQueFunctionalityIdentifier(), propertiesToUpdate);
+            } catch (UserFunctionalityManagementException e) {
                 throw Utils.handleFunctionalityLockMgtServerException(
                         IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FAILED_TO_UPDATE_PROPERTIES_FOR_FUNCTIONALITY,
-                        userId, tenantId,
-                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY,
-                        isDetailedErrorMessagesEnabled);
+                        userId, tenantId, getSecurityQueFunctionalityIdentifier(), isDetailedErrorMessagesEnabled);
             }
         }
     }
@@ -958,10 +947,15 @@ public class SecurityQuestionPasswordRecoveryManager {
                                     .getMessage());
             if (isDetailedErrorMessagesEnabled) {
                 message.append(String.format("functionalityIdentifier: %s for %s.",
-                        IdentityRecoveryConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY,
-                        user.getUserName()));
+                        getSecurityQueFunctionalityIdentifier(), user.getUserName()));
             }
             throw Utils.handleServerException(mappedErrorCode, message.toString(), null);
         }
+    }
+
+    private String getSecurityQueFunctionalityIdentifier(){
+
+        return UserFunctionalityMgtConstants.FunctionalityTypes.FUNCTIONALITY_SECURITY_QUESTION_PW_RECOVERY
+                .getFunctionalityIdentifier();
     }
 }

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.export.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.export.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.export.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.export.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.rename.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.rename.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.user.rename.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.rename.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.governance.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.governance.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.recovery.ui.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.ui.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.recovery.ui.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.ui.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.user.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.user.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -641,7 +641,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.17.109</carbon.identity.framework.version> <!--TODO - update the version-->
+        <carbon.identity.framework.version>5.18.67-SNAPSHOT</carbon.identity.framework.version> <!--TODO - update the version-->
         <carbon.identity.framework.imp.pkg.version.range>[5.15.28, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.wso2.carbon.identity.governance</groupId>
     <artifactId>identity-governance</artifactId>
-    <version>1.4.35-SNAPSHOT</version>
+    <version>1.4.35</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Governance Module</name>
@@ -37,7 +37,7 @@
         <url>https://github.com/wso2-extensions/identity-governance.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-governance.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-governance.git</connection>
-        <tag>v1.1.0-SNAPSHOT</tag>
+        <tag>v1.4.35</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -641,7 +641,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.18.73</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.18.75-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.28, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.wso2.carbon.identity.governance</groupId>
     <artifactId>identity-governance</artifactId>
-    <version>1.4.35</version>
+    <version>1.4.36-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Governance Module</name>
@@ -37,7 +37,7 @@
         <url>https://github.com/wso2-extensions/identity-governance.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-governance.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-governance.git</connection>
-        <tag>v1.4.35</tag>
+        <tag>v1.1.0-SNAPSHOT</tag>
     </scm>
 
     <repositories>

--- a/service-stubs/identity/org.wso2.carbon.identity.recovery.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.recovery.stub/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.identity.recovery.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.recovery.stub/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/pom.xml
+++ b/service-stubs/identity/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35-SNAPSHOT</version>
+        <version>1.4.35</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/pom.xml
+++ b/service-stubs/identity/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.35</version>
+        <version>1.4.36-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
This includes the following changes:

- Improve error handling in security question flow. frontport of https://github.com/wso2-support/identity-governance/pull/237
- Disable/Enable SMS based password recovery; frontport of https://github.com/wso2-support/identity-governance/pull/235

merge this PR after this https://github.com/wso2-extensions/identity-governance/pull/394

