### PR TITLE
Add support to skip password policy validation during ask password enabled flow

### DIFF
--- a/components/org.wso2.carbon.identity.password.policy/src/main/java/org/wso2/carbon/identity/password/policy/handler/PasswordPolicyValidationHandler.java
+++ b/components/org.wso2.carbon.identity.password.policy/src/main/java/org/wso2/carbon/identity/password/policy/handler/PasswordPolicyValidationHandler.java
@@ -52,7 +52,7 @@ public class PasswordPolicyValidationHandler extends AbstractEventHandler implem
     @Override
     public void handleEvent(Event event) throws IdentityEventException {
 
-        // Skip password policy validation if the Ask Password is enabled for the flow.
+        // Skip password policy validation if skipPasswordPatternValidation thread local is set to true.
         if (UserCoreUtil.getSkipPasswordPatternValidationThreadLocal()) {
             return;
         }

--- a/components/org.wso2.carbon.identity.password.policy/src/main/java/org/wso2/carbon/identity/password/policy/handler/PasswordPolicyValidationHandler.java
+++ b/components/org.wso2.carbon.identity.password.policy/src/main/java/org/wso2/carbon/identity/password/policy/handler/PasswordPolicyValidationHandler.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.mgt.policy.password.DefaultPasswordPatternPolicy
 import org.wso2.carbon.identity.password.policy.constants.PasswordPolicyConstants;
 import org.wso2.carbon.identity.password.policy.internal.IdentityPasswordPolicyServiceDataHolder;
 import org.wso2.carbon.identity.password.policy.util.Utils;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -50,6 +51,11 @@ public class PasswordPolicyValidationHandler extends AbstractEventHandler implem
 
     @Override
     public void handleEvent(Event event) throws IdentityEventException {
+
+        // Skip password policy validation if the Ask Password is enabled for the flow.
+        if (UserCoreUtil.getSkipPasswordPatternValidationThreadLocal()) {
+            return;
+        }
 
         Map<String, Object> eventProperties = event.getEventProperties();
 

--- a/pom.xml
+++ b/pom.xml
@@ -662,7 +662,7 @@
         <identity.data.publisher.authentication.version>5.3.0</identity.data.publisher.authentication.version>
 
         <!--Carbon Kernel Version-->
-        <carbon.kernel.version>4.6.1</carbon.kernel.version>
+        <carbon.kernel.version>4.6.2-m4</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.1</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>


### PR DESCRIPTION
### Purpose
> Fixing https://github.com/wso2/product-is/issues/10792
> Skip PasswordPolicyValidation if the password policy validation thread local is set to true.
> Depends on https://github.com/wso2-extensions/identity-user-workflow/pull/36