### PR TITLE
Fix for change username validity API responses

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -118,7 +118,8 @@ public class UserSelfRegistrationManager {
         return instance;
     }
 
-    public NotificationResponseBean registerUser(User user, String password, Claim[] claims, Property[] properties) throws IdentityRecoveryException {
+    public NotificationResponseBean registerUser(User user, String password, Claim[] claims, Property[] properties)
+            throws IdentityRecoveryException {
 
         publishEvent(user, claims, properties, IdentityEventConstants.Event.PRE_SELF_SIGNUP_REGISTER);
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -769,13 +769,22 @@ public class Utils {
         RealmConfiguration realmConfig = getRealmConfiguration(user);
         String passwordErrorMessage = realmConfig.getUserStoreProperty(PROPERTY_PASSWORD_ERROR_MSG);
         String exceptionMessage = exception.getMessage();
-        if (((StringUtils.indexOfAny(exceptionMessage, pwdPatternViolations) >= 0) && StringUtils
-                .containsIgnoreCase(exceptionMessage, passwordErrorMessage)) || exceptionMessage
-                .contains(UserCoreErrorConstants.ErrorMessages.ERROR_CODE_INVALID_PASSWORD.getCode())) {
+        if (((StringUtils.indexOfAny(exceptionMessage, pwdPatternViolations) >= 0) &&
+                StringUtils.containsIgnoreCase(exceptionMessage, passwordErrorMessage)) ||
+                exceptionMessage.contains(UserCoreErrorConstants.ErrorMessages.ERROR_CODE_INVALID_PASSWORD.getCode())) {
 
-            throw IdentityException.error(IdentityRecoveryClientException.class,
-                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_POLICY_VIOLATION.getCode(), passwordErrorMessage,
-                    exception);
+            if (StringUtils.isNotEmpty(passwordErrorMessage)) {
+                throw IdentityException.error(IdentityRecoveryClientException.class,
+                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_POLICY_VIOLATION.getCode(),
+                        passwordErrorMessage, exception);
+            } else {
+                String errorMessage = String.format(
+                        UserCoreErrorConstants.ErrorMessages.ERROR_CODE_INVALID_PASSWORD.getMessage(),
+                        realmConfig.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_JAVA_REG_EX));
+                throw IdentityException.error(IdentityRecoveryClientException.class,
+                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_POLICY_VIOLATION.getCode(),
+                        errorMessage, exception);
+            }
         }
     }
 

--- a/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImpl.java
@@ -21,20 +21,25 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.CarbonException;
+import org.wso2.carbon.core.util.AnonymousSessionUtil;
 import org.wso2.carbon.identity.mgt.constants.SelfRegistrationStatusCodes;
-import org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
+import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
 import org.wso2.carbon.identity.recovery.signup.UserSelfRegistrationManager;
 import org.wso2.carbon.identity.user.endpoint.Constants;
 import org.wso2.carbon.identity.user.endpoint.ValidateUsernameApiService;
+import org.wso2.carbon.identity.user.endpoint.dto.ErrorDTO;
 import org.wso2.carbon.identity.user.endpoint.dto.PropertyDTO;
 import org.wso2.carbon.identity.user.endpoint.dto.UsernameValidateInfoResponseDTO;
 import org.wso2.carbon.identity.user.endpoint.dto.UsernameValidationRequestDTO;
 import org.wso2.carbon.identity.user.endpoint.util.Utils;
-import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.UserStoreException;
 
 import java.util.List;
 import javax.ws.rs.core.Response;
@@ -43,21 +48,95 @@ public class ValidateUsernameApiServiceImpl extends ValidateUsernameApiService {
 
     private static final Log LOG = LogFactory.getLog(ResendCodeApiServiceImpl.class);
     private static final String SKIP_SIGN_UP_ENABLE_CHECK_KEY = "skipSignUpEnableCheck";
+    private static final String USERNAME_JAVA_REG_EX_VIOLATION_ERROR_MSG = "UsernameJavaRegExViolationErrorMsg";
+    private static final String DISABLE_USER_NAME_VALIDITY_API_ERROR_RESPONSES =
+            "DisableUserNameValidityApiErrorResponses";
 
     @Override
     public Response validateUsernamePost(UsernameValidationRequestDTO user) {
+
+        // Checking the property DisableUserNameValidityApiErrorResponses in identity.xml to decide whether to use the
+        // newly improved method or the old one.
+
+        if (isUserNameValidityApiErrorResponsesDisabled()) {
+            return checkUserNameValidity(user);
+        } else {
+            return checkUserNameValidityStatus(user);
+        }
+    }
+
+    /**
+     * This is the old way of checking username validity, where we return 200 ok for any instance. Keeping this to
+     * preserve backward compatibility. Need to use {@link #checkUserNameValidityStatus(UsernameValidationRequestDTO)}
+     * instead.
+     *
+     * @param user Username validation request.
+     * @return Response object.
+     */
+    private Response checkUserNameValidity(UsernameValidationRequestDTO user) {
+
+        if (StringUtils.isEmpty(user.getUsername())) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Username cannot be empty.").build();
+        }
+        try {
+            String tenantDomain = MultitenantUtils.getTenantDomain(user.getUsername());
+            List<PropertyDTO> propertyDTOList = user.getProperties();
+            boolean skipSelfSignUpEnabledCheck = false;
+            if (CollectionUtils.isNotEmpty(propertyDTOList)) {
+                for (PropertyDTO propertyDTO : propertyDTOList) {
+                    if (SKIP_SIGN_UP_ENABLE_CHECK_KEY.equalsIgnoreCase(propertyDTO.getKey())) {
+                        skipSelfSignUpEnabledCheck = Boolean.parseBoolean(propertyDTO.getValue());
+                    }
+                }
+            }
+            UserSelfRegistrationManager userSelfRegistrationManager = Utils
+                    .getUserSelfRegistrationManager();
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("Validating username for user %s", user.getUsername()));
+            }
+            UsernameValidateInfoResponseDTO responseDTO = new UsernameValidateInfoResponseDTO();
+            if (!userSelfRegistrationManager.isValidTenantDomain(tenantDomain)) {
+                logDebug(String.format("%s is an invalid tenant domain. Hence returning code %s: ", tenantDomain,
+                        SelfRegistrationStatusCodes.ERROR_CODE_INVALID_TENANT));
+                responseDTO.setStatusCode(Integer.parseInt(SelfRegistrationStatusCodes.ERROR_CODE_INVALID_TENANT));
+            } else if (!skipSelfSignUpEnabledCheck &&
+                    !userSelfRegistrationManager.isSelfRegistrationEnabled(tenantDomain)) {
+                logDebug(String.format("Self registration is not enabled for tenant domain: %s . Hence returning code" +
+                        ": %s", tenantDomain, SelfRegistrationStatusCodes.ERROR_CODE_SELF_REGISTRATION_DISABLED));
+                responseDTO.setStatusCode(
+                        Integer.parseInt(SelfRegistrationStatusCodes.ERROR_CODE_SELF_REGISTRATION_DISABLED));
+            } else if (userSelfRegistrationManager.isUsernameAlreadyTaken(user.getUsername())) {
+                logDebug(String.format("username : %s is an already taken. Hence returning code %s: ",
+                        user.getUsername(), SelfRegistrationStatusCodes.ERROR_CODE_USER_ALREADY_EXISTS));
+                responseDTO.setStatusCode(Integer.parseInt(SelfRegistrationStatusCodes.ERROR_CODE_USER_ALREADY_EXISTS));
+            } else if (!userSelfRegistrationManager.isMatchUserNameRegex(tenantDomain, user.getUsername())) {
+                logDebug(String.format("%s is an invalid user name. Hence returning code %s: ",
+                        user.getUsername(), SelfRegistrationStatusCodes.CODE_USER_NAME_INVALID));
+                responseDTO.setStatusCode(Integer.parseInt(SelfRegistrationStatusCodes.CODE_USER_NAME_INVALID));
+            } else {
+                logDebug(String.format("username : %s is available for self registration. Hence returning code %s: ",
+                        user.getUsername(), SelfRegistrationStatusCodes.CODE_USER_NAME_AVAILABLE));
+                responseDTO.setStatusCode(Integer.parseInt(SelfRegistrationStatusCodes.CODE_USER_NAME_AVAILABLE));
+            }
+            return Response.ok().entity(responseDTO).build();
+        } catch (IdentityRecoveryException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Error while checking username validity for user " + user.getUsername(), e);
+            }
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Error while checking user " +
+                    "existence").build();
+        }
+    }
+
+    private Response checkUserNameValidityStatus(UsernameValidationRequestDTO user) {
 
         if (StringUtils.isEmpty(user.getUsername())) {
             return Response.status(Response.Status.BAD_REQUEST).entity("Username cannot be empty.").build();
         }
 
-        String fullyQualifiedUsername = user.getUsername();
         try {
-            String tenantDomain = resolveTenantDomain(user);
-            String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(user.getUsername());
-            fullyQualifiedUsername = UserCoreUtil.addTenantDomainToEntry(tenantAwareUsername, tenantDomain);
+            String tenantDomain = MultitenantUtils.getTenantDomain(user.getUsername());
             List<PropertyDTO> propertyDTOList = user.getProperties();
-
             boolean skipSelfSignUpEnabledCheck = false;
 
             if (CollectionUtils.isNotEmpty(propertyDTOList)) {
@@ -67,54 +146,85 @@ public class ValidateUsernameApiServiceImpl extends ValidateUsernameApiService {
                     }
                 }
             }
-            UserSelfRegistrationManager userSelfRegistrationManager = Utils.getUserSelfRegistrationManager();
+            UserSelfRegistrationManager userSelfRegistrationManager = Utils
+                    .getUserSelfRegistrationManager();
             if (LOG.isDebugEnabled()) {
-                LOG.debug(String.format("Validating username for user %s", fullyQualifiedUsername));
+                LOG.debug(String.format("Validating username for user %s", user.getUsername()));
             }
             UsernameValidateInfoResponseDTO responseDTO = new UsernameValidateInfoResponseDTO();
-
-            if (IdentityUtil.isEmailUsernameEnabled() &&
-                    StringUtils.containsNone(user.getUsername(), "@")) {
-                logDebug("Username is invalid. Username should be in email format.");
-                responseDTO.setStatusCode(Integer.parseInt(
-                        SelfRegistrationStatusCodes.ERROR_CODE_INVALID_EMAIL_USERNAME));
-            } else if (!userSelfRegistrationManager.isValidTenantDomain(tenantDomain)) {
+            ErrorDTO errorDTO = new ErrorDTO();
+            if (!userSelfRegistrationManager.isValidTenantDomain(tenantDomain)) {
                 logDebug(String.format("%s is an invalid tenant domain. Hence returning code %s: ", tenantDomain,
                         SelfRegistrationStatusCodes.ERROR_CODE_INVALID_TENANT));
-                responseDTO.setStatusCode(Integer.parseInt(SelfRegistrationStatusCodes.ERROR_CODE_INVALID_TENANT));
-            } else if (!skipSelfSignUpEnabledCheck && !userSelfRegistrationManager.isSelfRegistrationEnabled(tenantDomain)) {
-                logDebug(String.format("Self registration is not enabled for tenant domain : %s . Hence returning " +
-                                "code %s", tenantDomain,
-                        SelfRegistrationStatusCodes.ERROR_CODE_SELF_REGISTRATION_DISABLED));
-                responseDTO.setStatusCode(
-                        Integer.parseInt(SelfRegistrationStatusCodes.ERROR_CODE_SELF_REGISTRATION_DISABLED));
-            } else if (userSelfRegistrationManager.isUsernameAlreadyTaken(fullyQualifiedUsername, tenantDomain)) {
+                errorDTO.setCode(SelfRegistrationStatusCodes.ERROR_CODE_INVALID_TENANT);
+                return Response.status(Response.Status.BAD_REQUEST).entity(errorDTO).build();
+            } else if (!skipSelfSignUpEnabledCheck &&
+                    !userSelfRegistrationManager.isSelfRegistrationEnabled(tenantDomain)) {
+                logDebug(String.format("Self registration is not enabled for tenant domain: %s. Hence returning code:" +
+                        " %s", tenantDomain, SelfRegistrationStatusCodes.ERROR_CODE_SELF_REGISTRATION_DISABLED));
+                errorDTO.setCode(SelfRegistrationStatusCodes.ERROR_CODE_SELF_REGISTRATION_DISABLED);
+                return Response.status(Response.Status.BAD_REQUEST).entity(errorDTO).build();
+            } else if (userSelfRegistrationManager.isUsernameAlreadyTaken(user.getUsername())) {
                 logDebug(String.format("username : %s is an already taken. Hence returning code %s: ",
-                        fullyQualifiedUsername, SelfRegistrationStatusCodes.ERROR_CODE_USER_ALREADY_EXISTS));
-                responseDTO.setStatusCode(Integer.parseInt(SelfRegistrationStatusCodes.ERROR_CODE_USER_ALREADY_EXISTS));
-            } else if (!userSelfRegistrationManager.isMatchUserNameRegex(tenantDomain, tenantAwareUsername)) {
+                        user.getUsername(), SelfRegistrationStatusCodes.ERROR_CODE_USER_ALREADY_EXISTS));
+                errorDTO.setCode(SelfRegistrationStatusCodes.ERROR_CODE_USER_ALREADY_EXISTS);
+                return Response.status(Response.Status.BAD_REQUEST).entity(errorDTO).build();
+            } else if (!userSelfRegistrationManager.isMatchUserNameRegex(tenantDomain, user.getUsername())) {
                 logDebug(String.format("%s is an invalid user name. Hence returning code %s: ",
-                        fullyQualifiedUsername, SelfRegistrationStatusCodes.CODE_USER_NAME_INVALID));
-                responseDTO.setStatusCode(Integer.parseInt(SelfRegistrationStatusCodes.CODE_USER_NAME_INVALID));
+                        user.getUsername(), SelfRegistrationStatusCodes.CODE_USER_NAME_INVALID));
+                errorDTO.setCode(SelfRegistrationStatusCodes.CODE_USER_NAME_INVALID);
+                errorDTO.setMessage(getRegexViolationErrorMsg(user, tenantDomain));
+                return Response.status(Response.Status.BAD_REQUEST).entity(errorDTO).build();
             } else {
                 logDebug(String.format("username : %s is available for self registration. Hence returning code %s: ",
-                        fullyQualifiedUsername, SelfRegistrationStatusCodes.CODE_USER_NAME_AVAILABLE));
+                        user.getUsername(), SelfRegistrationStatusCodes.CODE_USER_NAME_AVAILABLE));
                 responseDTO.setStatusCode(Integer.parseInt(SelfRegistrationStatusCodes.CODE_USER_NAME_AVAILABLE));
