### PR TITLE
Add capability to send the same confirmation code for password reset within a time period

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -153,6 +153,9 @@ public class IdentityRecoveryConstants {
 
     public static final String RECOVERY_QUESTION_PASSWORD_SKIP_ON_INSUFFICIENT_ANSWERS =
             "Recovery.Question.Password.SkipOnInsufficientAnswers";
+    public static final String RECOVERY_CONFIRMATION_CODE_TOLERANCE_PERIOD =
+            "Recovery.Notification.Password.Email.ConfirmationCodeTolerancePeriod";
+    public static final int RECOVERY_CONFIRMATION_CODE_DEFAULT_TOLERANCE = 0;
 
     private IdentityRecoveryConstants() {
 
@@ -313,6 +316,8 @@ public class IdentityRecoveryConstants {
                 "Unsupported notification channel : '%s'"),
         ERROR_CODE_ERROR_GENERATING_NEW_RESET_CODE("UAR-15006", "Error while generating new "
                 + "password reset code"),
+        ERROR_CODE_ERROR_RETRIEVING_RECOVERY_DATA("UAR-15007","Error while retrieving the user recovery data - '%s'"),
+        ERROR_CODE_ERROR_UPDATING_RECOVERY_DATA("UAR-15008", "Error while updating recovery data : '%s'"),
 
         // PWR - Password Recovery.
         ERROR_CODE_INVALID_TENANT_DOMAIN_PASSWORD_RESET("PWR-10001", "User's tenant domain does "
@@ -558,6 +563,9 @@ public class IdentityRecoveryConstants {
         public static final String INVALIDATE_USER_CODE_BY_SCENARIO = "DELETE FROM IDN_RECOVERY_DATA WHERE " +
                 "USER_NAME = ? AND SCENARIO = ? AND STEP = ? AND USER_DOMAIN = ? AND TENANT_ID =?";
 
+        public static final String UPDATE_CODE = "UPDATE IDN_RECOVERY_DATA SET CODE = ?, STEP = ?, REMAINING_SETS = ? " +
+                "WHERE CODE = ?";
+
         public static final String INVALIDATE_USER_CODE_BY_SCENARIO_CASE_INSENSITIVE = "DELETE FROM " +
                 "IDN_RECOVERY_DATA WHERE LOWER(USER_NAME)=LOWER(?) AND SCENARIO = ? AND STEP = ? AND " +
                 "USER_DOMAIN = ? AND TENANT_ID =?";
@@ -580,6 +588,13 @@ public class IdentityRecoveryConstants {
                 + "* FROM IDN_RECOVERY_DATA WHERE LOWER(USER_NAME)=LOWER(?) AND SCENARIO = ? AND " +
                 "USER_DOMAIN = ? AND TENANT_ID = ?";
 
+        public static final String LOAD_RECOVERY_DATA_OF_USER_BY_STEP = "SELECT "
+                + "* FROM IDN_RECOVERY_DATA WHERE USER_NAME = ? AND SCENARIO = ? AND USER_DOMAIN = ? " +
+                "AND TENANT_ID = ? AND STEP = ?";
+
+        public static final String LOAD_RECOVERY_DATA_OF_USER_BY_STEP_CASE_INSENSITIVE = "SELECT "
+                + "* FROM IDN_RECOVERY_DATA WHERE LOWER(USER_NAME)=LOWER(?) AND SCENARIO = ? AND USER_DOMAIN = ? " +
+                "AND TENANT_ID = ? AND STEP = ?";
     }
 
     public static class Questions {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/model/UserRecoveryData.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/model/UserRecoveryData.java
@@ -21,6 +21,8 @@ package org.wso2.carbon.identity.recovery.model;
 
 import org.wso2.carbon.identity.application.common.model.User;
 
+import java.sql.Timestamp;
+
 /**
  * This object represents an entry of the identity metadata database.
  */
@@ -31,9 +33,11 @@ public class UserRecoveryData {
     private boolean codeExpired;
 
 
-    private Enum recoveryScenario;
-    private Enum recoveryStep;
+    private Timestamp timeCreated;
 
+    private Enum recoveryScenario;
+
+    private Enum recoveryStep;
     public UserRecoveryData(User user, String secret, Enum recoveryScenario, Enum recoveryStep) {
 
         this.user = user;
@@ -56,6 +60,25 @@ public class UserRecoveryData {
         this.recoveryScenario = recoveryScenario;
         this.recoveryStep = recoveryStep;
         this.codeExpired = isExpired;
+    }
+
+    public UserRecoveryData(User user, String secret, Enum recoveryScenario, Enum recoveryStep, Timestamp timeCreated) {
+
+        this.user = user;
+        this.secret = secret;
+        this.recoveryScenario = recoveryScenario;
+        this.recoveryStep = recoveryStep;
+        this.timeCreated = timeCreated;
+    }
+
+    public Timestamp getTimeCreated() {
+
+        return timeCreated;
+    }
+
+    public void setTimeCreated(Timestamp timeCreated) {
+
+        this.timeCreated = timeCreated;
     }
 
     public String getRemainingSetIds() {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/store/UserRecoveryDataStore.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/store/UserRecoveryDataStore.java
@@ -59,6 +59,9 @@ public interface UserRecoveryDataStore {
     UserRecoveryData loadWithoutCodeExpiryValidation(User user, Enum recoveryScenario) throws
             IdentityRecoveryException;
 
+    UserRecoveryData loadWithoutCodeExpiryValidation(User user, Enum recoveryScenario, Enum recoveryStep)
+            throws IdentityRecoveryException;
+
     void invalidate(String code) throws
             IdentityRecoveryException;
 
@@ -76,4 +79,17 @@ public interface UserRecoveryDataStore {
     default void deleteRecoveryDataByTenantId(int tenantId) throws IdentityRecoveryException {
 
     }
+
+    /**
+     * Update the existing recovery entry of the existing code and replace with a new code, recovery step and channel list
+     * by not changing the existing code creation time.
+     *
+     * @param oldCode Existing code.
+     * @param code Newly created code which replaces the existing code.
+     * @param recoveryStep Recovery step that needs to be updated in the database.
+     * @param channelList String which contains the list of channels to be updated.
+     * @throws IdentityRecoveryException If an error occurred during the update operation.
+     */
+    void invalidateWithoutChangeTimeCreated(String oldCode, String code, Enum recoveryStep, String channelList)
+            throws IdentityRecoveryException;
 }


### PR DESCRIPTION
### Proposed changes in this pull request

> Fixes https://github.com/wso2/product-is/issues/10985
Added the capability to send the same confirmation code for the notification based password recovery scenario when the following recovery requests or the resend requests are inside a configured time period (tolerance period) with the initial request.