### PR TITLE
Skip email/mobile verification if verifyEmail/verifyMobile claim is not available when updationg the claim for the first time

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -502,7 +502,7 @@ public class IdentityRecoveryConstants {
                 "EnableVerification";
         public static final String MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME = "UserClaimUpdate.MobileNumber." +
                 "VerificationCode.ExpiryTime";
-        public static final String CHECK_FOR_VERIFY_CLAIM_ON_ADDITION = "UserClaimUpdate.CheckForVerifyClaimOnAddition";
+        public static final String CHECK_FOR_VERIFY_CLAIM_ON_UPDATE = "UserClaimUpdate.CheckForVerifyClaimOnUpdate";
         public static final String ASK_PASSWORD_EXPIRY_TIME = "EmailVerification.AskPassword.ExpiryTime";
         public static final String ASK_PASSWORD_TEMP_PASSWORD_GENERATOR = "EmailVerification.AskPassword.PasswordGenerator";
         public static final String EMAIL_ACCOUNT_LOCK_ON_CREATION = "EmailVerification.LockOnCreation";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -502,7 +502,7 @@ public class IdentityRecoveryConstants {
                 "EnableVerification";
         public static final String MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME = "UserClaimUpdate.MobileNumber." +
                 "VerificationCode.ExpiryTime";
-        public static final String CHECK_FOR_VERIFY_CLAIM_ON_UPDATE = "UserClaimUpdate.CheckForVerifyClaimOnUpdate";
+        public static final String USE_VERIFY_CLAIM_ON_UPDATE = "UserClaimUpdate.UseVerifyClaim";
         public static final String ASK_PASSWORD_EXPIRY_TIME = "EmailVerification.AskPassword.ExpiryTime";
         public static final String ASK_PASSWORD_TEMP_PASSWORD_GENERATOR = "EmailVerification.AskPassword.PasswordGenerator";
         public static final String EMAIL_ACCOUNT_LOCK_ON_CREATION = "EmailVerification.LockOnCreation";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -82,6 +82,7 @@ public class IdentityRecoveryConstants {
     // Notification channel claims.
     public static final String VERIFY_EMAIL_CLIAM = "http://wso2.org/claims/identity/verifyEmail";
     public static final String EMAIL_VERIFIED_CLAIM = "http://wso2.org/claims/identity/emailVerified";
+    public static final String VERIFY_MOBILE_CLAIM = "http://wso2.org/claims/identity/verifyMobile";
     public static final String EMAIL_ADDRESS_PENDING_VALUE_CLAIM =
             "http://wso2.org/claims/identity/emailaddress.pendingValue";
     public static final String MOBILE_NUMBER_PENDING_VALUE_CLAIM =

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -502,6 +502,7 @@ public class IdentityRecoveryConstants {
                 "EnableVerification";
         public static final String MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME = "UserClaimUpdate.MobileNumber." +
                 "VerificationCode.ExpiryTime";
+        public static final String CHECK_FOR_VERIFY_CLAIM_ON_ADDITION = "UserClaimUpdate.CheckForVerifyClaimOnAddition";
         public static final String ASK_PASSWORD_EXPIRY_TIME = "EmailVerification.AskPassword.ExpiryTime";
         public static final String ASK_PASSWORD_TEMP_PASSWORD_GENERATOR = "EmailVerification.AskPassword.PasswordGenerator";
         public static final String EMAIL_ACCOUNT_LOCK_ON_CREATION = "EmailVerification.LockOnCreation";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
@@ -118,7 +118,11 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
     @Override
     public int getPriority(MessageContext messageContext) {
 
-        return 50;
+        int priority = super.getPriority(messageContext);
+        if (priority == -1) {
+            return 50;
+        }
+        return priority;
     }
 
     /**
@@ -271,11 +275,11 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
                 return;
             }
             /*
-            When 'CheckForVerifyClaimOnUpdate' is enabled, the verification should happen only if the 'verifyMobile'
-            temporary claim exists as 'true' in the claim list.
-            If 'CheckForVerifyClaimOnUpdate' is disabled, no need to check for 'verifyMobile' claim.
+            When 'UseVerifyClaim' is enabled, the verification should happen only if the 'verifyMobile'
+            temporary claim exists as 'true' in the claim list. If 'UseVerifyClaim' is disabled, no need to
+            check for 'verifyMobile' claim.
              */
-            if (Utils.isCheckForVerifyClaimOnUpdateEnabled() && !isVerifyMobileClaimAvailable(claims)) {
+            if (Utils.isUseVerifyClaimEnabled() && !isVerifyMobileClaimAvailable(claims)) {
                 Utils.setThreadLocalToSkipSendingSmsOtpVerificationOnUpdate(IdentityRecoveryConstants
                         .SkipMobileNumberVerificationOnUpdateStates.SKIP_ON_INAPPLICABLE_CLAIMS.toString());
                 invalidatePendingMobileVerification(user, userStoreManager, claims);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
@@ -106,6 +106,7 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
 
         if (IdentityEventConstants.Event.POST_SET_USER_CLAIMS.equals(eventName)) {
             postSetUserClaimOnMobileNumberUpdate(user, userStoreManager);
+            claims.remove(IdentityRecoveryConstants.VERIFY_MOBILE_CLAIM);
         }
     }
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -403,17 +403,15 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
                 return;
             }
             /*
-            When 'CheckForVerifyClaimOnAddition' is enabled, the verification should happen only if the 'verifyEmail'
-            temporary claim exists as 'true' in the claim list during a first time email address claim update.
-            If 'CheckForVerifyClaimOnAddition' is disabled, no need to check for 'verifyEmail' claim.
+            When 'CheckForVerifyClaimOnUpdate' is enabled, the verification should happen only if the 'verifyEmail'
+            temporary claim exists as 'true' in the claim list.
+            If 'CheckForVerifyClaimOnUpdate' is disabled, no need to check for 'verifyEmail' claim.
              */
-            if (StringUtils.isBlank(existingEmail) && Utils.isCheckForVerifyClaimOnAdditionEnabled()) {
-                if (!isVerifyEmailClaimAvailable(claims)) {
-                    Utils.setThreadLocalToSkipSendingEmailVerificationOnUpdate(IdentityRecoveryConstants
-                            .SkipEmailVerificationOnUpdateStates.SKIP_ON_INAPPLICABLE_CLAIMS.toString());
-                    invalidatePendingEmailVerification(user, userStoreManager, claims);
-                    return;
-                }
+            if (Utils.isCheckForVerifyClaimOnUpdateEnabled() && !isVerifyEmailClaimAvailable(claims)) {
+                Utils.setThreadLocalToSkipSendingEmailVerificationOnUpdate(IdentityRecoveryConstants
+                        .SkipEmailVerificationOnUpdateStates.SKIP_ON_INAPPLICABLE_CLAIMS.toString());
+                invalidatePendingEmailVerification(user, userStoreManager, claims);
+                return;
             }
             claims.put(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM, emailAddress);
             claims.remove(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -184,7 +184,7 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
 
         if (IdentityEventConstants.Event.POST_SET_USER_CLAIMS.equals(eventName)) {
             postSetUserClaimsOnEmailUpdate(user, userStoreManager);
-            claims.remove(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM);
+            claims.remove(IdentityRecoveryConstants.VERIFY_EMAIL_CLIAM);
         }
     }
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -184,6 +184,7 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
 
         if (IdentityEventConstants.Event.POST_SET_USER_CLAIMS.equals(eventName)) {
             postSetUserClaimsOnEmailUpdate(user, userStoreManager);
+            claims.remove(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM);
         }
     }
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -403,11 +403,11 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
                 return;
             }
             /*
-            When 'CheckForVerifyClaimOnUpdate' is enabled, the verification should happen only if the 'verifyEmail'
-            temporary claim exists as 'true' in the claim list.
-            If 'CheckForVerifyClaimOnUpdate' is disabled, no need to check for 'verifyEmail' claim.
+            When 'UseVerifyClaim' is enabled, the verification should happen only if the 'verifyEmail' temporary
+            claim exists as 'true' in the claim list. If 'UseVerifyClaim' is disabled, no need to check for
+            'verifyEmail' claim.
              */
-            if (Utils.isCheckForVerifyClaimOnUpdateEnabled() && !isVerifyEmailClaimAvailable(claims)) {
+            if (Utils.isUseVerifyClaimEnabled() && !isVerifyEmailClaimAvailable(claims)) {
                 Utils.setThreadLocalToSkipSendingEmailVerificationOnUpdate(IdentityRecoveryConstants
                         .SkipEmailVerificationOnUpdateStates.SKIP_ON_INAPPLICABLE_CLAIMS.toString());
                 invalidatePendingEmailVerification(user, userStoreManager, claims);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1113,15 +1113,15 @@ public class Utils {
     /**
      * When updating email/mobile claim value, sending the verification notification can be controlled by sending
      * an additional temporary claim ('verifyEmail'/'verifyMobile') along with the update request.
-     * This option can be enabled form identity.xml by setting 'CheckForVerifyClaimOnUpdate' to true.
-     * When this option is enabled, email/mobile verification notification on a claim update will be triggered based
-     * on the 'verifyEmail'/'verifyMobile' temporary claim sent along with the update request.
+     * This option can be enabled form identity.xml by setting 'UseVerifyClaim' to true. When this option is enabled,
+     * email/mobile verification notification on a claim update will be triggered based on the
+     * 'verifyEmail'/'verifyMobile' temporary claim sent along with the update request.
      *
-     * @return True if 'CheckForVerifyClaimOnUpdate' config is set to true, false otherwise.
+     * @return True if 'UseVerifyClaim' config is set to true, false otherwise.
      */
-    public static boolean isCheckForVerifyClaimOnUpdateEnabled() {
+    public static boolean isUseVerifyClaimEnabled() {
 
         return Boolean.parseBoolean(IdentityUtil.getProperty
-                (IdentityRecoveryConstants.ConnectorConfig.CHECK_FOR_VERIFY_CLAIM_ON_UPDATE));
+                (IdentityRecoveryConstants.ConnectorConfig.USE_VERIFY_CLAIM_ON_UPDATE));
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -77,8 +77,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AUDIT_MESSAGE;
-
 /**
  * Class which contains the Utils for user recovery.
  */
@@ -1113,17 +1111,17 @@ public class Utils {
     }
 
     /**
-     * When adding a new email/mobile claim value instead of updating an exiting value, the verification notification
-     * can be controlled by sending an additional temporary claim ('verifyEmail'/'verifyMobile') along with the update
-     * request. This option can be enabled form identity.xml by setting 'CheckForVerifyClaimOnAddition' to true.
-     * When this option is enabled, email/mobile verification notification on a new addition will be triggered based on
-     * the 'verifyEmail'/'verifyMobile' temporary claim sent along with the update request.
+     * When updating email/mobile claim value, sending the verification notification can be controlled by sending
+     * an additional temporary claim ('verifyEmail'/'verifyMobile') along with the update request.
+     * This option can be enabled form identity.xml by setting 'CheckForVerifyClaimOnUpdate' to true.
+     * When this option is enabled, email/mobile verification notification on a claim update will be triggered based
+     * on the 'verifyEmail'/'verifyMobile' temporary claim sent along with the update request.
      *
-     * @return True if 'CheckForVerifyClaimOnAddition' config is set to true, false otherwise.
+     * @return True if 'CheckForVerifyClaimOnUpdate' config is set to true, false otherwise.
      */
-    public static boolean isCheckForVerifyClaimOnAdditionEnabled() {
+    public static boolean isCheckForVerifyClaimOnUpdateEnabled() {
 
         return Boolean.parseBoolean(IdentityUtil.getProperty
-                (IdentityRecoveryConstants.ConnectorConfig.CHECK_FOR_VERIFY_CLAIM_ON_ADDITION));
+                (IdentityRecoveryConstants.ConnectorConfig.CHECK_FOR_VERIFY_CLAIM_ON_UPDATE));
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1111,4 +1111,19 @@ public class Utils {
         }
         return sb.toString();
     }
+
+    /**
+     * When adding a new email/mobile claim value instead of updating an exiting value, the verification notification
+     * can be controlled by sending an additional temporary claim ('verifyEmail'/'verifyMobile') along with the update
+     * request. This option can be enabled form identity.xml by setting 'CheckForVerifyClaimOnAddition' to true.
+     * When this option is enabled, email/mobile verification notification on a new addition will be triggered based on
+     * the 'verifyEmail'/'verifyMobile' temporary claim sent along with the update request.
+     *
+     * @return True if 'CheckForVerifyClaimOnAddition' config is set to true, false otherwise.
+     */
+    public static boolean isCheckForVerifyClaimOnAdditionEnabled() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty
+                (IdentityRecoveryConstants.ConnectorConfig.CHECK_FOR_VERIFY_CLAIM_ON_ADDITION));
+    }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

This PR fixes the issue of Email/SMS OTP flows breaking when email/mobile verification is enabled, and a user without email/mobile claim tries to authenticate using email/SMS OTP flows.
Resolves : https://github.com/wso2/product-is/issues/10358

With this modification, 
- Sending the email verification email is skipped when updating the email for the first time if 'verifyEmail' claim(set to true) is not sent with the update request. 
- Sending the mobile verification SMS OTP is skipped when updating the mobile number for the first time if 'verifyMobilel' claim(set to true) is not sent with the update request. 

