### PR TITLE
Check if mobile verification is done by an admin and skip in such cases.

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
@@ -43,9 +43,9 @@ import org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.util.Utils;
 import org.wso2.carbon.user.core.UserCoreConstants;
-import org.wso2.carbon.user.core.UserStoreConfigConstants;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -287,13 +287,9 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
 
         String usernameFromContext = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
         String tenantDomainFromContext = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-        String userRealm = UserStoreConfigConstants.PRIMARY;
-        String[] strComponent = usernameFromContext.split("/");
-        if (usernameFromContext.split("/").length == 2) {
-            userRealm = strComponent[0];
-            usernameFromContext = strComponent[1];
-        }
-        User invokingUser = getUser(usernameFromContext, tenantDomainFromContext, userRealm);
+        String userDomain = UserCoreUtil.extractDomainFromName(usernameFromContext);
+        User invokingUser = getUser(UserCoreUtil.removeDomainFromName(usernameFromContext), tenantDomainFromContext,
+                userDomain);
         return user.equals(invokingUser);
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

Currently, the mobile verification on update feature sends an SMS OTP to the user in both scenarios where the user himself updates the mobile number, and where an admin user updates the user's mobile number. This PR modifies that behavior so that verification is not required when an admin user updates the mobile number on behalf of a user.
