### PR TITLE
 Fix for the remainingAttempts query parameter not returning issue

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
@@ -1740,8 +1740,8 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
 
         IdentityUtil.threadLocalProperties.get().put(USER_EXIST_THREAD_LOCAL_PROPERTY, true);
         if (log.isDebugEnabled()) {
-            log.debug(USER_EXIST_THREAD_LOCAL_PROPERTY + " is added as true to the thread local for the user: " +
-                    userName + "in the user store domain: " + userStoreDomain);
+            log.debug(String.format("The %s is added as true to the thread local for the user: %s " +
+                    "in the user store domain: %s.", USER_EXIST_THREAD_LOCAL_PROPERTY, userName, userStoreDomain));
         }
     }
 }

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
@@ -62,6 +62,12 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
     IdentityEventService eventMgtService = IdentityMgtServiceDataHolder.getInstance().getIdentityEventService();
     private static String RE_CAPTCHA_USER_DOMAIN = "user-domain-recaptcha";
 
+    /**
+     * USER_EXIST_THREAD_LOCAL_PROPERTY is used to maintain the state of user existence
+     * which has used in org.wso2.carbon.identity.governance.listener.BasicAuthenticator.
+     */
+    private static String USER_EXIST_THREAD_LOCAL_PROPERTY = "userExistThreadLocalProperty";
+
     @Override
     public int getExecutionOrderId() {
 
@@ -119,12 +125,9 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
                         "user store domain: " + userStoreManager.getRealmConfiguration().getUserStoreProperty
                         (UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME));
             }
-            if (isAuthPolicyAccountExistCheck()) {
-                IdentityErrorMsgContext customErrorMessageContext = new IdentityErrorMsgContext(UserCoreConstants
-                        .ErrorCode.USER_DOES_NOT_EXIST);
-                IdentityUtil.setIdentityErrorMsg(customErrorMessageContext);
-            }
             return true;
+        } else {
+            setUserExistThreadLocal();
         }
         IdentityUtil.threadLocalProperties.get().remove(IdentityCoreConstants.USER_ACCOUNT_STATE);
         String eventName = IdentityEventConstants.Event.POST_AUTHENTICATION;
@@ -1732,9 +1735,11 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
         return isExists;
     }
 
-    private boolean isAuthPolicyAccountExistCheck() {
+    private void setUserExistThreadLocal() {
 
-        return Boolean.parseBoolean(IdentityUtil.getProperty("AuthenticationPolicy.CheckAccountExist"));
+        IdentityUtil.threadLocalProperties.get().put(USER_EXIST_THREAD_LOCAL_PROPERTY, true);
+        if (log.isDebugEnabled()) {
+            log.debug(USER_EXIST_THREAD_LOCAL_PROPERTY + " is added as true to the thread local.");
+        }
     }
-
 }

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
@@ -127,7 +127,8 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
             }
             return true;
         } else {
-            setUserExistThreadLocal();
+            setUserExistThreadLocal(userName, userStoreManager.getRealmConfiguration().getUserStoreProperty
+                    (UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME));
         }
         IdentityUtil.threadLocalProperties.get().remove(IdentityCoreConstants.USER_ACCOUNT_STATE);
         String eventName = IdentityEventConstants.Event.POST_AUTHENTICATION;
@@ -1735,11 +1736,12 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
         return isExists;
     }
 
-    private void setUserExistThreadLocal() {
+    private void setUserExistThreadLocal(String userName, String userStoreDomain) {
 
         IdentityUtil.threadLocalProperties.get().put(USER_EXIST_THREAD_LOCAL_PROPERTY, true);
         if (log.isDebugEnabled()) {
-            log.debug(USER_EXIST_THREAD_LOCAL_PROPERTY + " is added as true to the thread local.");
+            log.debug(USER_EXIST_THREAD_LOCAL_PROPERTY + " is added as true to the thread local for the user: " +
+                    userName + "in the user store domain: " + userStoreDomain);
         }
     }
 }


### PR DESCRIPTION
## Description
 Fix for the remainingAttempts query parameter not returning issue for the users in the secondary user store.

## Approach
Maintain the state of the user existence through `userExistThreadLocalProperty` to set the error code to IdentityErrorMsgContext accordingly based on the "user does not exist" and "invalid credentials" cases.

Resolves: wso2/product-is#9583
Related PR: https://github.com/wso2-extensions/identity-local-auth-basicauth/pull/78