### PR TITLE
Captcha support for custom authenticators that has auth mechanism set as 'basic'

### DIFF
--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaConstants.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaConstants.java
@@ -45,6 +45,10 @@ public class CaptchaConstants {
 
     public static final String RE_CAPTCHA_FAILED_REDIRECT_URLS = "recaptcha.failed.redirect.urls";
 
+    public static final String BASIC_AUTHENTICATOR = "BasicAuthenticator";
+
+    public static final String BASIC_AUTH_MECHANISM = "basic";
+
     public static final class ReCaptchaConnectorPropertySuffixes {
 
         public static final String ENABLE = ".enable";

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaUtil.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaUtil.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.captcha.util;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
@@ -36,6 +37,8 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.User;
@@ -473,11 +476,16 @@ public class CaptchaUtil {
                                                              String currentAuthenticatorName) {
 
         int currentStep = authenticationContext.getCurrentStep();
-        List<AuthenticatorConfig> authenticatorList = authenticationContext.getSequenceConfig().getStepMap()
-                .get(currentStep).getAuthenticatorList();
-        for (AuthenticatorConfig authenticatorConfig : authenticatorList) {
-            if (authenticatorConfig.getName().equals(currentAuthenticatorName)) {
-                return authenticatorConfig.getApplicationAuthenticator();
+        SequenceConfig sequenceConfig = authenticationContext.getSequenceConfig();
+        if (sequenceConfig != null) {
+            Map<Integer, StepConfig> stepConfigMap = sequenceConfig.getStepMap();
+            if (MapUtils.isNotEmpty(stepConfigMap) && stepConfigMap.containsKey(currentStep)) {
+                List<AuthenticatorConfig> authenticatorList = stepConfigMap.get(currentStep).getAuthenticatorList();
+                for (AuthenticatorConfig authenticatorConfig : authenticatorList) {
+                    if (authenticatorConfig.getName().equals(currentAuthenticatorName)) {
+                        return authenticatorConfig.getApplicationAuthenticator();
+                    }
+                }
             }
         }
         return null;

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/validator/FailLoginAttemptValidationHandler.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/validator/FailLoginAttemptValidationHandler.java
@@ -39,6 +39,8 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.util.Map;
 
+import static org.wso2.carbon.identity.captcha.util.CaptchaUtil.isValidAuthenticator;
+
 /**
  * Validate no of failed login attempts against the no configured and engage captcha
  */
@@ -94,8 +96,9 @@ public class FailLoginAttemptValidationHandler extends AbstractEventHandler {
         if (StringUtils.isBlank(currentAuthenticator) && MapUtils.isNotEmpty(map)) {
             currentAuthenticator = (String) map.get(FrameworkConstants.AUTHENTICATOR);
         }
-        if ("BasicAuthenticator".equals(currentAuthenticator) && MapUtils.isNotEmpty(map) && map.get
-                (FrameworkConstants.AnalyticsAttributes.USER) != null) {
+        if (("BasicAuthenticator".equals(currentAuthenticator) ||
+                isValidAuthenticator(authenticationContext, currentAuthenticator)) &&
+                MapUtils.isNotEmpty(map) && map.get(FrameworkConstants.AnalyticsAttributes.USER) != null) {
 
             if (map.get(FrameworkConstants.AnalyticsAttributes.USER) instanceof User) {
                 User failedUser = (User) map.get(FrameworkConstants.AnalyticsAttributes.USER);

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/validator/FailLoginAttemptValidator.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/validator/FailLoginAttemptValidator.java
@@ -39,6 +39,9 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
+import static org.wso2.carbon.identity.captcha.util.CaptchaConstants.BASIC_AUTHENTICATOR;
+import static org.wso2.carbon.identity.captcha.util.CaptchaUtil.isValidAuthenticator;
+
 /**
  * FailLoginAttemptValidator is changed to act as an event handler for its' subscribed event in
  * {@link FailLoginAttemptValidationHandler} with this release.
@@ -79,7 +82,8 @@ public class FailLoginAttemptValidator extends AbstractIdentityMessageHandler im
         if (StringUtils.isBlank(currentAuthenticator) && MapUtils.isNotEmpty(map)) {
             currentAuthenticator = (String) map.get(FrameworkConstants.AUTHENTICATOR);
         }
-        if ("BasicAuthenticator".equals(currentAuthenticator) && map != null && map.get
+        if ((BASIC_AUTHENTICATOR.equals(currentAuthenticator) ||
+                isValidAuthenticator(authenticationContext, currentAuthenticator)) && map != null && map.get
                 (FrameworkConstants.AnalyticsAttributes.USER) != null) {
 
             if (map.get(FrameworkConstants.AnalyticsAttributes.USER) instanceof User) {


### PR DESCRIPTION
### Proposed changes in this pull request

This resolves the issue of re-captcha not appearing after maximum allowed attempts during SSO when using a custom authenticator.

For a custom authenticator to obtain support for re-captcha verification after max failed attempts are reached, the following configuration should be added to <CARBON_HOME>/repository/conf/deployment.toml file and set `AuthMechanism` of the custom authenticator to `basic`.

```
[[authentication.custom_authenticator]]
name = "SampleCustomAuthenticatorName"
[authentication.custom_authenticator.parameters]
AuthMechanism = "basic"
```

Resolves : https://github.com/wso2/product-is/issues/9975