### PR TITLE
Revert "Fix tenant issue in "/validate-username" and "/claims" endpoints."

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -107,8 +107,6 @@ public class IdentityRecoveryConstants {
             ".org/claims/identity/failedPasswordRecoveryAttempts";
     public static final String SIGN_UP_ROLE_SEPARATOR = ",";
 
-    public static final String ENABLE_TENANT_QUALIFIED_URLS = "EnableTenantQualifiedUrls";
-
     public static final String NOTIFICATION_EVENTNAME_PREFIX = "TRIGGER_";
     public static final String NOTIFICATION_EVENTNAME_SUFFIX = "_NOTIFICATION";
     public static final String SEND_TO = "send-to";

--- a/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImpl.java
@@ -19,25 +19,20 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.mgt.constants.SelfRegistrationStatusCodes;
 import org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants;
-import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
-import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.signup.UserSelfRegistrationManager;
-import org.wso2.carbon.identity.user.endpoint.Constants;
 import org.wso2.carbon.identity.user.endpoint.ValidateUsernameApiService;
 import org.wso2.carbon.identity.user.endpoint.dto.PropertyDTO;
 import org.wso2.carbon.identity.user.endpoint.dto.UsernameValidateInfoResponseDTO;
 import org.wso2.carbon.identity.user.endpoint.dto.UsernameValidationRequestDTO;
 import org.wso2.carbon.identity.user.endpoint.util.Utils;
-import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
-import java.util.List;
 import javax.ws.rs.core.Response;
+import java.util.List;
 
 public class ValidateUsernameApiServiceImpl extends ValidateUsernameApiService {
 
@@ -51,25 +46,25 @@ public class ValidateUsernameApiServiceImpl extends ValidateUsernameApiService {
             return Response.status(Response.Status.BAD_REQUEST).entity("Username cannot be empty.").build();
         }
 
-        String fullyQualifiedUsername = user.getUsername();
         try {
-            String tenantDomain = resolveTenantDomain(user);
-            String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(user.getUsername());
-            fullyQualifiedUsername = UserCoreUtil.addTenantDomainToEntry(tenantAwareUsername, tenantDomain);
             List<PropertyDTO> propertyDTOList = user.getProperties();
-
+            String tenantDomain = MultitenantUtils.getTenantDomain(user.getUsername());
             boolean skipSelfSignUpEnabledCheck = false;
 
             if (CollectionUtils.isNotEmpty(propertyDTOList)) {
                 for (PropertyDTO propertyDTO : propertyDTOList) {
                     if (SKIP_SIGN_UP_ENABLE_CHECK_KEY.equalsIgnoreCase(propertyDTO.getKey())) {
                         skipSelfSignUpEnabledCheck = Boolean.parseBoolean(propertyDTO.getValue());
+                    } else if (IdentityManagementEndpointConstants.TENANT_DOMAIN.equals(
+                            propertyDTO.getKey())) {
+                        tenantDomain = propertyDTO.getValue();
                     }
                 }
             }
-            UserSelfRegistrationManager userSelfRegistrationManager = Utils.getUserSelfRegistrationManager();
+            UserSelfRegistrationManager userSelfRegistrationManager = Utils
+                    .getUserSelfRegistrationManager();
             if (LOG.isDebugEnabled()) {
-                LOG.debug(String.format("Validating username for user %s", fullyQualifiedUsername));
+                LOG.debug(String.format("Validating username for user %s", user.getUsername()));
             }
             UsernameValidateInfoResponseDTO responseDTO = new UsernameValidateInfoResponseDTO();
 
@@ -83,34 +78,27 @@ public class ValidateUsernameApiServiceImpl extends ValidateUsernameApiService {
                         SelfRegistrationStatusCodes.ERROR_CODE_INVALID_TENANT));
                 responseDTO.setStatusCode(Integer.parseInt(SelfRegistrationStatusCodes.ERROR_CODE_INVALID_TENANT));
             } else if (!skipSelfSignUpEnabledCheck && !userSelfRegistrationManager.isSelfRegistrationEnabled(tenantDomain)) {
-                logDebug(String.format("Self registration is not enabled for tenant domain : %s . Hence returning " +
-                                "code %s", tenantDomain,
-                        SelfRegistrationStatusCodes.ERROR_CODE_SELF_REGISTRATION_DISABLED));
+                logDebug(String.format("Self registration is not enabled for tenant domain : %s . Hence returning code",
+                        tenantDomain, SelfRegistrationStatusCodes.ERROR_CODE_SELF_REGISTRATION_DISABLED));
                 responseDTO.setStatusCode(
                         Integer.parseInt(SelfRegistrationStatusCodes.ERROR_CODE_SELF_REGISTRATION_DISABLED));
-            } else if (userSelfRegistrationManager.isUsernameAlreadyTaken(fullyQualifiedUsername, tenantDomain)) {
+            } else if (userSelfRegistrationManager.isUsernameAlreadyTaken(user.getUsername(), tenantDomain)) {
                 logDebug(String.format("username : %s is an already taken. Hence returning code %s: ",
-                        fullyQualifiedUsername, SelfRegistrationStatusCodes.ERROR_CODE_USER_ALREADY_EXISTS));
+                        user.getUsername(), SelfRegistrationStatusCodes.ERROR_CODE_USER_ALREADY_EXISTS));
                 responseDTO.setStatusCode(Integer.parseInt(SelfRegistrationStatusCodes.ERROR_CODE_USER_ALREADY_EXISTS));
