### PR TITLE
Use default tenant-wide properties for security-question-based password recovery flow, if the config store is not configured.

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -74,6 +74,10 @@ public class IdentityRecoveryConstants {
     public static final String FUNCTION_LOCKOUT_TIME_PROPERTY = "LockoutTime";
     public static final String FUNCTION_LOGIN_FAIL_TIMEOUT_RATIO_PROPERTY = "TimeoutRatio";
 
+    public static final String MAX_ATTEMPTS_DEFAULT = "5";
+    public static final String LOCKOUT_TIME_DEFAULT = "5";
+    public static final String LOGIN_FAIL_TIMEOUT_RATIO_DEFAULT = "2";
+
     public static final String USER_NEW_CHALLENGE_ANSWERS = "userNewChallengeAnswers";
     public static final String USER_OLD_CHALLENGE_ANSWERS = "userOldChallengeAnswers";
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/ConfigStoreFunctionalityLockPropertyHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/ConfigStoreFunctionalityLockPropertyHandler.java
@@ -28,7 +28,6 @@ import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationMa
 import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
-import org.wso2.carbon.identity.recovery.IdentityRecoveryServerException;
 import org.wso2.carbon.identity.recovery.handler.function.ResourceToProperties;
 import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
 import org.wso2.carbon.identity.recovery.util.Utils;
@@ -69,7 +68,9 @@ public class ConfigStoreFunctionalityLockPropertyHandler {
                                             functionalityIdentifier);
                     properties = new ResourceToProperties().apply(resource);
                 } else {
-                    log.trace("User Functionality properties are not configured. Resorting to default values.");
+                    if (log.isDebugEnabled()) {
+                        log.debug("User Functionality properties are not configured. Resorting to default values.");
+                    }
                     return getDefaultConfigurationPropertiesMap();
                 }
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/ConfigStoreFunctionalityLockPropertyHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/ConfigStoreFunctionalityLockPropertyHandler.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.recovery.handler.function.ResourceToProperties;
 import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
 import org.wso2.carbon.identity.recovery.util.Utils;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -68,7 +69,8 @@ public class ConfigStoreFunctionalityLockPropertyHandler {
                                             functionalityIdentifier);
                     properties = new ResourceToProperties().apply(resource);
                 } else {
-                    throw new UnsupportedOperationException("User Functionality properties are not configured.");
+                    log.trace("User Functionality properties are not configured. Resorting to default values.");
+                    return getDefaultConfigurationPropertiesMap();
                 }
 
             } catch (ConfigurationManagementException e) {
@@ -87,6 +89,18 @@ public class ConfigStoreFunctionalityLockPropertyHandler {
         } finally {
             FrameworkUtils.endTenantFlow();
         }
+        return properties;
+    }
+
+    private Map<String, String> getDefaultConfigurationPropertiesMap() {
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(IdentityRecoveryConstants.FUNCTION_MAX_ATTEMPTS_PROPERTY,
+                IdentityRecoveryConstants.MAX_ATTEMPTS_DEFAULT);
+        properties.put(IdentityRecoveryConstants.FUNCTION_LOCKOUT_TIME_PROPERTY,
+                IdentityRecoveryConstants.LOCKOUT_TIME_DEFAULT);
+        properties.put(IdentityRecoveryConstants.FUNCTION_LOGIN_FAIL_TIMEOUT_RATIO_PROPERTY,
+                IdentityRecoveryConstants.LOGIN_FAIL_TIMEOUT_RATIO_DEFAULT);
         return properties;
     }
 


### PR DESCRIPTION


### Proposed changes in this pull request

Update the ConfigStoreFunctionalityLockPropertyHandler to use a set of default tenant-wide property values in case the properties are not available in the config store.

Fixes https://github.com/wso2/product-is/issues/9662.

### When should this PR be merged

ASAP