### PR TITLE
Introduce new state for user when admin forced reset the user password

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityMgtConstants.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityMgtConstants.java
@@ -27,6 +27,16 @@ public class IdentityMgtConstants {
     public static final String ERROR_CODE_DELIMITER = "-";
 
     /**
+     * User account states.
+     */
+    public class AccountStates {
+
+        private AccountStates() {}
+
+        public static final String PENDING_ADMIN_FORCED_USER_PASSWORD_RESET = "PENDING_FUPR";
+    }
+
+    /**
      * Class that contains the error scenarios.
      */
     public static class Error_Scenario {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AdminForcedPasswordResetHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AdminForcedPasswordResetHandler.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.RecoveryScenarios;
@@ -33,11 +34,12 @@ import org.wso2.carbon.identity.recovery.RecoverySteps;
 import org.wso2.carbon.identity.recovery.model.UserRecoveryData;
 import org.wso2.carbon.identity.recovery.util.Utils;
 import org.wso2.carbon.registry.core.utils.UUIDGenerator;
+import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 
 import java.security.SecureRandom;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 
 public class AdminForcedPasswordResetHandler extends UserEmailVerificationHandler {
 
@@ -126,7 +128,7 @@ public class AdminForcedPasswordResetHandler extends UserEmailVerificationHandle
                 claims.remove(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM);
             }
             setRecoveryData(user, recoveryScenario, RecoverySteps.UPDATE_PASSWORD, OTP);
-            lockAccount(user, userStoreManager);
+            lockAccountOnAdminPasswordReset(user, userStoreManager);
 
             if (adminPasswordResetOTP | adminPasswordResetRecoveryLink) {
                 try {
@@ -192,6 +194,29 @@ public class AdminForcedPasswordResetHandler extends UserEmailVerificationHandle
         }
     }
 
+    private void lockAccountOnAdminPasswordReset(User user, UserStoreManager userStoreManager)
+            throws IdentityEventException {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Locking user account on admin forced password reset: " + user.getUserName());
+        }
+        HashMap<String, String> userClaims = new HashMap<>();
+        userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
+        userClaims.put(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI,
+                IdentityMgtConstants.AccountStates.PENDING_ADMIN_FORCED_USER_PASSWORD_RESET);
+        setUserClaims(userClaims, user, userStoreManager);
+    }
+
+    protected void setUserClaims(Map<String, String> userClaims, User user, UserStoreManager userStoreManager)
+            throws IdentityEventException {
+
+        try {
+            userStoreManager.setUserClaimValues(user.getUserName(), userClaims, null);
+        } catch (UserStoreException e) {
+            throw new IdentityEventException("Error while setting user claim value :" + user.getUserName(), e);
+        }
+    }
+
     @Override
     public String getName() {
         return "adminForcedPasswordReset";
@@ -216,5 +241,4 @@ public class AdminForcedPasswordResetHandler extends UserEmailVerificationHandle
         }
         return sb.toString();
     }
-
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -512,13 +512,6 @@ public class NotificationPasswordRecoveryManager {
             throws IdentityEventException {
 
         HashMap<String, String> userClaims = new HashMap<>();
-
-        // If the scenario is initiated by the admin, set the account locked claim to TRUE.
-        if (RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_EMAIL_LINK.equals(userRecoveryData.getRecoveryScenario())
-                || RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_OTP.
-                equals(userRecoveryData.getRecoveryScenario())) {
-            userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.FALSE.toString());
-        }
         // If notifications are internally managed we try to set the verified claims since this is an opportunity
         // to verify a user channel.
         if (isNotificationInternallyManaged) {
@@ -540,6 +533,13 @@ public class NotificationPasswordRecoveryManager {
                 userClaims.put(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI,
                         IdentityRecoveryConstants.ACCOUNT_STATE_UNLOCKED);
             }
+        }
+        // If the scenario is initiated by the admin, set the account locked claim to TRUE.
+        if (RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_EMAIL_LINK.equals(userRecoveryData.getRecoveryScenario())
+                || RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_OTP.
+                equals(userRecoveryData.getRecoveryScenario())) {
+            userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.FALSE.toString());
+            userClaims.remove(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI);
         }
         return userClaims;
     }


### PR DESCRIPTION
### Proposed changes in this pull request
> Public fix for https://github.com/wso2/product-is/issues/9708
> A new state called `PENDING_FUPR` is introduced as a intermediary state during the admin forced user password reset flow.

### Depends on PR
> https://github.com/wso2/carbon-identity-framework/pull/3197