### PR TITLE
Password recovery no email fix

### DIFF
--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/main/java/org/wso2/carbon/identity/recovery/endpoint/Constants.java
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/main/java/org/wso2/carbon/identity/recovery/endpoint/Constants.java
@@ -36,5 +36,6 @@ public final class Constants {
 
     public static final String ERROR_MESSAGE_EMAIL_NOT_FOUND =
             "Email notification sending failed. Sending email address is not configured for the user.";
+    public static final String ERROR_CODE_EMAIL_NOT_FOUND = "20016";
 
 }

--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
@@ -81,6 +81,12 @@ public class RecoverPasswordApiServiceImpl extends RecoverPasswordApiService {
         } catch (IdentityRecoveryException e) {
             RecoveryUtil.handleInternalServerError(Constants.SERVER_ERROR, e.getErrorCode(), LOG, e);
         } catch (Throwable throwable) {
+            if (throwable != null && StringUtils.equals(Constants.ERROR_MESSAGE_EMAIL_NOT_FOUND,
+                    throwable.getMessage())) {
+                String msg = "You have not set the users email address. Please set the email address and reset again.";
+                LOG.error(msg);
+                RecoveryUtil.handleBadRequest(msg, Constants.ERROR_CODE_EMAIL_NOT_FOUND);
+            }
             RecoveryUtil.handleInternalServerError(Constants.SERVER_ERROR, IdentityRecoveryConstants
                     .ErrorMessages.ERROR_CODE_UNEXPECTED.getCode(), LOG, throwable);
         }

--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
@@ -83,7 +83,7 @@ public class RecoverPasswordApiServiceImpl extends RecoverPasswordApiService {
         } catch (Throwable throwable) {
             if (throwable != null && StringUtils.equals(Constants.ERROR_MESSAGE_EMAIL_NOT_FOUND,
                     throwable.getMessage())) {
-                LOG.error(throwable);
+                LOG.error(throwable.getMessage(), throwable);
                 RecoveryUtil.handleBadRequest(throwable.getMessage(), Constants.ERROR_CODE_EMAIL_NOT_FOUND);
             }
             RecoveryUtil.handleInternalServerError(Constants.SERVER_ERROR, IdentityRecoveryConstants

--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
@@ -83,9 +83,8 @@ public class RecoverPasswordApiServiceImpl extends RecoverPasswordApiService {
         } catch (Throwable throwable) {
             if (throwable != null && StringUtils.equals(Constants.ERROR_MESSAGE_EMAIL_NOT_FOUND,
                     throwable.getMessage())) {
-                String msg = "You have not set the users email address. Please set the email address and reset again.";
-                LOG.error(msg);
-                RecoveryUtil.handleBadRequest(msg, Constants.ERROR_CODE_EMAIL_NOT_FOUND);
+                LOG.error(throwable);
+                RecoveryUtil.handleBadRequest(throwable.getMessage(), Constants.ERROR_CODE_EMAIL_NOT_FOUND);
             }
             RecoveryUtil.handleInternalServerError(Constants.SERVER_ERROR, IdentityRecoveryConstants
                     .ErrorMessages.ERROR_CODE_UNEXPECTED.getCode(), LOG, throwable);


### PR DESCRIPTION
### Proposed changes in this pull request
Removed Internal server error during the password recovery when user does not have an email and added a meaningful error
Fixes - https://github.com/wso2/product-is/issues/9587

