### PR TITLE
Fix incorrect error response returned for export user information by ID

### DIFF
--- a/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/PiInfoApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/PiInfoApiServiceImpl.java
@@ -59,12 +59,12 @@ public class PiInfoApiServiceImpl extends PiInfoApiService {
                     .entity(e.getMessage())
                     .build();
         }
-        Map userAttributes;
+        Map userAttributes = null;
         try {
             userAttributes = Utils.getUserInformationService().getRetainedUserInformation(username, userStoreDomain,
                     tenantId);
         } catch (UserExportException e) {
-            return Response.serverError().entity(e.getMessage()).build();
+            Utils.handleNotFound(e.getMessage(), String.valueOf(Response.Status.NOT_FOUND.getStatusCode()));
         }
         return Response.ok().status(Response.Status.OK).entity(userAttributes).build();
     }


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/9794

### Proposed changes in this pull request
With this PR if invalid input (e.g: a value that is not base64 URL encoded) is passed for [1] it will return 404 user not found as the response. Previously this was returning 500 with no error logs in the console.

Sample request:
`curl -X GET -H "Authorization: Basic YWRtaW5Ad3NvMi5jb206YWRtaW4=" -H "Content-Type: application/json"  "https://localhost:9443/t/wso2.com/api/identity/user/v1.0/pi-info/43a4d796-6ea8-421a-a6f7-8b07a2534ee1" `

Response:
{
   "code" : "404",
   "description" : "Error while retrieving the user information.",
   "message" : "Not Found"
}

[1] https://docs.wso2.com/display/IS510/apidocs/self-registration/#!/operations#UserExport#getUserById

