### PR TITLE
[Improvement] Enable user account confirmation when the user account is not locked

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -480,6 +480,7 @@ public class IdentityRecoveryConstants {
         public static final String RECOVERY_CALLBACK_REGEX = "Recovery.CallbackRegex";
         public static final String ENABLE_SELF_SIGNUP = "SelfRegistration.Enable";
         public static final String ACCOUNT_LOCK_ON_CREATION = "SelfRegistration.LockOnCreation";
+        public static final String SEND_CONFIRMATION_NOTIFICATION = "SelfRegistration.SendConfirmationOnCreation";
         public static final String SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE = "SelfRegistration.Notification" +
                 ".InternallyManage";
         public static final String SELF_REGISTRATION_RE_CAPTCHA = "SelfRegistration.ReCaptcha";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
@@ -75,6 +75,8 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP, "User self registration");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION,
                 "Lock user account on creation");
+        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION,
+                "Enable Account Confirmation On Creation");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
                 "Manage notifications sending internally");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA, "Prompt reCaptcha");
@@ -104,6 +106,8 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
                 "Allow user's to self register to the system.");
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION,
                 "Lock self registered user account until e-mail verification.");
+        descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION,
+                "Enable user account confirmation when the user account is not locked on creation");
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
                 "Disable if the client application handles notification sending");
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA,
@@ -134,6 +138,7 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
         List<String> properties = new ArrayList<>();
         properties.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION);
+        properties.add(IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME);
@@ -153,6 +158,7 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
 
         String enableSelfSignUp = "false";
         String enableAccountLockOnCreation = "true";
+        String enableSendNotificationOnCreation = "false";
         String enableNotificationInternallyManage = "true";
         String enableSelfRegistrationReCaptcha = "true";
         String verificationCodeExpiryTime = "1440";
@@ -167,6 +173,8 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
                 IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP);
         String accountLockProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION);
+        String SendNotificationOnCreationProperty = IdentityUtil.getProperty(
+                IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION);
         String notificationInternallyMangedProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE);
         String reCaptchaProperty = IdentityUtil.getProperty(
@@ -191,6 +199,9 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
         }
         if (StringUtils.isNotEmpty(accountLockProperty)) {
             enableAccountLockOnCreation = accountLockProperty;
+        }
+        if (StringUtils.isNotEmpty(SendNotificationOnCreationProperty)) {
+            enableSendNotificationOnCreation = SendNotificationOnCreationProperty;
         }
         if (StringUtils.isNotEmpty(notificationInternallyMangedProperty)) {
             enableNotificationInternallyManage = notificationInternallyMangedProperty;
@@ -224,6 +235,8 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP, enableSelfSignUp);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION,
                 enableAccountLockOnCreation);
+        defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION,
+                enableSendNotificationOnCreation);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
                 enableNotificationInternallyManage);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA,

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
@@ -133,7 +133,7 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
                     return;
                 }
                 // If notifications are externally managed, no send notifications.