+                return Response.ok().entity(responseDTO).build();
             }
-            return Response.ok().entity(responseDTO).build();
-        } catch (IdentityRecoveryException e) {
+        } catch (IdentityRecoveryException | CarbonException | UserStoreException e) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Error while checking username validity for user " + fullyQualifiedUsername, e);
-            }
-            if (e instanceof IdentityRecoveryClientException) {
-                if (StringUtils.isNotBlank(e.getErrorDescription())) {
-                    return Response.status(Response.Status.BAD_REQUEST).entity(e.getErrorDescription()).build();
-                }
-                return Response.status(Response.Status.BAD_REQUEST).entity("Invalid Request").build();
+                LOG.debug("Error while checking username validity for user " + user.getUsername(), e);
             }
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Error while checking user " +
                     "existence").build();
         }
+    }
+
+    private String getRegexViolationErrorMsg(UsernameValidationRequestDTO user, String tenantDomain)
+            throws CarbonException, UserStoreException {
+
+        String userDomain = IdentityUtil.extractDomainFromName(user.getUsername());
+        UserRealm userRealm = getUserRealm(tenantDomain);
+        RealmConfiguration realmConfiguration = userRealm.getUserStoreManager().getSecondaryUserStoreManager
+                (userDomain).getRealmConfiguration();
+        String errorMsg = realmConfiguration
+                .getUserStoreProperty(USERNAME_JAVA_REG_EX_VIOLATION_ERROR_MSG);
+        if (StringUtils.isNotEmpty(errorMsg)) {
+            return errorMsg;
+        } else {
+            return user.getUsername() + " is an invalid user name. Please pick a valid username.";
+        }
+    }
+
+    /**
+     * If the property DisableUserNameValidityApiErrorResponses is set to True in identity.xml, username validity API
+     * will not return error response for invalid usernames. All responses will be 200 OK with specific error codes.
+     */
+    public static boolean isUserNameValidityApiErrorResponsesDisabled() {
+
+        String enableUserNameValidationApiResponseProperty =
+                IdentityUtil.getProperty(DISABLE_USER_NAME_VALIDITY_API_ERROR_RESPONSES);
+        if (StringUtils.isNotBlank(enableUserNameValidationApiResponseProperty)) {
+            return Boolean.parseBoolean(enableUserNameValidationApiResponseProperty);
+        }
+        return false;
+    }
+
+    private UserRealm getUserRealm(String tenantDomain) throws CarbonException {
+
+        return AnonymousSessionUtil.getRealmByTenantDomain(IdentityRecoveryServiceDataHolder.getInstance()
+                        .getRegistryService(), IdentityRecoveryServiceDataHolder.getInstance().getRealmService(),
+                tenantDomain);
     }
 
     private void logDebug(String message) {


### PR DESCRIPTION
### Proposed changes in this pull request

Previous username validation API was implemented to send 200 OK responses for any instance, including errors as well. This PR changes that behaviour by sending 400 errors on invalid username instances to maintain backward compatibility, a property has been introduced.

Property name: DisableUserNameValidityApiErrorResponses
Location to add: identity.xml
Behaviour: If set to true, old behaviour will be engaged.
Default: False (Property will not be added to the identity.xml).

Resolve:  https://github.com/wso2/product-is/issues/9349