-            } else if (!userSelfRegistrationManager.isMatchUserNameRegex(tenantDomain, tenantAwareUsername)) {
+            } else if (!userSelfRegistrationManager.isMatchUserNameRegex(tenantDomain, user.getUsername())) {
                 logDebug(String.format("%s is an invalid user name. Hence returning code %s: ",
-                        fullyQualifiedUsername, SelfRegistrationStatusCodes.CODE_USER_NAME_INVALID));
+                        user.getUsername(), SelfRegistrationStatusCodes.CODE_USER_NAME_INVALID));
                 responseDTO.setStatusCode(Integer.parseInt(SelfRegistrationStatusCodes.CODE_USER_NAME_INVALID));
             } else {
-                logDebug(String.format("username : %s is available for self registration. Hence returning code %s: ",
-                        fullyQualifiedUsername, SelfRegistrationStatusCodes.CODE_USER_NAME_AVAILABLE));
+                logDebug(String.format("username : %s is avilable for self registration. Hence returning code %s: ",
+                        user.getUsername(), SelfRegistrationStatusCodes.CODE_USER_NAME_AVAILABLE));
                 responseDTO.setStatusCode(Integer.parseInt(SelfRegistrationStatusCodes.CODE_USER_NAME_AVAILABLE));
             }
             return Response.ok().entity(responseDTO).build();
         } catch (IdentityRecoveryException e) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Error while checking username validity for user " + fullyQualifiedUsername, e);
-            }
-            if (e instanceof IdentityRecoveryClientException) {
-                if (StringUtils.isNotBlank(e.getErrorDescription())) {
-                    return Response.status(Response.Status.BAD_REQUEST).entity(e.getErrorDescription()).build();
-                }
-                return Response.status(Response.Status.BAD_REQUEST).entity("Invalid Request").build();
+                LOG.debug("Error while checking username validity for user " + user.getUsername(), e);
             }
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Error while checking user " +
                     "existence").build();
@@ -122,51 +110,5 @@ public class ValidateUsernameApiServiceImpl extends ValidateUsernameApiService {
         if (LOG.isDebugEnabled()) {
             LOG.debug(message);
         }
-    }
-
-    /**
-     * Resolve the tenant domain.
-     *
-     * @param usernameValidationRequestDTO UsernameValidationRequestDTO object.
-     * @return Tenant domain.
-     * @throws IdentityRecoveryClientException If the tenant domain in the UsernameValidationRequestDTO is not same
-     *                                         as the tenant domain in the request.
-     */
-    private String resolveTenantDomain(UsernameValidationRequestDTO usernameValidationRequestDTO)
-            throws IdentityRecoveryClientException {
-
-        String tenantDomain;
-        String usernameInTheRequest = usernameValidationRequestDTO.getUsername();
-
-        // Added to maintain the backward compatibility.
-        if (!Boolean.parseBoolean(IdentityUtil.getProperty(IdentityRecoveryConstants.ENABLE_TENANT_QUALIFIED_URLS))) {
-            return MultitenantUtils.getTenantDomain(usernameInTheRequest);
-        }
-
-        String tenantDomainFromContext = (String) IdentityUtil.threadLocalProperties.get()
-                .get(Constants.TENANT_NAME_FROM_CONTEXT);
-        if (StringUtils.isNotBlank(tenantDomainFromContext)) {
-            tenantDomain = tenantDomainFromContext.toLowerCase();
-        } else {
-            tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
-        }
-        String tenantAwareUsernameInTheRequest = MultitenantUtils.getTenantAwareUsername(usernameInTheRequest);
-
-        /*
-        This means that the user has not specified a tenant domain in the username of the validation request.
-        Therefore, accept the tenant domain in the request url.
-         */
-        if (usernameInTheRequest.equals(tenantAwareUsernameInTheRequest)) {
-            return tenantDomain;
-        }
-        // Since the above condition is false, there is a tenant domain specified in the username of the request.
-        String tenantDomainInValidationRequest = MultitenantUtils.getTenantDomain(usernameInTheRequest);
-
-        // Tenant domain is specified and it is NOT EQUAL to the one specified in the request.
-        if (!tenantDomain.equals(tenantDomainInValidationRequest)) {
-            throw new IdentityRecoveryClientException(String.format("Tenant domain in the request: %s does not match " +
-                    "with the domain specified in the URL: %s", tenantDomainInValidationRequest, tenantDomain));
-        }
-        return tenantDomain;
     }
 }


### PR DESCRIPTION
Reverts wso2-extensions/identity-governance#441 due to test failures

```
org.wso2.identity.integration.test.consent.SelfSignUpConsentTest.testPurposesWithoutConfiguredPurposes
org.wso2.identity.integration.test.consent.SelfSignUpConsentTest.testWithPurposes
org.wso2.identity.integration.test.consent.SelfSignUpConsentTest.selfSignUpWithConsents
org.wso2.identity.integration.test.consent.SelfSignUpConsentTest.testForAnInvalidTenant
org.wso2.identity.integration.test.consent.SelfSignUpConsentTest.testForCrossTenantWithoutEnabling
```