### PR TITLE
Fix locked reason claim value

### DIFF
--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/AccountValidatorThread.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/AccountValidatorThread.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.governance.IdentityGovernanceException;
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
 import org.wso2.carbon.user.api.Tenant;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserCoreConstants;
@@ -230,6 +231,8 @@ public class AccountValidatorThread implements Runnable {
 
                 Map<String, String> updatedClaims = new HashMap<>();
                 updatedClaims.put(NotificationConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
+                updatedClaims.put(NotificationConstants.ACCOUNT_LOCKED_REASON_CLAIM,
+                        IdentityMgtConstants.LockedReason.IDLE_ACCOUNT.toString());
                 updatedClaims.put(NotificationConstants.PASSWORD_RESET_FAIL_ATTEMPTS_CLAIM, "0");
                 try {
                     userStoreManager.setUserClaimValues(IdentityUtil.addDomainToName(receiver.getUsername(),

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationConstants.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationConstants.java
@@ -46,6 +46,7 @@ public class NotificationConstants {
     public final static String LAST_LOGIN_TIME_IDENTITY_CLAIM = "http://wso2.org/claims/identity/lastLoginTime";
 
     public static final String ACCOUNT_LOCKED_CLAIM = "http://wso2.org/claims/identity/accountLocked";
+    public static final String ACCOUNT_LOCKED_REASON_CLAIM = "http://wso2.org/claims/identity/lockedReason";
     public static final String PASSWORD_RESET_FAIL_ATTEMPTS_CLAIM = "http://wso2" +
             ".org/claims/identity/failedPasswordRecoveryAttempts";
 }

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityMgtConstants.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityMgtConstants.java
@@ -112,6 +112,17 @@ public class IdentityMgtConstants {
         public static final String DEFAULT_NOTIFICATION_CHANNEL = "Notification.DefaultNotificationChannel";
     }
 
+    public enum LockedReason {
+
+        PENDING_SELF_REGISTRATION,
+        PENDING_ADMIN_FORCED_USER_PASSWORD_RESET,
+        PENDING_EMAIL_VERIFICATION,
+        PENDING_ASK_PASSWORD,
+        IDLE_ACCOUNT,
+        ADMIN_INITIATED,
+        MAX_ATTEMPTS_EXCEEDED
+    }
+
     public enum ErrorMessages {
 
         ERROR_CODE_DEFAULT_BAD_REQUEST("10000", "Bad Request"),

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -61,6 +61,7 @@ public class IdentityRecoveryConstants {
     public static final String NOTIFY = "notify";
     public static final String WSO2CARBON_CLAIM_DIALECT = "http://wso2.org/claims";
     public static final String ACCOUNT_LOCKED_CLAIM = "http://wso2.org/claims/identity/accountLocked";
+    public static final String ACCOUNT_LOCKED_REASON_CLAIM = "http://wso2.org/claims/identity/lockedReason";
     public static final String ACCOUNT_UNLOCK_TIME_CLAIM = "http://wso2.org/claims/identity/unlockTime";
     public static final String ACCOUNT_DISABLED_CLAIM = "http://wso2.org/claims/identity/accountDisabled";
     public static final String LITE_USER_CLAIM = "http://wso2.org/claims/identity/isLiteUser";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AdminForcedPasswordResetHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AdminForcedPasswordResetHandler.java
@@ -126,7 +126,7 @@ public class AdminForcedPasswordResetHandler extends UserEmailVerificationHandle
 
             claims.remove(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM);
             setRecoveryData(user, recoveryScenario, RecoverySteps.UPDATE_PASSWORD, OTP);
-            lockAccountOnAdminPasswordReset(user, userStoreManager);
+            lockAccountOnAdminPasswordReset(user, claims);
 
             if (adminPasswordResetOTP | adminPasswordResetRecoveryLink) {
                 try {
@@ -195,17 +195,16 @@ public class AdminForcedPasswordResetHandler extends UserEmailVerificationHandle
         }
     }
 
-    private void lockAccountOnAdminPasswordReset(User user, UserStoreManager userStoreManager)
-            throws IdentityEventException {
+    private void lockAccountOnAdminPasswordReset(User user, Map<String, String> claims) {
 
         if (log.isDebugEnabled()) {
             log.debug("Locking user account on admin forced password reset: " + user.getUserName());
         }
-        HashMap<String, String> userClaims = new HashMap<>();
-        userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
-        userClaims.put(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI,
+        claims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
+        claims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_REASON_CLAIM,
+                IdentityMgtConstants.LockedReason.PENDING_ADMIN_FORCED_USER_PASSWORD_RESET.toString());
+        claims.put(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI,
                 IdentityMgtConstants.AccountStates.PENDING_ADMIN_FORCED_USER_PASSWORD_RESET);
-        setUserClaims(userClaims, user, userStoreManager);
     }
 
     protected void setUserClaims(Map<String, String> userClaims, User user, UserStoreManager userStoreManager)

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.RecoveryScenarios;
@@ -173,6 +174,9 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
                 // Need to lock user account.
                 if (isAccountLockOnCreation) {
                     lockAccount(user, userStoreManager);
+                    setUserClaim(IdentityRecoveryConstants.ACCOUNT_LOCKED_REASON_CLAIM,
+                            IdentityMgtConstants.LockedReason.PENDING_EMAIL_VERIFICATION.toString(),
+                            userStoreManager, user);
                 }
                 Utils.publishRecoveryEvent(eventProperties, IdentityEventConstants.Event.POST_VERIFY_EMAIL_CLAIM,
                         confirmationCode);
@@ -185,6 +189,14 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
                     }
                     initNotification(user, RecoveryScenarios.ASK_PASSWORD, RecoverySteps.UPDATE_PASSWORD,
                             IdentityRecoveryConstants.NOTIFICATION_TYPE_ASK_PASSWORD, confirmationCode);
+                }
+
+                // Need to lock user account.
+                if (isAccountLockOnCreation) {
+                    lockAccount(user, userStoreManager);
+                    setUserClaim(IdentityRecoveryConstants.ACCOUNT_LOCKED_REASON_CLAIM,
+                            IdentityMgtConstants.LockedReason.PENDING_ASK_PASSWORD.toString(),
+                            userStoreManager, user);
                 }
                 Utils.publishRecoveryEvent(eventProperties, IdentityEventConstants.Event.POST_ADD_USER_WITH_ASK_PASSWORD,
                         confirmationCode);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
@@ -154,6 +154,8 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
                 HashMap<String, String> userClaims = new HashMap<>();
                 //Need to lock user account
                 userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
+                userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_REASON_CLAIM,
+                        IdentityMgtConstants.LockedReason.PENDING_SELF_REGISTRATION.toString());
                 if (Utils.isAccountStateClaimExisting(tenantDomain)) {
                     userClaims.put(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI,
                             IdentityRecoveryConstants.PENDING_SELF_REGISTRATION);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -537,6 +537,8 @@ public class NotificationPasswordRecoveryManager {
             if (Utils.isAccountStateClaimExisting(userRecoveryData.getUser().getTenantDomain())) {
                 userClaims.put(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI,
                         IdentityRecoveryConstants.ACCOUNT_STATE_UNLOCKED);
+                userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_REASON_CLAIM, StringUtils.EMPTY);
+                userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.FALSE.toString());
             }
         }
         // If the scenario is initiated by the admin, set the account locked claim to TRUE.
@@ -544,6 +546,7 @@ public class NotificationPasswordRecoveryManager {
                 || RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_OTP.
                 equals(userRecoveryData.getRecoveryScenario())) {
             userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.FALSE.toString());
+            userClaims.remove(IdentityRecoveryConstants.ACCOUNT_LOCKED_REASON_CLAIM);
             userClaims.remove(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI);
         }
         return userClaims;

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -900,6 +900,7 @@ public class UserSelfRegistrationManager {
 
         // Need to unlock user account
         userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.FALSE.toString());
+        userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_REASON_CLAIM, StringUtils.EMPTY);
 
         // Set the verified claims to TRUE.
         setVerificationClaims(user, verificationChannel, externallyVerifiedChannelClaim, recoveryScenario, userClaims);


### PR DESCRIPTION
## Description

This fix will add the values to  the LockedReason claim values to track the locked reason. With this PR, following locked reasons are added.

- PENDING_SELF_REGISTRATION
- PENDING_ADMIN_FORCED_USER_PASSWORD_RESET
- PENDING_EMAIL_VERIFICATION
- PENDING_ASK_PASSWORD
- IDLE_ACCOUNT    
- ADMIN_INITIATED,
- MAX_ATTEMPTS_EXCEEDED    

**Related PR:** https://github.com/wso2-support/identity-event-handler-account-lock/pull/50
**Resolves**: https://github.com/wso2/product-is/issues/10867

This will also resolve the issue: https://github.com/wso2/product-is/issues/10930.

### When should this PR be merged
Before merging https://github.com/wso2-extensions/identity-event-handler-account-lock/pull/84