-                if ((isAccountLockOnCreation || isEnableConfirmationOnCreation) && isNotificationInternallyManage ){
+                if ((isAccountLockOnCreation || isEnableConfirmationOnCreation) && isNotificationInternallyManage) {
                     userRecoveryDataStore.invalidate(user);
 
                     // Create a secret key based on the preferred notification channel.
@@ -156,7 +156,7 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
             if (isAccountLockOnCreation || isEnableConfirmationOnCreation) {
                 HashMap<String, String> userClaims = new HashMap<>();
                 if (isAccountLockOnCreation) {
-                    //Need to lock user account
+                    // Need to lock user account.
                     userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
                     userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_REASON_CLAIM,
                             IdentityMgtConstants.LockedReason.PENDING_SELF_REGISTRATION.toString());

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
@@ -111,6 +111,9 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
         boolean isAccountLockOnCreation = Boolean.parseBoolean(Utils.getConnectorConfig
                 (IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION, user.getTenantDomain()));
 
+        boolean isEnableConfirmationOnCreation = Boolean.parseBoolean(Utils.getConnectorConfig
+                (IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION, user.getTenantDomain()));
+
         boolean isNotificationInternallyManage = Boolean.parseBoolean(Utils.getConnectorConfig
                 (IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE, user.getTenantDomain()));
 
@@ -130,7 +133,7 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
                     return;
                 }
                 // If notifications are externally managed, no send notifications.
-                if (isNotificationInternallyManage && isAccountLockOnCreation) {
+                if ((isAccountLockOnCreation || isEnableConfirmationOnCreation) && isNotificationInternallyManage ){
                     userRecoveryDataStore.invalidate(user);
 
                     // Create a secret key based on the preferred notification channel.
@@ -150,20 +153,27 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
             } catch (IdentityRecoveryException e) {
                 throw new IdentityEventException("Error while sending self sign up notification ", e);
             }
-            if (isAccountLockOnCreation) {
+            if (isAccountLockOnCreation || isEnableConfirmationOnCreation) {
                 HashMap<String, String> userClaims = new HashMap<>();
-                //Need to lock user account
-                userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
-                userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_REASON_CLAIM,
-                        IdentityMgtConstants.LockedReason.PENDING_SELF_REGISTRATION.toString());
+                if (isAccountLockOnCreation) {
+                    //Need to lock user account
+                    userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
+                    userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_REASON_CLAIM,
+                            IdentityMgtConstants.LockedReason.PENDING_SELF_REGISTRATION.toString());
+                }
                 if (Utils.isAccountStateClaimExisting(tenantDomain)) {
                     userClaims.put(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI,
                             IdentityRecoveryConstants.PENDING_SELF_REGISTRATION);
                 }
                 try {
-                    userStoreManager.setUserClaimValues(user.getUserName() , userClaims, null);
+                    userStoreManager.setUserClaimValues(user.getUserName(), userClaims, null);
                     if (log.isDebugEnabled()) {
-                        log.debug("Locked user account: " + user.getUserName());
+                        if (isAccountLockOnCreation) {
+                            log.debug("Locked user account: " + user.getUserName());
+                        }
+                        if (isEnableConfirmationOnCreation) {
+                            log.debug("Send verification notification for user account: " + user.getUserName());
+                        }
                     }
                 } catch (UserStoreException e) {
                     throw new IdentityEventException("Error while lock user account :" + user.getUserName(), e);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -904,6 +904,11 @@ public class UserSelfRegistrationManager {
 
         // Set the verified claims to TRUE.
         setVerificationClaims(user, verificationChannel, externallyVerifiedChannelClaim, recoveryScenario, userClaims);
+
+        // Set accountState claim UNLOCK.
+        userClaims.put(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI,
+                IdentityRecoveryConstants.ACCOUNT_STATE_UNLOCKED);
+
         //Set account verified time claim.
         userClaims.put(IdentityRecoveryConstants.ACCOUNT_CONFIRMED_TIME_CLAIM, Instant.now().toString());
         return userClaims;

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImplTest.java
@@ -94,6 +94,8 @@ public class SelfRegistrationConfigImplTest {
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP, "User self registration");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION,
                 "Lock user account on creation");
+        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION,
+                "Enable Account Confirmation On Creation");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
                 "Manage notifications sending internally");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA, "Prompt reCaptcha");
@@ -125,6 +127,8 @@ public class SelfRegistrationConfigImplTest {
                 "Allow user's to self register to the system.");
         descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION,
                 "Lock self registered user account until e-mail verification.");
+        descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION,
+                "Enable user account confirmation when the user account is not locked on creation");
         descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
                 "Disable if the client application handles notification sending");
         descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA,
@@ -158,6 +162,7 @@ public class SelfRegistrationConfigImplTest {
         List<String> propertiesExpected = new ArrayList<>();
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION);
+        propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA);
         propertiesExpected
@@ -184,6 +189,7 @@ public class SelfRegistrationConfigImplTest {
 
         String testEnableSelfSignUp = "false";
         String testEnableAccountLockOnCreation = "true";
+        String testEnableSendNotificationOnCreation = "false";
         String testEnableNotificationInternallyManage = "true";
         String testEnableSelfRegistrationReCaptcha = "true";
         String testVerificationCodeExpiryTime = "1440";
@@ -198,6 +204,8 @@ public class SelfRegistrationConfigImplTest {
         propertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP, testEnableSelfSignUp);
         propertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION,
                 testEnableAccountLockOnCreation);
+        propertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION,
+                testEnableSendNotificationOnCreation);
         propertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
                 testEnableNotificationInternallyManage);
         propertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA,

--- a/pom.xml
+++ b/pom.xml
@@ -658,7 +658,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.18.206</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.19.41</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.28, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -658,7 +658,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.19.41</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.19.44</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.28, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -658,7 +658,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.19.44</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.19.53</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.28, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
Resolves: wso2/product-is/issues/10356
### Purpose				
In self registration, there is no option to enable send verification notification to the user if disable account lock on creation. 
And also sometimes users may have to access the self registered account without verifying the account. 

### Describe the improvement
After a user creates an account, the user gets access to the account without verifying. 
And also the user has an option to verify the account by clicking verification notification. 
The client application has the ability to determine the user account state whether it is verified or not. (using accountState claim ). Then the client application can limit the user access according to the user account state. 

### Additional context
Application can be configured to enable send verification notification even if disable “Account Lock On Creation” option.
accountState claim value:
 Before verify the account : PENDING_SR
After verified the account : UNLOCK

This PR is related with  https://github.com/wso2/carbon-identity-framework/pull/3392

### Product Version
Wso2 IS 5.10.0
### How to reproduce
Identity -> Identity Providers and then click Resident
Expand the Account Management Policies section, and then expand the User Self Registration section
enable “Enable Send Notification On Creation”
