### PR TITLE
Add Multi attribute login

### DIFF
--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.governance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.governance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.governance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.governance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.governance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.governance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.history/pom.xml
+++ b/components/org.wso2.carbon.identity.password.history/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.history/pom.xml
+++ b/components/org.wso2.carbon.identity.password.history/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.history/pom.xml
+++ b/components/org.wso2.carbon.identity.password.history/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.history/pom.xml
+++ b/components/org.wso2.carbon.identity.password.history/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.history/pom.xml
+++ b/components/org.wso2.carbon.identity.password.history/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.history/pom.xml
+++ b/components/org.wso2.carbon.identity.password.history/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.policy/pom.xml
+++ b/components/org.wso2.carbon.identity.password.policy/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.policy/pom.xml
+++ b/components/org.wso2.carbon.identity.password.policy/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.policy/pom.xml
+++ b/components/org.wso2.carbon.identity.password.policy/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.policy/pom.xml
+++ b/components/org.wso2.carbon.identity.password.policy/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.policy/pom.xml
+++ b/components/org.wso2.carbon.identity.password.policy/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.policy/pom.xml
+++ b/components/org.wso2.carbon.identity.password.policy/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.piicontroller/pom.xml
+++ b/components/org.wso2.carbon.identity.piicontroller/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.piicontroller/pom.xml
+++ b/components/org.wso2.carbon.identity.piicontroller/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.piicontroller/pom.xml
+++ b/components/org.wso2.carbon.identity.piicontroller/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.piicontroller/pom.xml
+++ b/components/org.wso2.carbon.identity.piicontroller/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.piicontroller/pom.xml
+++ b/components/org.wso2.carbon.identity.piicontroller/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.piicontroller/pom.xml
+++ b/components/org.wso2.carbon.identity.piicontroller/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
@@ -8,7 +8,6 @@ import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
-import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
@@ -49,18 +48,6 @@ public class RecoverPasswordApiServiceImpl extends RecoverPasswordApiService {
         UserDTO user = recoveryInitiatingRequest.getUser();
         int tenantIdFromContext = IdentityTenantUtil.getTenantId(user.getTenantDomain());
 
-        if (IdentityRecoveryServiceDataHolder.getInstance().getMultiAttributeLoginService().
-                isEnabled(user.getTenantDomain())) {
-            ResolvedUserResult resolvedUser = IdentityRecoveryServiceDataHolder.getInstance().
-                    getMultiAttributeLoginService().resolveUser(user.getUsername(), user.getTenantDomain());
-            if (resolvedUser != null && ResolvedUserResult.UserResolvedStatus.SUCCESS.
-                    equals(resolvedUser.getResolvedStatus())) {
-                user.setUsername(resolvedUser.getUser().getUsername());
-                UserDTO userDTO = recoveryInitiatingRequest.getUser();
-                userDTO.setUsername(user.getUsername());
-                recoveryInitiatingRequest.setUser(userDTO);
-            }
-        }
         if (StringUtils.isBlank(user.getRealm())) {
             String[] userList = RecoveryUtil.getUserList(tenantIdFromContext, user.getUsername());
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
@@ -5,9 +5,11 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
@@ -47,7 +49,15 @@ public class RecoverPasswordApiServiceImpl extends RecoverPasswordApiService {
 
         UserDTO user = recoveryInitiatingRequest.getUser();
         int tenantIdFromContext = IdentityTenantUtil.getTenantId(user.getTenantDomain());
-
+        ResolvedUserResult resolvedUserResult =
+                FrameworkUtils.processMultiAttributeLoginIdentification(user.getUsername(), user.getTenantDomain());
+        if (resolvedUserResult != null && ResolvedUserResult.UserResolvedStatus.SUCCESS.
+                equals(resolvedUserResult.getResolvedStatus())) {
+            user.setUsername(resolvedUserResult.getUser().getUsername());
+            UserDTO userDTO = recoveryInitiatingRequest.getUser();
+            userDTO.setUsername(user.getUsername());
+            recoveryInitiatingRequest.setUser(userDTO);
+        }
         if (StringUtils.isBlank(user.getRealm())) {
             String[] userList = RecoveryUtil.getUserList(tenantIdFromContext, user.getUsername());
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/test/java/org/wso2/carbon/identity/recovery/endpoint/RecoverPasswordApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/test/java/org/wso2/carbon/identity/recovery/endpoint/RecoverPasswordApiServiceImplTest.java
@@ -24,8 +24,10 @@ import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.IObjectFactory;
 import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.bean.NotificationResponseBean;
 import org.wso2.carbon.identity.recovery.endpoint.Utils.RecoveryUtil;
@@ -49,7 +51,7 @@ import static org.testng.Assert.assertEquals;
 /**
  * This class covers unit tests for RecoverPasswordApiServiceImpl.java
  */
-@PrepareForTest({RecoveryUtil.class, IdentityTenantUtil.class})
+@PrepareForTest({RecoveryUtil.class, IdentityTenantUtil.class, FrameworkUtils.class})
 public class RecoverPasswordApiServiceImplTest extends PowerMockTestCase {
     
     @Mock
@@ -66,10 +68,13 @@ public class RecoverPasswordApiServiceImplTest extends PowerMockTestCase {
 
         mockStatic(IdentityTenantUtil.class);
         mockStatic(RecoveryUtil.class);
+        mockStatic(FrameworkUtils.class);
+        ResolvedUserResult resolvedUserResult = new ResolvedUserResult(ResolvedUserResult.UserResolvedStatus.FAIL);
         when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
         when(RecoveryUtil.getNotificationBasedPwdRecoveryManager()).thenReturn(notificationPasswordRecoveryManager);
         when(notificationPasswordRecoveryManager.sendRecoveryNotification(any(User.class), anyString(), anyBoolean(),
                 any(Property[].class))).thenReturn(notificationResponseBean);
+        when(FrameworkUtils.processMultiAttributeLoginIdentification(anyString(), anyString())).thenReturn(resolvedUserResult);
         assertEquals(recoverPasswordApiService.recoverPasswordPost(buildRecoveryInitiatingRequestDTO(), "", true).
                 getStatus(), 202);
     }

--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/test/java/org/wso2/carbon/identity/recovery/endpoint/RecoverPasswordApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/test/java/org/wso2/carbon/identity/recovery/endpoint/RecoverPasswordApiServiceImplTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.bean.NotificationResponseBean;
 import org.wso2.carbon.identity.recovery.endpoint.Utils.RecoveryUtil;
@@ -33,6 +34,7 @@ import org.wso2.carbon.identity.recovery.endpoint.dto.PropertyDTO;
 import org.wso2.carbon.identity.recovery.endpoint.dto.RecoveryInitiatingRequestDTO;
 import org.wso2.carbon.identity.recovery.endpoint.dto.UserDTO;
 import org.wso2.carbon.identity.recovery.endpoint.impl.RecoverPasswordApiServiceImpl;
+import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
 import org.wso2.carbon.identity.recovery.model.Property;
 import org.wso2.carbon.identity.recovery.password.NotificationPasswordRecoveryManager;
 
@@ -42,6 +44,7 @@ import java.util.List;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertEquals;
@@ -49,14 +52,18 @@ import static org.testng.Assert.assertEquals;
 /**
  * This class covers unit tests for RecoverPasswordApiServiceImpl.java
  */
-@PrepareForTest({RecoveryUtil.class, IdentityTenantUtil.class})
+@PrepareForTest({RecoveryUtil.class, IdentityTenantUtil.class, IdentityRecoveryServiceDataHolder.class})
 public class RecoverPasswordApiServiceImplTest extends PowerMockTestCase {
-    
+
+    private MultiAttributeLoginService multiAttributeLoginService;
     @Mock
     NotificationPasswordRecoveryManager notificationPasswordRecoveryManager;
 
     @Mock
     NotificationResponseBean notificationResponseBean;
+
+    @Mock
+    IdentityRecoveryServiceDataHolder identityRecoveryServiceDataHolder;
 
     @InjectMocks
     RecoverPasswordApiServiceImpl recoverPasswordApiService;
@@ -70,6 +77,10 @@ public class RecoverPasswordApiServiceImplTest extends PowerMockTestCase {
         when(RecoveryUtil.getNotificationBasedPwdRecoveryManager()).thenReturn(notificationPasswordRecoveryManager);
         when(notificationPasswordRecoveryManager.sendRecoveryNotification(any(User.class), anyString(), anyBoolean(),
                 any(Property[].class))).thenReturn(notificationResponseBean);
+        multiAttributeLoginService = mock(MultiAttributeLoginService.class);
+        mockStatic(IdentityRecoveryServiceDataHolder.class);
+        when(IdentityRecoveryServiceDataHolder.getInstance()).thenReturn(identityRecoveryServiceDataHolder);
+        when(identityRecoveryServiceDataHolder.getMultiAttributeLoginService()).thenReturn(multiAttributeLoginService);
         assertEquals(recoverPasswordApiService.recoverPasswordPost(buildRecoveryInitiatingRequestDTO(), "", true).
                 getStatus(), 202);
     }

--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/test/java/org/wso2/carbon/identity/recovery/endpoint/RecoverPasswordApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/test/java/org/wso2/carbon/identity/recovery/endpoint/RecoverPasswordApiServiceImplTest.java
@@ -26,7 +26,6 @@ import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.bean.NotificationResponseBean;
 import org.wso2.carbon.identity.recovery.endpoint.Utils.RecoveryUtil;
@@ -34,7 +33,6 @@ import org.wso2.carbon.identity.recovery.endpoint.dto.PropertyDTO;
 import org.wso2.carbon.identity.recovery.endpoint.dto.RecoveryInitiatingRequestDTO;
 import org.wso2.carbon.identity.recovery.endpoint.dto.UserDTO;
 import org.wso2.carbon.identity.recovery.endpoint.impl.RecoverPasswordApiServiceImpl;
-import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
 import org.wso2.carbon.identity.recovery.model.Property;
 import org.wso2.carbon.identity.recovery.password.NotificationPasswordRecoveryManager;
 
@@ -44,7 +42,6 @@ import java.util.List;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
-import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertEquals;
@@ -52,18 +49,14 @@ import static org.testng.Assert.assertEquals;
 /**
  * This class covers unit tests for RecoverPasswordApiServiceImpl.java
  */
-@PrepareForTest({RecoveryUtil.class, IdentityTenantUtil.class, IdentityRecoveryServiceDataHolder.class})
+@PrepareForTest({RecoveryUtil.class, IdentityTenantUtil.class})
 public class RecoverPasswordApiServiceImplTest extends PowerMockTestCase {
-
-    private MultiAttributeLoginService multiAttributeLoginService;
+    
     @Mock
     NotificationPasswordRecoveryManager notificationPasswordRecoveryManager;
 
     @Mock
     NotificationResponseBean notificationResponseBean;
-
-    @Mock
-    IdentityRecoveryServiceDataHolder identityRecoveryServiceDataHolder;
 
     @InjectMocks
     RecoverPasswordApiServiceImpl recoverPasswordApiService;
@@ -77,10 +70,6 @@ public class RecoverPasswordApiServiceImplTest extends PowerMockTestCase {
         when(RecoveryUtil.getNotificationBasedPwdRecoveryManager()).thenReturn(notificationPasswordRecoveryManager);
         when(notificationPasswordRecoveryManager.sendRecoveryNotification(any(User.class), anyString(), anyBoolean(),
                 any(Property[].class))).thenReturn(notificationResponseBean);
-        multiAttributeLoginService = mock(MultiAttributeLoginService.class);
-        mockStatic(IdentityRecoveryServiceDataHolder.class);
-        when(IdentityRecoveryServiceDataHolder.getInstance()).thenReturn(identityRecoveryServiceDataHolder);
-        when(identityRecoveryServiceDataHolder.getMultiAttributeLoginService()).thenReturn(multiAttributeLoginService);
         assertEquals(recoverPasswordApiService.recoverPasswordPost(buildRecoveryInitiatingRequestDTO(), "", true).
                 getStatus(), 202);
     }

--- a/components/org.wso2.carbon.identity.recovery.ui/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.ui/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.ui/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.ui/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.ui/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.ui/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.ui/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.ui/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.ui/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.ui/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.ui/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.ui/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -166,6 +166,8 @@
                             org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.logging.*; version="${commons-logging.osgi.version.range}",
+                            org.wso2.carbon.identity.multi.attribute.login.mgt.*;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -166,8 +166,6 @@
                             org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.logging.*; version="${commons-logging.osgi.version.range}",
-                            org.wso2.carbon.identity.multi.attribute.login.mgt.*;
-                            version="${carbon.identity.framework.imp.pkg.version.range}",
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -480,6 +480,7 @@ public class IdentityRecoveryConstants {
         public static final String RECOVERY_CALLBACK_REGEX = "Recovery.CallbackRegex";
         public static final String ENABLE_SELF_SIGNUP = "SelfRegistration.Enable";
         public static final String ACCOUNT_LOCK_ON_CREATION = "SelfRegistration.LockOnCreation";
+        public static final String SEND_CONFIRMATION_NOTIFICATION = "SelfRegistration.SendConfirmationOnCreation";
         public static final String SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE = "SelfRegistration.Notification" +
                 ".InternallyManage";
         public static final String SELF_REGISTRATION_RE_CAPTCHA = "SelfRegistration.ReCaptcha";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
@@ -75,6 +75,8 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP, "User self registration");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION,
                 "Lock user account on creation");
+        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION,
+                "Enable Account Confirmation On Creation");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
                 "Manage notifications sending internally");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA, "Prompt reCaptcha");
@@ -104,6 +106,8 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
                 "Allow user's to self register to the system.");
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION,
                 "Lock self registered user account until e-mail verification.");
+        descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION,
+                "Enable user account confirmation when the user account is not locked on creation");
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
                 "Disable if the client application handles notification sending");
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA,
@@ -134,6 +138,7 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
         List<String> properties = new ArrayList<>();
         properties.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION);
+        properties.add(IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME);
@@ -153,6 +158,7 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
 
         String enableSelfSignUp = "false";
         String enableAccountLockOnCreation = "true";
+        String enableSendNotificationOnCreation = "false";
         String enableNotificationInternallyManage = "true";
         String enableSelfRegistrationReCaptcha = "true";
         String verificationCodeExpiryTime = "1440";
@@ -167,6 +173,8 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
                 IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP);
         String accountLockProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION);
+        String SendNotificationOnCreationProperty = IdentityUtil.getProperty(
+                IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION);
         String notificationInternallyMangedProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE);
         String reCaptchaProperty = IdentityUtil.getProperty(
@@ -191,6 +199,9 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
         }
         if (StringUtils.isNotEmpty(accountLockProperty)) {
             enableAccountLockOnCreation = accountLockProperty;
+        }
+        if (StringUtils.isNotEmpty(SendNotificationOnCreationProperty)) {
+            enableSendNotificationOnCreation = SendNotificationOnCreationProperty;
         }
         if (StringUtils.isNotEmpty(notificationInternallyMangedProperty)) {
             enableNotificationInternallyManage = notificationInternallyMangedProperty;
@@ -224,6 +235,8 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP, enableSelfSignUp);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION,
                 enableAccountLockOnCreation);
+        defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION,
+                enableSendNotificationOnCreation);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
                 enableNotificationInternallyManage);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA,

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
@@ -36,7 +36,6 @@ import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
 import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
-import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.recovery.ChallengeQuestionManager;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.confirmation.ResendConfirmationManager;
@@ -395,21 +394,5 @@ public class IdentityRecoveryServiceComponent {
             log.debug("Configuration Manager service is unset in the Template Manager component.");
         }
         dataHolder.getInstance().setConfigurationManager(null);
-    }
-
-    @Reference(
-            name = "MultiAttributeLoginService",
-            service = MultiAttributeLoginService.class,
-            cardinality = ReferenceCardinality.MANDATORY,
-            policy = ReferencePolicy.DYNAMIC,
-            unbind = "unsetMultiAttributeLoginService")
-    protected void setMultiAttributeLoginService(MultiAttributeLoginService multiAttributeLogin) {
-
-        IdentityRecoveryServiceDataHolder.getInstance().setMultiAttributeLoginService(multiAttributeLogin);
-    }
-
-    protected void unsetMultiAttributeLoginService(MultiAttributeLoginService multiAttributeLogin) {
-
-        IdentityRecoveryServiceDataHolder.getInstance().setMultiAttributeLoginService(null);
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
 import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.recovery.ChallengeQuestionManager;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.confirmation.ResendConfirmationManager;
@@ -394,5 +395,21 @@ public class IdentityRecoveryServiceComponent {
             log.debug("Configuration Manager service is unset in the Template Manager component.");
         }
         dataHolder.getInstance().setConfigurationManager(null);
+    }
+
+    @Reference(
+            name = "MultiAttributeLoginService",
+            service = MultiAttributeLoginService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetMultiAttributeLoginService")
+    protected void setMultiAttributeLoginService(MultiAttributeLoginService multiAttributeLogin) {
+
+        IdentityRecoveryServiceDataHolder.getInstance().setMultiAttributeLoginService(multiAttributeLogin);
+    }
+
+    protected void unsetMultiAttributeLoginService(MultiAttributeLoginService multiAttributeLogin) {
+
+        IdentityRecoveryServiceDataHolder.getInstance().setMultiAttributeLoginService(null);
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceDataHolder.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceDataHolder.java
@@ -44,6 +44,7 @@ public class IdentityRecoveryServiceDataHolder {
     private ConsentUtilityService consentUtilityService;
     private ClaimMetadataManagementService claimMetadataManagementService;
     private UserFunctionalityManager userFunctionalityManagerService;
+    private MultiAttributeLoginService multiAttributeLoginService;
     public static IdentityRecoveryServiceDataHolder getInstance() {
 
         return instance;
@@ -221,5 +222,25 @@ public class IdentityRecoveryServiceDataHolder {
     public void setConfigurationManager(ConfigurationManager configurationManager) {
 
         this.configurationManager = configurationManager;
+    }
+    /**
+     * Get multi attribute login OSGI service.
+     *
+     * @return MultiAttributeLoginService service.
+     */
+    public MultiAttributeLoginService getMultiAttributeLoginService() {
+
+        return multiAttributeLoginService;
+    }
+
+    /**
+     * Set multi attribute login OSGI service.
+     *
+     *
+     * @param multiAttributeLoginService
+     */
+    public void setMultiAttributeLoginService(MultiAttributeLoginService multiAttributeLoginService) {
+
+        this.multiAttributeLoginService = multiAttributeLoginService;
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceDataHolder.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceDataHolder.java
@@ -44,7 +44,6 @@ public class IdentityRecoveryServiceDataHolder {
     private ConsentUtilityService consentUtilityService;
     private ClaimMetadataManagementService claimMetadataManagementService;
     private UserFunctionalityManager userFunctionalityManagerService;
-    private MultiAttributeLoginService multiAttributeLoginService;
     public static IdentityRecoveryServiceDataHolder getInstance() {
 
         return instance;
@@ -222,25 +221,5 @@ public class IdentityRecoveryServiceDataHolder {
     public void setConfigurationManager(ConfigurationManager configurationManager) {
 
         this.configurationManager = configurationManager;
-    }
-    /**
-     * Get multi attribute login OSGI service.
-     *
-     * @return MultiAttributeLoginService service.
-     */
-    public MultiAttributeLoginService getMultiAttributeLoginService() {
-
-        return multiAttributeLoginService;
-    }
-
-    /**
-     * Set multi attribute login OSGI service.
-     *
-     *
-     * @param multiAttributeLoginService
-     */
-    public void setMultiAttributeLoginService(MultiAttributeLoginService multiAttributeLoginService) {
-
-        this.multiAttributeLoginService = multiAttributeLoginService;
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -905,6 +905,11 @@ public class UserSelfRegistrationManager {
 
         // Set the verified claims to TRUE.
         setVerificationClaims(user, verificationChannel, externallyVerifiedChannelClaim, recoveryScenario, userClaims);
+
+        // Set accountState claim UNLOCK.
+        userClaims.put(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI,
+                IdentityRecoveryConstants.ACCOUNT_STATE_UNLOCKED);
+
         //Set account verified time claim.
         userClaims.put(IdentityRecoveryConstants.ACCOUNT_CONFIRMED_TIME_CLAIM, Instant.now().toString());
         return userClaims;

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImplTest.java
@@ -94,6 +94,8 @@ public class SelfRegistrationConfigImplTest {
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP, "User self registration");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION,
                 "Lock user account on creation");
+        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION,
+                "Enable Account Confirmation On Creation");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
                 "Manage notifications sending internally");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA, "Prompt reCaptcha");
@@ -125,6 +127,8 @@ public class SelfRegistrationConfigImplTest {
                 "Allow user's to self register to the system.");
         descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION,
                 "Lock self registered user account until e-mail verification.");
+        descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION,
+                "Enable user account confirmation when the user account is not locked on creation");
         descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
                 "Disable if the client application handles notification sending");
         descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA,
@@ -158,6 +162,7 @@ public class SelfRegistrationConfigImplTest {
         List<String> propertiesExpected = new ArrayList<>();
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION);
+        propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA);
         propertiesExpected
@@ -184,6 +189,7 @@ public class SelfRegistrationConfigImplTest {
 
         String testEnableSelfSignUp = "false";
         String testEnableAccountLockOnCreation = "true";
+        String testEnableSendNotificationOnCreation = "false";
         String testEnableNotificationInternallyManage = "true";
         String testEnableSelfRegistrationReCaptcha = "true";
         String testVerificationCodeExpiryTime = "1440";
@@ -198,6 +204,8 @@ public class SelfRegistrationConfigImplTest {
         propertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP, testEnableSelfSignUp);
         propertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION,
                 testEnableAccountLockOnCreation);
+        propertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION,
+                testEnableSendNotificationOnCreation);
         propertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
                 testEnableNotificationInternallyManage);
         propertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA,

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImpl.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.CarbonException;
 import org.wso2.carbon.core.util.AnonymousSessionUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.mgt.constants.SelfRegistrationStatusCodes;
+import org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
@@ -65,6 +66,8 @@ public class ValidateUsernameApiServiceImpl extends ValidateUsernameApiService {
                 for (PropertyDTO propertyDTO : propertyDTOList) {
                     if (SKIP_SIGN_UP_ENABLE_CHECK_KEY.equalsIgnoreCase(propertyDTO.getKey())) {
                         skipSelfSignUpEnabledCheck = Boolean.parseBoolean(propertyDTO.getValue());
+                    } else if (IdentityManagementEndpointConstants.TENANT_DOMAIN.equals(propertyDTO.getKey())) {
+                        tenantDomain = propertyDTO.getValue();
                     }
                 }
             }

--- a/components/org.wso2.carbon.identity.user.export.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.export.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.export.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.export.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.export.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.export.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.export.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.export.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.export.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.export.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.export.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.export.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.rename.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.rename.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.user.rename.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.rename.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.user.rename.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.rename.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.user.rename.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.rename.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.user.rename.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.rename.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.user.rename.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.rename.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.governance.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.governance.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.governance.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.governance.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.governance.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.governance.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/pom.xml
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/pom.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>identity-governance</artifactId>
+        <groupId>org.wso2.carbon.identity.governance</groupId>
+        <version>1.4.92-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.multi.attribute.login.resolver.regex</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Multi Attribute Login - Regex Based Username Resolver</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.multi.attribute.login.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.2.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>
+                            ${project.artifactId}
+                        </Bundle-SymbolicName>
+                        <Private-Package>
+                            org.wso2.carbon.identity.multi.attribute.login.resolver.regex.internal
+                        </Private-Package>
+                        <Export-Package>
+                            org.wso2.carbon.identity.multi.attribute.login.resolver.regex.*;
+                            version="${identity.governance.exp.pkg.version}",
+                            !org.wso2.carbon.identity.multi.attribute.login.resolver.regex.internal
+                        </Export-Package>
+                        <Import-Package>
+                            org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
+                            org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.governance; version="${identity.governance.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.multi.attribute.login.mgt.*;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",
+                            org.wso2.carbon.user.core.*; version="${carbon.kernel.imp.pkg.version.range}",
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-prepare-agent-integration</id>
+                        <goals>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report-integration</id>
+                        <goals>
+                            <goal>report-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <!--<minimum>0.10</minimum>-->
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.multi.attribute.login.resolver.regex;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginResolver;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
+import org.wso2.carbon.identity.multi.attribute.login.resolver.regex.utils.UserResolverUtil;
+import org.wso2.carbon.user.api.Claim;
+import org.wso2.carbon.user.api.ClaimManager;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.UniqueIDUserStoreManager;
+import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.common.AuthenticationResult;
+import org.wso2.carbon.user.core.common.User;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * This class is used to implement MultiAttributeLoginResolver. In this class, users will be resolved using a regex
+ * pattern.
+ */
+public class RegexResolver implements MultiAttributeLoginResolver {
+
+    private static final Log log = LogFactory.getLog(RegexResolver.class);
+
+    @Override
+    public ResolvedUserResult resolveUser(String loginAttribute, List<String> allowedAttributes, String tenantDomain) {
+
+        ResolvedUserResult resolvedUserResult = new ResolvedUserResult(ResolvedUserResult.UserResolvedStatus.FAIL);
+        try {
+            UserRealm userRealm = UserResolverUtil.getUserRealm(tenantDomain);
+            UniqueIDUserStoreManager userStoreManager = UserResolverUtil.getUserStoreManager(tenantDomain);
+            ClaimManager claimManager = userRealm.getClaimManager();
+            for (String claimURI : allowedAttributes) {
+                Claim claim = claimManager.getClaim(claimURI);
+                if (claim == null) {
+                    continue;
+                }
+                String regex = claim.getRegEx();
+                if (StringUtils.isBlank(regex)) {
+                    continue;
+                }
+                Pattern pattern = Pattern.compile(regex);
+                if (pattern.matcher(loginAttribute).matches()) {
+                    List<User> userList = userStoreManager.getUserListWithID(claimURI, loginAttribute, null);
+                    if (userList.size() == 1) {
+                        resolvedUserResult.setResolvedStatus(ResolvedUserResult.UserResolvedStatus.SUCCESS);
+                        resolvedUserResult.setResolvedClaim(claimURI);
+                        resolvedUserResult.setResolvedValue(loginAttribute);
+                        resolvedUserResult.setUser(userList.get(0));
+                        break;
+                    } else if (userList.size() > 1) {
+                        resolvedUserResult.setResolvedStatus(ResolvedUserResult.UserResolvedStatus.FAIL);
+                        resolvedUserResult.setErrorMessage("Found multiple users for " + claim.getDisplayTag() +
+                                " to value " + loginAttribute);
+                        break;
+                    }
+                }
+            }
+        } catch (UserStoreException e) {
+            log.error("Error occurred while resolving user name", e);
+        }
+        return resolvedUserResult;
+    }
+
+    @Override
+    public ResolvedUserResult resolveUser(String loginAttribute, List<String> allowedAttributes, String tenantDomain,
+                                          String hint) {
+
+        log.warn("User resolver with hint is not yet implemented. Proceeding without the hint.");
+        return resolveUser(loginAttribute, allowedAttributes, tenantDomain);
+    }
+
+    @Override
+    public AuthenticationResult authenticateWithIdentifier(String loginAttributeValue, List<String> allowedAttributes,
+                                                           Object credential, String tenantDomain) {
+
+        AuthenticationResult authenticationResult =
+                new AuthenticationResult(AuthenticationResult.AuthenticationStatus.FAIL);
+        ClaimManager claimManager;
+        try {
+            UserRealm userRealm = UserResolverUtil.getUserRealm(tenantDomain);
+            UniqueIDUserStoreManager userStoreManager = UserResolverUtil.getUserStoreManager(tenantDomain);
+            claimManager = userRealm.getClaimManager();
+            for (String claimURI : allowedAttributes) {
+                Claim claim = claimManager.getClaim(claimURI);
+                if (claim == null) {
+                    continue;
+                }
+                String regex = claim.getRegEx();
+                if (StringUtils.isBlank(regex)) {
+                    continue;
+                }
+                Pattern pattern = Pattern.compile(regex);
+                if (pattern.matcher(loginAttributeValue).matches()) {
+                    authenticationResult = userStoreManager.
+                            authenticateWithID(claimURI, loginAttributeValue, credential, StringUtils.EMPTY);
+                    if (AuthenticationResult.AuthenticationStatus.SUCCESS.
+                            equals(authenticationResult.getAuthenticationStatus())) {
+                        break;
+                    }
+                }
+            }
+        } catch (UserStoreException e) {
+            log.error("Error occurred while resolving authenticationResult", e);
+        }
+        return authenticationResult;
+    }
+}

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/internal/RegexResolverServiceComponent.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/internal/RegexResolverServiceComponent.java
@@ -42,13 +42,6 @@ public class RegexResolverServiceComponent {
 
     private static final Log log = LogFactory.getLog(RegexResolverServiceComponent.class);
 
-    private static RealmService realmService;
-
-    public static RealmService getRealmService() {
-
-        return realmService;
-    }
-
     @Activate
     protected void activate(ComponentContext context) {
 
@@ -74,11 +67,11 @@ public class RegexResolverServiceComponent {
             unbind = "unsetRealmService")
     protected void setRealmService(RealmService realmService) {
 
-        RegexResolverServiceComponent.realmService = realmService;
+        RegexResolverServiceDataHolder.getInstance().setRealmService(realmService);
     }
 
     protected void unsetRealmService(RealmService realmService) {
 
-        RegexResolverServiceComponent.realmService = null;
+        RegexResolverServiceDataHolder.getInstance().setRealmService(null);
     }
 }

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/internal/RegexResolverServiceComponent.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/internal/RegexResolverServiceComponent.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.multi.attribute.login.resolver.regex.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginResolver;
+import org.wso2.carbon.identity.multi.attribute.login.resolver.regex.RegexResolver;
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ * This class is used to activate MultiAttributeLoginResolver.
+ */
+@Component(
+        name = "identity.multi.attribute.login.resolver.regex.component",
+        immediate = true
+)
+public class RegexResolverServiceComponent {
+
+    private static final Log log = LogFactory.getLog(RegexResolverServiceComponent.class);
+
+    private static RealmService realmService;
+
+    public static RealmService getRealmService() {
+
+        return realmService;
+    }
+
+    @Activate
+    protected void activate(ComponentContext context) {
+
+        BundleContext bundleContext = context.getBundleContext();
+        try {
+            MultiAttributeLoginResolver multiAttributeLoginResolver =
+                    new RegexResolver();
+            bundleContext.registerService(MultiAttributeLoginResolver.class.getName(), multiAttributeLoginResolver,
+                    null);
+            if (log.isDebugEnabled()) {
+                log.debug("MultiAttributeLoginResolver activated successfully.");
+            }
+        } catch (Throwable e) {
+            log.error("Error while activating MultiAttributeLoginResolver.", e);
+        }
+    }
+
+    @Reference(
+            name = "RealmService",
+            service = org.wso2.carbon.user.core.service.RealmService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRealmService")
+    protected void setRealmService(RealmService realmService) {
+
+        RegexResolverServiceComponent.realmService = realmService;
+    }
+
+    protected void unsetRealmService(RealmService realmService) {
+
+        RegexResolverServiceComponent.realmService = null;
+    }
+}

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/internal/RegexResolverServiceDataHolder.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/internal/RegexResolverServiceDataHolder.java
@@ -18,31 +18,33 @@
 
 package org.wso2.carbon.identity.multi.attribute.login.resolver.regex.internal;
 
-import org.mockito.Mock;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
 import org.wso2.carbon.user.core.service.RealmService;
 
-import static org.mockito.MockitoAnnotations.initMocks;
-import static org.testng.Assert.assertNotNull;
+/**
+ * RegexResolverService data holder class
+ */
+public class RegexResolverServiceDataHolder {
 
-public class RegexResolverServiceComponentTest {
-    private RegexResolverServiceDataHolder regexResolverServiceDataHolder;
+    private static RegexResolverServiceDataHolder instance = new RegexResolverServiceDataHolder();
 
-    @Mock
-    RealmService mockRealmService;
+    private RealmService realmService;
 
-    @BeforeTest
-    public void setup() {
-        initMocks(this);
-        regexResolverServiceDataHolder = RegexResolverServiceDataHolder.getInstance();
+    private RegexResolverServiceDataHolder() {
+
     }
 
-    @Test
-    public void testSetRealmService() throws Exception {
+    public static RegexResolverServiceDataHolder getInstance() {
 
-        regexResolverServiceDataHolder.setRealmService(mockRealmService);
-        assertNotNull(regexResolverServiceDataHolder.getRealmService());
+        return instance;
     }
 
+    public RealmService getRealmService() {
+
+        return realmService;
+    }
+
+    public void setRealmService(RealmService realmService) {
+
+        this.realmService = realmService;
+    }
 }

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/utils/UserResolverUtil.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/utils/UserResolverUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.multi.attribute.login.resolver.regex.utils;
+
+import org.wso2.carbon.identity.multi.attribute.login.resolver.regex.internal.RegexResolverServiceComponent;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.UniqueIDUserStoreManager;
+import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ * This is a helper class for regex based user resolve service.
+ */
+public class UserResolverUtil {
+
+    private UserResolverUtil() {
+
+    }
+
+    public static UserRealm getUserRealm(String tenantDomain) throws UserStoreException {
+
+        RealmService realmService = RegexResolverServiceComponent.getRealmService();
+        UserRealm userRealm = null;
+        if (realmService != null) {
+            int tenantId = RegexResolverServiceComponent.getRealmService().getTenantManager().getTenantId(tenantDomain);
+            userRealm = (UserRealm) RegexResolverServiceComponent.getRealmService().getTenantUserRealm(tenantId);
+        }
+        return userRealm;
+    }
+
+    public static UniqueIDUserStoreManager getUserStoreManager(String tenantDomain) throws UserStoreException {
+
+        UserRealm userRealm = getUserRealm(tenantDomain);
+        return (UniqueIDUserStoreManager) userRealm.getUserStoreManager();
+    }
+}

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/utils/UserResolverUtil.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/utils/UserResolverUtil.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.multi.attribute.login.resolver.regex.utils;
 
 import org.wso2.carbon.identity.multi.attribute.login.resolver.regex.internal.RegexResolverServiceComponent;
+import org.wso2.carbon.identity.multi.attribute.login.resolver.regex.internal.RegexResolverServiceDataHolder;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UniqueIDUserStoreManager;
 import org.wso2.carbon.user.core.UserRealm;
@@ -35,11 +36,11 @@ public class UserResolverUtil {
 
     public static UserRealm getUserRealm(String tenantDomain) throws UserStoreException {
 
-        RealmService realmService = RegexResolverServiceComponent.getRealmService();
+        RealmService realmService = RegexResolverServiceDataHolder.getInstance().getRealmService();
         UserRealm userRealm = null;
         if (realmService != null) {
-            int tenantId = RegexResolverServiceComponent.getRealmService().getTenantManager().getTenantId(tenantDomain);
-            userRealm = (UserRealm) RegexResolverServiceComponent.getRealmService().getTenantUserRealm(tenantId);
+            int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
+            userRealm = (UserRealm) realmService.getTenantUserRealm(tenantId);
         }
         return userRealm;
     }

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/test/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolverTest.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/test/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolverTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.multi.attribute.login.resolver.regex;
+
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.IObjectFactory;
+import org.testng.annotations.ObjectFactory;
+import org.testng.annotations.Test;
+import org.mockito.Mock;
+import org.testng.annotations.BeforeTest;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
+import org.wso2.carbon.identity.multi.attribute.login.resolver.regex.internal.RegexResolverServiceComponent;
+import org.wso2.carbon.identity.multi.attribute.login.resolver.regex.utils.UserResolverUtil;
+import org.wso2.carbon.user.api.Claim;
+import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.UniqueIDUserStoreManager;
+import org.wso2.carbon.user.core.claim.ClaimManager;
+import org.wso2.carbon.user.core.common.User;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.tenant.TenantManager;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+@PrepareForTest({RegexResolverServiceComponent.class, User.class, ResolvedUserResult.class})
+public class RegexResolverTest {
+
+    private RegexResolver regexResolver;
+    private List<User> userList;
+    private List<String> allowedAttributes;
+    private User user;
+    private static final String TEST_CLAIM_URI = "http://wso2.org/claims/telephone";
+    private static final String TEST_CLAIM_REGEX = "^(\\+\\d{1,2}\\s?)?1?\\-?\\.?\\s?\\(?\\d{3}\\)?[\\s.-]?\\d{3}[\\s.-]?\\d{4}$";
+    private static final String TEST_LOGIN_IDENTIFIER = "+99777521771";
+    private static final String TEST_TENANT_DOMAIN = "testTenantDomain";
+
+    @Mock
+    UniqueIDUserStoreManager mockUserStoreManager;
+
+    @Mock
+    UserRealm mockUserRealm;
+
+    @Mock
+    RealmService mockRealmService;
+
+    @Mock
+    ClaimManager mockClaimManager;
+
+    @Mock
+    Claim mockClaim;
+
+    @Mock
+    TenantManager mockTenantManager;
+
+    @BeforeTest
+    public void init() throws Exception {
+
+        initMocks(this);
+        regexResolver = new RegexResolver();
+        allowedAttributes = new ArrayList<>();
+        allowedAttributes.add(TEST_CLAIM_URI);
+        user = new User();
+        user.setUsername("chathuranga");
+        userList = new ArrayList<>();
+        userList.add(user);
+    }
+
+    @Test
+    public void testResolveUser() throws Exception {
+
+        mockStatic(RegexResolverServiceComponent.class);
+        when(RegexResolverServiceComponent.getRealmService()).thenReturn(mockRealmService);
+        when(mockRealmService.getTenantManager()).thenReturn(mockTenantManager);
+        when(mockTenantManager.getTenantId(TEST_TENANT_DOMAIN)).thenReturn(-1234);
+        when(mockUserRealm.getClaimManager()).thenReturn(mockClaimManager);
+        when(mockUserRealm.getUserStoreManager()).thenReturn(mockUserStoreManager);
+        when(mockClaimManager.getClaim(TEST_CLAIM_URI)).thenReturn(mockClaim);
+        when(mockClaim.getRegEx()).thenReturn(TEST_CLAIM_REGEX);
+        when(UserResolverUtil.getUserRealm(TEST_TENANT_DOMAIN)).thenReturn(mockUserRealm);
+        when(UserResolverUtil.getUserStoreManager(TEST_TENANT_DOMAIN)).thenReturn(mockUserStoreManager);
+        when(mockUserStoreManager.getUserListWithID(TEST_CLAIM_URI, TEST_LOGIN_IDENTIFIER, null)).
+                thenReturn(userList);
+        mockStatic(ResolvedUserResult.class);
+        regexResolver.resolveUser(TEST_LOGIN_IDENTIFIER, allowedAttributes, TEST_TENANT_DOMAIN, "hint");
+        assertEquals(regexResolver.resolveUser(TEST_LOGIN_IDENTIFIER, allowedAttributes,
+                TEST_TENANT_DOMAIN).getUser().getUsername(), "chathuranga");
+        assertNotEquals(regexResolver.resolveUser(TEST_LOGIN_IDENTIFIER,
+                allowedAttributes, TEST_TENANT_DOMAIN).getUser().getUsername(), "+99777521771");
+    }
+
+    @ObjectFactory
+    public IObjectFactory getObjectFactory() {
+
+        return new org.powermock.modules.testng.PowerMockObjectFactory();
+    }
+}

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/test/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolverTest.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/test/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolverTest.java
@@ -26,6 +26,7 @@ import org.mockito.Mock;
 import org.testng.annotations.BeforeTest;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
 import org.wso2.carbon.identity.multi.attribute.login.resolver.regex.internal.RegexResolverServiceComponent;
+import org.wso2.carbon.identity.multi.attribute.login.resolver.regex.internal.RegexResolverServiceDataHolder;
 import org.wso2.carbon.identity.multi.attribute.login.resolver.regex.utils.UserResolverUtil;
 import org.wso2.carbon.user.api.Claim;
 import org.wso2.carbon.user.core.UserRealm;
@@ -45,7 +46,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
-@PrepareForTest({RegexResolverServiceComponent.class, User.class, ResolvedUserResult.class})
+@PrepareForTest({RegexResolverServiceDataHolder.class, User.class, ResolvedUserResult.class})
 public class RegexResolverTest {
 
     private RegexResolver regexResolver;
@@ -75,6 +76,9 @@ public class RegexResolverTest {
     @Mock
     TenantManager mockTenantManager;
 
+    @Mock
+    RegexResolverServiceDataHolder mockRegexResolverServiceDataHolder;
+
     @BeforeTest
     public void init() throws Exception {
 
@@ -91,8 +95,9 @@ public class RegexResolverTest {
     @Test
     public void testResolveUser() throws Exception {
 
-        mockStatic(RegexResolverServiceComponent.class);
-        when(RegexResolverServiceComponent.getRealmService()).thenReturn(mockRealmService);
+        mockStatic(RegexResolverServiceDataHolder.class);
+        when(RegexResolverServiceDataHolder.getInstance()).thenReturn(mockRegexResolverServiceDataHolder);
+        when(mockRegexResolverServiceDataHolder.getRealmService()).thenReturn(mockRealmService);
         when(mockRealmService.getTenantManager()).thenReturn(mockTenantManager);
         when(mockTenantManager.getTenantId(TEST_TENANT_DOMAIN)).thenReturn(-1234);
         when(mockUserRealm.getClaimManager()).thenReturn(mockClaimManager);

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/test/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/internal/RegexResolverServiceComponentTest.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/test/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/internal/RegexResolverServiceComponentTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.multi.attribute.login.resolver.regex.internal;
+
+import org.mockito.Mock;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.wso2.carbon.user.core.service.RealmService;
+
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.testng.Assert.assertNotNull;
+
+public class RegexResolverServiceComponentTest {
+    private RegexResolverServiceComponent regexResolverServiceComponent;
+
+    @Mock
+    RealmService mockRealmService;
+
+    @BeforeTest
+    public void setup() {
+        initMocks(this);
+        regexResolverServiceComponent = new RegexResolverServiceComponent();
+    }
+
+    @Test
+    public void testSetRealmService() throws Exception {
+
+        regexResolverServiceComponent.setRealmService(mockRealmService);
+        assertNotNull(regexResolverServiceComponent.getRealmService());
+    }
+
+}

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/test/resources/testng.xml
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/test/resources/testng.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Identity-Governance-Multi-Attribute-Login-Regex-Resolver-Test-Suite">
+    <test name="Util-Tests" preserve-order="true" parallel="false">
+        <parameter name="log-level" value="info"/>
+        <classes>
+            <class name="org.wso2.carbon.identity.multi.attribute.login.resolver.regex.RegexResolverTest" />
+            <class name="org.wso2.carbon.identity.multi.attribute.login.resolver.regex.internal.RegexResolverServiceComponentTest" />
+        </classes>
+    </test>
+</suite>

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/pom.xml
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/pom.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>identity-governance</artifactId>
+        <groupId>org.wso2.carbon.identity.governance</groupId>
+        <version>1.4.92-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.multi.attribute.login.service</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Multi Attribute Login - Service</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.multi.attribute.login.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.governance</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Import-Package>
+                            org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
+                            org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.common.*;version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.event.*; version="${project.version}",
+                            org.wso2.carbon.identity.governance.common;
+                            version="${identity.governance.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.governance;version="${identity.governance.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.multi.attribute.login.mgt.*;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.user.core.*; version="${carbon.kernel.package.import.version.range}",
+                        </Import-Package>
+                        <Export-Package>
+                            org.wso2.carbon.identity.multi.attribute.login.*;
+                            version="${project.version}",
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-prepare-agent-integration</id>
+                        <goals>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report-integration</id>
+                        <goals>
+                            <goal>report-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/constants/MultiAttributeLoginConstants.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/constants/MultiAttributeLoginConstants.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.multi.attribute.login.constants;
+
+/**
+ * Multi attribute login related constants.
+ */
+public class MultiAttributeLoginConstants {
+
+    public static final String USERNAME_CLAIM_URI = "http://wso2.org/claims/username";
+
+    public static final String MULTI_ATTRIBUTE_LOGIN_PROPERTY = "account.multiattributelogin.handler.enable";
+    public static final String ALLOWED_LOGIN_ATTRIBUTES = "account.multiattributelogin.handler.allowedattributes";
+
+    public static final String HANDLER_NAME = "multiattribute.login.handler";
+    public static final String HANDLER_FRIENDLY_NAME = "Multi Attribute Login";
+    public static final String HANDLER_CATEGORY = "Login Policies";
+    public static final String HANDLER_SUB_CATEGORY = "DEFAULT";
+
+    public static final class MultiAttributeLoginNameMapping {
+
+        public static final String MULTI_ATTRIBUTE_LOGIN_PROPERTY_NAME_MAPPING = "Enable Multi Attribute Login";
+        public static final String ALLOWED_LOGIN_ATTRIBUTES_NAME_MAPPING = "Allowed Attribute Claim List";
+    }
+
+    public static final class MultiAttributeLoginDescriptionMapping {
+        public static final String MULTI_ATTRIBUTE_LOGIN_PROPERTY_DESCRIPTION_MAPPING = "Enable using multiple " +
+                "attributes as login identifier";
+        public static final String ALLOWED_LOGIN_ATTRIBUTES_DESCRIPTION_MAPPING = "Allowed claim list separated by commas";
+
+    }
+
+}

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/constants/MultiAttributeLoginConstants.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/constants/MultiAttributeLoginConstants.java
@@ -30,7 +30,7 @@ public class MultiAttributeLoginConstants {
 
     public static final String HANDLER_NAME = "multiattribute.login.handler";
     public static final String HANDLER_FRIENDLY_NAME = "Multi Attribute Login";
-    public static final String HANDLER_CATEGORY = "Login Policies";
+    public static final String HANDLER_CATEGORY = "Account Management";
     public static final String HANDLER_SUB_CATEGORY = "DEFAULT";
 
     public static final class MultiAttributeLoginNameMapping {

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/handler/MultiAttributeLoginHandler.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/handler/MultiAttributeLoginHandler.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.multi.attribute.login.handler;
+
+import org.wso2.carbon.identity.governance.IdentityGovernanceException;
+import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
+import org.wso2.carbon.identity.multi.attribute.login.constants.MultiAttributeLoginConstants;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * This handler is used to manage multi attribute login configurations in carbon console.
+ */
+public class MultiAttributeLoginHandler implements IdentityConnectorConfig {
+
+    @Override
+    public String getName() {
+
+        return MultiAttributeLoginConstants.HANDLER_NAME;
+    }
+
+    @Override
+    public String getFriendlyName() {
+
+        return MultiAttributeLoginConstants.HANDLER_FRIENDLY_NAME;
+    }
+
+    @Override
+    public String getCategory() {
+
+        return MultiAttributeLoginConstants.HANDLER_CATEGORY;
+    }
+
+    @Override
+    public String getSubCategory() {
+
+        return MultiAttributeLoginConstants.HANDLER_SUB_CATEGORY;
+    }
+
+    @Override
+    public int getOrder() {
+
+        return 0;
+    }
+
+    @Override
+    public Map<String, String> getPropertyNameMapping() {
+
+        Map<String, String> nameMapping = new HashMap<>();
+        nameMapping.put(MultiAttributeLoginConstants.MULTI_ATTRIBUTE_LOGIN_PROPERTY,
+                MultiAttributeLoginConstants.MultiAttributeLoginNameMapping.MULTI_ATTRIBUTE_LOGIN_PROPERTY_NAME_MAPPING);
+        nameMapping.put(MultiAttributeLoginConstants.ALLOWED_LOGIN_ATTRIBUTES,
+                MultiAttributeLoginConstants.MultiAttributeLoginNameMapping.ALLOWED_LOGIN_ATTRIBUTES_NAME_MAPPING);
+        return nameMapping;
+    }
+
+    @Override
+    public Map<String, String> getPropertyDescriptionMapping() {
+
+        Map<String, String> descriptionMapping = new HashMap<>();
+        descriptionMapping.put(MultiAttributeLoginConstants.MULTI_ATTRIBUTE_LOGIN_PROPERTY,
+                MultiAttributeLoginConstants.MultiAttributeLoginDescriptionMapping.MULTI_ATTRIBUTE_LOGIN_PROPERTY_DESCRIPTION_MAPPING);
+        descriptionMapping.put(MultiAttributeLoginConstants.ALLOWED_LOGIN_ATTRIBUTES,
+                MultiAttributeLoginConstants.MultiAttributeLoginDescriptionMapping.ALLOWED_LOGIN_ATTRIBUTES_DESCRIPTION_MAPPING);
+        return descriptionMapping;
+    }
+
+    @Override
+    public String[] getPropertyNames() {
+
+        List<String> properties = new ArrayList<>();
+        properties.add(MultiAttributeLoginConstants.MULTI_ATTRIBUTE_LOGIN_PROPERTY);
+        properties.add(MultiAttributeLoginConstants.ALLOWED_LOGIN_ATTRIBUTES);
+        return properties.toArray(new String[0]);
+    }
+
+    @Override
+    public Properties getDefaultPropertyValues(String s) {
+
+        Map<String, String> defaultProperties = new HashMap<>();
+        defaultProperties.put(MultiAttributeLoginConstants.MULTI_ATTRIBUTE_LOGIN_PROPERTY, "false");
+        defaultProperties.put(MultiAttributeLoginConstants.ALLOWED_LOGIN_ATTRIBUTES,
+                MultiAttributeLoginConstants.USERNAME_CLAIM_URI);
+        Properties properties = new Properties();
+        properties.putAll(defaultProperties);
+        return properties;
+    }
+
+    @Override
+    public Map<String, String> getDefaultPropertyValues(String[] strings, String s) throws IdentityGovernanceException {
+
+        Map<String, String> defaultProperties = new HashMap<>();
+        defaultProperties.put(MultiAttributeLoginConstants.MULTI_ATTRIBUTE_LOGIN_PROPERTY, "false");
+        defaultProperties.put(MultiAttributeLoginConstants.ALLOWED_LOGIN_ATTRIBUTES,
+                MultiAttributeLoginConstants.USERNAME_CLAIM_URI);
+        return defaultProperties;
+    }
+}
+

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/internal/MultiAttributeLoginDataHolder.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/internal/MultiAttributeLoginDataHolder.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.multi.attribute.login.internal;
+
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginResolver;
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ * Multi attribute login service data holder class
+ */
+public class MultiAttributeLoginDataHolder {
+
+    private static MultiAttributeLoginDataHolder instance = new MultiAttributeLoginDataHolder();
+    private RealmService realmService;
+    private IdentityGovernanceService identityGovernanceService;
+    private MultiAttributeLoginResolver multiAttributeLoginResolver;
+
+    private MultiAttributeLoginDataHolder() {
+
+    }
+
+    public static MultiAttributeLoginDataHolder getInstance() {
+
+        return instance;
+    }
+
+    public RealmService getRealmService() {
+
+        return realmService;
+    }
+
+    public void setRealmService(RealmService realmService) {
+
+        this.realmService = realmService;
+    }
+
+    public IdentityGovernanceService getIdentityGovernanceService() {
+
+        return identityGovernanceService;
+    }
+
+    public void setIdentityGovernanceService(IdentityGovernanceService identityGovernanceService) {
+
+        this.identityGovernanceService = identityGovernanceService;
+    }
+
+    public MultiAttributeLoginResolver getMultiAttributeLoginResolver() {
+
+        return multiAttributeLoginResolver;
+    }
+
+    public void setMultiAttributeLoginResolver(MultiAttributeLoginResolver multiAttributeLoginResolver) {
+
+        this.multiAttributeLoginResolver = multiAttributeLoginResolver;
+    }
+}

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/internal/MultiAttributeLoginServiceComponent.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/internal/MultiAttributeLoginServiceComponent.java
@@ -45,24 +45,6 @@ import org.wso2.carbon.user.core.service.RealmService;
 public class MultiAttributeLoginServiceComponent {
 
     private static final Log log = LogFactory.getLog(MultiAttributeLoginServiceComponent.class);
-    private static RealmService realmService;
-    private static IdentityGovernanceService identityGovernanceService;
-    private static MultiAttributeLoginResolver multiAttributeLoginResolver;
-
-    public static MultiAttributeLoginResolver getMultiAttributeLoginResolver() {
-
-        return multiAttributeLoginResolver;
-    }
-
-    public static RealmService getRealmService() {
-
-        return realmService;
-    }
-
-    public static IdentityGovernanceService getIdentityGovernanceService() {
-
-        return identityGovernanceService;
-    }
 
     @Activate
     protected void activate(ComponentContext context) {
@@ -98,12 +80,12 @@ public class MultiAttributeLoginServiceComponent {
             unbind = "unsetRealmService")
     protected void setRealmService(RealmService realmService) {
 
-        MultiAttributeLoginServiceComponent.realmService = realmService;
+        MultiAttributeLoginDataHolder.getInstance().setRealmService(realmService);
     }
 
     protected void unsetRealmService(RealmService realmService) {
 
-        MultiAttributeLoginServiceComponent.realmService = null;
+        MultiAttributeLoginDataHolder.getInstance().setRealmService(null);
     }
 
     @Reference(
@@ -115,12 +97,12 @@ public class MultiAttributeLoginServiceComponent {
     )
     protected void setMultiAttributeLoginResolver(MultiAttributeLoginResolver multiAttributeLoginResolver) {
 
-        MultiAttributeLoginServiceComponent.multiAttributeLoginResolver = multiAttributeLoginResolver;
+        MultiAttributeLoginDataHolder.getInstance().setMultiAttributeLoginResolver(multiAttributeLoginResolver);
     }
 
     protected void unsetMultiAttributeLoginResolver(MultiAttributeLoginResolver multiAttributeLoginResolver) {
 
-        MultiAttributeLoginServiceComponent.multiAttributeLoginResolver = null;
+        MultiAttributeLoginDataHolder.getInstance().setMultiAttributeLoginResolver(null);
     }
 
     @Reference(
@@ -132,11 +114,11 @@ public class MultiAttributeLoginServiceComponent {
     )
     protected void setIdentityGovernanceService(IdentityGovernanceService identityGovernanceService) {
 
-        MultiAttributeLoginServiceComponent.identityGovernanceService = identityGovernanceService;
+        MultiAttributeLoginDataHolder.getInstance().setIdentityGovernanceService(identityGovernanceService);
     }
 
     protected void unsetIdentityGovernanceService(IdentityGovernanceService identityGovernanceService) {
 
-        MultiAttributeLoginServiceComponent.identityGovernanceService = null;
+        MultiAttributeLoginDataHolder.getInstance().setIdentityGovernanceService(null);
     }
 }

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/internal/MultiAttributeLoginServiceComponent.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/internal/MultiAttributeLoginServiceComponent.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.multi.attribute.login.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
+import org.wso2.carbon.identity.multi.attribute.login.handler.MultiAttributeLoginHandler;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginResolver;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
+import org.wso2.carbon.identity.multi.attribute.login.service.MultiAttributeLoginServiceServiceImpl;
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ * This class is used to activate MultiAttributeLoginService.
+ */
+@Component(
+        name = "identity.core.multi.attribute.login.component",
+        immediate = true
+)
+public class MultiAttributeLoginServiceComponent {
+
+    private static final Log log = LogFactory.getLog(MultiAttributeLoginServiceComponent.class);
+    private static RealmService realmService;
+    private static IdentityGovernanceService identityGovernanceService;
+    private static MultiAttributeLoginResolver multiAttributeLoginResolver;
+
+    public static MultiAttributeLoginResolver getMultiAttributeLoginResolver() {
+
+        return multiAttributeLoginResolver;
+    }
+
+    public static RealmService getRealmService() {
+
+        return realmService;
+    }
+
+    public static IdentityGovernanceService getIdentityGovernanceService() {
+
+        return identityGovernanceService;
+    }
+
+    @Activate
+    protected void activate(ComponentContext context) {
+
+        BundleContext bundleContext = context.getBundleContext();
+        try {
+            IdentityConnectorConfig multiAttributeLoginHandler = new MultiAttributeLoginHandler();
+            bundleContext.registerService(IdentityConnectorConfig.class.getName(),
+                    multiAttributeLoginHandler, null);
+            if (log.isDebugEnabled()) {
+                log.debug("MultiAttributeLoginHandler is registered.");
+            }
+        } catch (Throwable e) {
+            log.error("Error while activating MultiAttributeLoginHandler.", e);
+        }
+        try {
+            MultiAttributeLoginService multiAttributeLoginService = new MultiAttributeLoginServiceServiceImpl();
+            bundleContext.registerService(MultiAttributeLoginService.class.getName(),
+                    multiAttributeLoginService, null);
+            if (log.isDebugEnabled()) {
+                log.debug("MultiAttributeLoginService is registered.");
+            }
+        } catch (Throwable e) {
+            log.error("Error while activating multi attribute login bundle.", e);
+        }
+    }
+
+    @Reference(
+            name = "RealmService",
+            service = org.wso2.carbon.user.core.service.RealmService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRealmService")
+    protected void setRealmService(RealmService realmService) {
+
+        MultiAttributeLoginServiceComponent.realmService = realmService;
+    }
+
+    protected void unsetRealmService(RealmService realmService) {
+
+        MultiAttributeLoginServiceComponent.realmService = null;
+    }
+
+    @Reference(
+            name = "MultiAttributeLoginResolver",
+            service = MultiAttributeLoginResolver.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetMultiAttributeLoginResolver"
+    )
+    protected void setMultiAttributeLoginResolver(MultiAttributeLoginResolver multiAttributeLoginResolver) {
+
+        MultiAttributeLoginServiceComponent.multiAttributeLoginResolver = multiAttributeLoginResolver;
+    }
+
+    protected void unsetMultiAttributeLoginResolver(MultiAttributeLoginResolver multiAttributeLoginResolver) {
+
+        MultiAttributeLoginServiceComponent.multiAttributeLoginResolver = null;
+    }
+
+    @Reference(
+            name = "IdentityGovernanceService",
+            service = IdentityGovernanceService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdentityGovernanceService"
+    )
+    protected void setIdentityGovernanceService(IdentityGovernanceService identityGovernanceService) {
+
+        MultiAttributeLoginServiceComponent.identityGovernanceService = identityGovernanceService;
+    }
+
+    protected void unsetIdentityGovernanceService(IdentityGovernanceService identityGovernanceService) {
+
+        MultiAttributeLoginServiceComponent.identityGovernanceService = null;
+    }
+}

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/service/MultiAttributeLoginServiceServiceImpl.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/service/MultiAttributeLoginServiceServiceImpl.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.multi.attribute.login.constants.MultiAttributeLoginConstants;
+import org.wso2.carbon.identity.multi.attribute.login.internal.MultiAttributeLoginDataHolder;
 import org.wso2.carbon.identity.multi.attribute.login.internal.MultiAttributeLoginServiceComponent;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
@@ -104,7 +105,7 @@ public class MultiAttributeLoginServiceServiceImpl implements MultiAttributeLogi
                 new AuthenticationResult(AuthenticationResult.AuthenticationStatus.FAIL);
         if (StringUtils.isNotBlank(loginIdentifierValue) && StringUtils.isNotBlank(tenantDomain)) {
             List<String> allowedAttributes = getAllowedClaimsForTenant(tenantDomain);
-            authenticationResult = MultiAttributeLoginServiceComponent.getMultiAttributeLoginResolver().
+            authenticationResult = MultiAttributeLoginDataHolder.getInstance().getMultiAttributeLoginResolver().
                     authenticateWithIdentifier(loginIdentifierValue, allowedAttributes, credential, tenantDomain);
         }
         return authenticationResult;
@@ -123,7 +124,7 @@ public class MultiAttributeLoginServiceServiceImpl implements MultiAttributeLogi
         ResolvedUserResult resolvedUserResult = new ResolvedUserResult(ResolvedUserResult.UserResolvedStatus.FAIL);
         if (StringUtils.isNotBlank(loginIdentifierValue) && StringUtils.isNotBlank(tenantDomain)) {
             List<String> allowedAttributes = getAllowedClaimsForTenant(tenantDomain);
-            resolvedUserResult = MultiAttributeLoginServiceComponent.getMultiAttributeLoginResolver().
+            resolvedUserResult = MultiAttributeLoginDataHolder.getInstance().getMultiAttributeLoginResolver().
                     resolveUser(loginIdentifierValue, allowedAttributes, tenantDomain);
         }
         return resolvedUserResult;
@@ -143,7 +144,7 @@ public class MultiAttributeLoginServiceServiceImpl implements MultiAttributeLogi
         ResolvedUserResult resolvedUserResult = new ResolvedUserResult(ResolvedUserResult.UserResolvedStatus.FAIL);
         if (StringUtils.isNotBlank(loginIdentifierValue) && StringUtils.isNotBlank(tenantDomain)) {
             List<String> allowedClaimList = getAllowedClaimsForTenant(tenantDomain);
-            resolvedUserResult = MultiAttributeLoginServiceComponent.getMultiAttributeLoginResolver().
+            resolvedUserResult = MultiAttributeLoginDataHolder.getInstance().getMultiAttributeLoginResolver().
                     resolveUser(loginIdentifierValue, allowedClaimList, tenantDomain, hint);
         }
         return resolvedUserResult;

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/service/MultiAttributeLoginServiceServiceImpl.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/service/MultiAttributeLoginServiceServiceImpl.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.multi.attribute.login.service;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.multi.attribute.login.constants.MultiAttributeLoginConstants;
+import org.wso2.carbon.identity.multi.attribute.login.internal.MultiAttributeLoginServiceComponent;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
+import org.wso2.carbon.identity.multi.attribute.login.utill.MultiAttributeLoginUtil;
+import org.wso2.carbon.user.core.common.AuthenticationResult;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This service provides the services needed to multi attribute login.
+ */
+public class MultiAttributeLoginServiceServiceImpl implements MultiAttributeLoginService {
+
+    private static final Log log = LogFactory.getLog(MultiAttributeLoginServiceServiceImpl.class);
+
+    /**
+     * This method is used to determine whether the multi attribute login feature is enable or disable.
+     *
+     * @param tenantDomain User tenant domain.
+     * @return True if multi attribute login is enabled for given tenant, otherwise return false.
+     */
+    @Override
+    public boolean isEnabled(String tenantDomain) {
+
+        if (StringUtils.isNotBlank(tenantDomain)) {
+            try {
+                return Boolean.parseBoolean(MultiAttributeLoginUtil.getConnectorConfig(MultiAttributeLoginConstants
+                        .MULTI_ATTRIBUTE_LOGIN_PROPERTY, tenantDomain));
+            } catch (IdentityEventException e) {
+                log.error("Error occurred while retrieving multi attribute login property.", e);
+            }
+        }
+        return false;
+    }
+
+    /**
+     * This method is used to get list of claim URIs which are enable for multi attribute login on given tenant domain.
+     *
+     * @param tenantDomain User tenant domain.
+     * @return Multi attribute login enabled claim URI list.
+     */
+    public List<String> getAllowedClaimsForTenant(String tenantDomain) {
+
+        List<String> allowedClaimsList = new ArrayList<>();
+        if (StringUtils.isNotBlank(tenantDomain)) {
+            try {
+                String claimList = MultiAttributeLoginUtil.
+                        getConnectorConfig(MultiAttributeLoginConstants.ALLOWED_LOGIN_ATTRIBUTES, tenantDomain);
+                if (StringUtils.isNotBlank(claimList)) {
+                    claimList = StringUtils.deleteWhitespace(claimList);
+                    allowedClaimsList = Arrays.asList(claimList.split(","));
+                }
+
+            } catch (IdentityEventException e) {
+                log.error("Error occurred while retrieving allowed login claims.", e);
+            }
+        }
+        if (allowedClaimsList.isEmpty()) {
+            allowedClaimsList.add(MultiAttributeLoginConstants.USERNAME_CLAIM_URI);
+        }
+        return allowedClaimsList;
+    }
+
+    /**
+     * This method is used to authenticate user using multi attribute login identifier.
+     *
+     * @param loginIdentifierValue User entered login identifier.
+     * @param credential           User credential.
+     * @param tenantDomain         User tenant domain.
+     * @return AuthenticationResult.
+     */
+    @Override
+    public AuthenticationResult authenticateWithIdentifier(String loginIdentifierValue, Object credential,
+                                                           String tenantDomain) {
+
+        AuthenticationResult authenticationResult =
+                new AuthenticationResult(AuthenticationResult.AuthenticationStatus.FAIL);
+        if (StringUtils.isNotBlank(loginIdentifierValue) && StringUtils.isNotBlank(tenantDomain)) {
+            List<String> allowedAttributes = getAllowedClaimsForTenant(tenantDomain);
+            authenticationResult = MultiAttributeLoginServiceComponent.getMultiAttributeLoginResolver().
+                    authenticateWithIdentifier(loginIdentifierValue, allowedAttributes, credential, tenantDomain);
+        }
+        return authenticationResult;
+    }
+
+    /**
+     * This method is used to resolve user from given login identifier.
+     *
+     * @param loginIdentifierValue User entered login identifier value.
+     * @param tenantDomain         User tenant domain.
+     * @return ResolvedUserResult object with resolved user and resolved login identifier claim.
+     */
+    @Override
+    public ResolvedUserResult resolveUser(String loginIdentifierValue, String tenantDomain) {
+
+        ResolvedUserResult resolvedUserResult = new ResolvedUserResult(ResolvedUserResult.UserResolvedStatus.FAIL);
+        if (StringUtils.isNotBlank(loginIdentifierValue) && StringUtils.isNotBlank(tenantDomain)) {
+            List<String> allowedAttributes = getAllowedClaimsForTenant(tenantDomain);
+            resolvedUserResult = MultiAttributeLoginServiceComponent.getMultiAttributeLoginResolver().
+                    resolveUser(loginIdentifierValue, allowedAttributes, tenantDomain);
+        }
+        return resolvedUserResult;
+    }
+
+    /**
+     * This method is used to resolve user from given login identifier and hint.
+     *
+     * @param loginIdentifierValue Multi attribute login identifier value.
+     * @param tenantDomain         User tenant domain.
+     * @param hint                 Claim URI of the login attribute as a hint.
+     * @return ResolvedUserResult object with resolved user and resolved login identifier claim.
+     */
+    @Override
+    public ResolvedUserResult resolveUser(String loginIdentifierValue, String tenantDomain, String hint) {
+
+        ResolvedUserResult resolvedUserResult = new ResolvedUserResult(ResolvedUserResult.UserResolvedStatus.FAIL);
+        if (StringUtils.isNotBlank(loginIdentifierValue) && StringUtils.isNotBlank(tenantDomain)) {
+            List<String> allowedClaimList = getAllowedClaimsForTenant(tenantDomain);
+            resolvedUserResult = MultiAttributeLoginServiceComponent.getMultiAttributeLoginResolver().
+                    resolveUser(loginIdentifierValue, allowedClaimList, tenantDomain, hint);
+        }
+        return resolvedUserResult;
+    }
+}

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/utill/MultiAttributeLoginUtil.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/utill/MultiAttributeLoginUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.multi.attribute.login.utill;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.governance.IdentityGovernanceException;
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.multi.attribute.login.internal.MultiAttributeLoginServiceComponent;
+
+/**
+ * This is utility class used for returning connector configurations.
+ */
+public class MultiAttributeLoginUtil {
+
+    public static String getConnectorConfig(String key, String tenantDomain) throws IdentityEventException {
+
+        try {
+            Property[] connectorConfigs;
+            IdentityGovernanceService identityGovernanceService = MultiAttributeLoginServiceComponent
+                    .getIdentityGovernanceService();
+            if (identityGovernanceService != null) {
+                connectorConfigs = identityGovernanceService.getConfiguration(new String[]{key}, tenantDomain);
+                if (connectorConfigs != null && connectorConfigs.length > 0) {
+                    return connectorConfigs[0].getValue();
+                }
+            }
+            return StringUtils.EMPTY;
+        } catch (IdentityGovernanceException e) {
+            throw new IdentityEventException("Error while getting connector configurations for property :" + key, e);
+        }
+    }
+}
+

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/utill/MultiAttributeLoginUtil.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/utill/MultiAttributeLoginUtil.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.governance.IdentityGovernanceException;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.multi.attribute.login.internal.MultiAttributeLoginDataHolder;
 import org.wso2.carbon.identity.multi.attribute.login.internal.MultiAttributeLoginServiceComponent;
 
 /**
@@ -34,7 +35,7 @@ public class MultiAttributeLoginUtil {
 
         try {
             Property[] connectorConfigs;
-            IdentityGovernanceService identityGovernanceService = MultiAttributeLoginServiceComponent
+            IdentityGovernanceService identityGovernanceService = MultiAttributeLoginDataHolder.getInstance()
                     .getIdentityGovernanceService();
             if (identityGovernanceService != null) {
                 connectorConfigs = identityGovernanceService.getConfiguration(new String[]{key}, tenantDomain);

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/test/java/org/wso2/carbon/identity/multi/attribute/login/handler/MultiAttributeLoginHandlerTest.java
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/test/java/org/wso2/carbon/identity/multi/attribute/login/handler/MultiAttributeLoginHandlerTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.multi.attribute.login.handler;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.multi.attribute.login.constants.MultiAttributeLoginConstants;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+
+public class MultiAttributeLoginHandlerTest {
+
+    MultiAttributeLoginHandler multiAttributeLoginHandler;
+
+    @BeforeMethod
+    public void setUp() {
+
+        initMocks(this);
+        multiAttributeLoginHandler = new MultiAttributeLoginHandler();
+    }
+
+    @Test
+    public void testGetName() {
+
+        assertEquals(multiAttributeLoginHandler.getName(),
+                MultiAttributeLoginConstants.HANDLER_NAME, "Valid handler name.");
+        assertNotEquals(multiAttributeLoginHandler.getName(),
+                "multiattrssibute.logins.handler", "Invalid handler name.");
+        assertFalse(Boolean.parseBoolean(multiAttributeLoginHandler.getName()),
+                "Invalid handler name.");
+    }
+
+    @Test
+    public void testGetFriendlyName() {
+
+        assertEquals(multiAttributeLoginHandler.getFriendlyName(),
+                MultiAttributeLoginConstants.HANDLER_FRIENDLY_NAME, "Valid FriendlyName.");
+        assertNotEquals(multiAttributeLoginHandler.getFriendlyName(),
+                "MultiAttributer Login", "Invalid FriendlyName.");
+    }
+
+    @Test
+    public void testGetCategory() {
+
+        assertEquals(multiAttributeLoginHandler.getCategory(),
+                MultiAttributeLoginConstants.HANDLER_CATEGORY, "Valid Category.");
+        assertNotEquals(multiAttributeLoginHandler.getCategory(),
+                "LoginPolicies", "Invalid Category");
+
+    }
+
+    @Test
+    public void testGetSubCategory() {
+
+        assertEquals(multiAttributeLoginHandler.getSubCategory(),
+                "DEFAULT", "Valid SubCategory.");
+        assertNotEquals(multiAttributeLoginHandler.getSubCategory(),
+                "LoginPolicies", "Invalid SubCategory.");
+
+    }
+
+    @Test
+    public void testGetOrder() {
+
+        assertEquals(multiAttributeLoginHandler.getOrder(),
+                0, "Valid order.");
+        assertNotEquals(multiAttributeLoginHandler.getOrder(),
+                2, "Invalid order.");
+    }
+
+    @Test
+    public void testGetPropertyNameMapping() {
+
+        Map<String, String> expectedMappingTrue = new HashMap<>();
+        expectedMappingTrue.put(MultiAttributeLoginConstants.MULTI_ATTRIBUTE_LOGIN_PROPERTY,
+                MultiAttributeLoginConstants.MultiAttributeLoginNameMapping.MULTI_ATTRIBUTE_LOGIN_PROPERTY_NAME_MAPPING);
+        expectedMappingTrue.put(MultiAttributeLoginConstants.ALLOWED_LOGIN_ATTRIBUTES,
+                MultiAttributeLoginConstants.MultiAttributeLoginNameMapping.ALLOWED_LOGIN_ATTRIBUTES_NAME_MAPPING);
+        assertEquals(multiAttributeLoginHandler.getPropertyNameMapping(), expectedMappingTrue,
+                "Valid property name mapping.");
+
+        Map<String, String> expectedMappingFalse = new HashMap<>();
+        expectedMappingFalse.put(MultiAttributeLoginConstants.MULTI_ATTRIBUTE_LOGIN_PROPERTY,
+                "EnableMultiAttributeLogin");
+        expectedMappingFalse.put(MultiAttributeLoginConstants.ALLOWED_LOGIN_ATTRIBUTES,
+                "AllowedAttributeClaimList");
+        assertNotEquals(multiAttributeLoginHandler.getPropertyNameMapping(), expectedMappingFalse,
+                "Invalid property name mapping.");
+    }
+
+    @Test
+    public void testGetPropertyDescriptionMapping() {
+
+        Map<String, String> expecteddescriptionMappingTrue = new HashMap<>();
+        expecteddescriptionMappingTrue.put(MultiAttributeLoginConstants.MULTI_ATTRIBUTE_LOGIN_PROPERTY,
+                MultiAttributeLoginConstants.MultiAttributeLoginDescriptionMapping.MULTI_ATTRIBUTE_LOGIN_PROPERTY_DESCRIPTION_MAPPING);
+        expecteddescriptionMappingTrue.put(MultiAttributeLoginConstants.ALLOWED_LOGIN_ATTRIBUTES,
+                MultiAttributeLoginConstants.MultiAttributeLoginDescriptionMapping.ALLOWED_LOGIN_ATTRIBUTES_DESCRIPTION_MAPPING);
+        assertEquals(multiAttributeLoginHandler.getPropertyDescriptionMapping(), expecteddescriptionMappingTrue,
+                "Valid property description mapping.");
+
+        Map<String, String> expecteddescriptionMappingFalse = new HashMap<>();
+        expecteddescriptionMappingFalse.put(MultiAttributeLoginConstants.MULTI_ATTRIBUTE_LOGIN_PROPERTY,
+                "Enableusingmultipleattributesasloginidentifier");
+        expecteddescriptionMappingFalse.put(MultiAttributeLoginConstants.ALLOWED_LOGIN_ATTRIBUTES,
+                "Allowedclaimlistseparatedbycommas.");
+        assertNotEquals(multiAttributeLoginHandler.getPropertyDescriptionMapping(), expecteddescriptionMappingFalse,
+                "Invalid property description mapping.");
+    }
+
+    @Test
+    public void testGetPropertyNames() {
+
+        List<String> expectedpropertiesTrue = new ArrayList<>();
+        expectedpropertiesTrue.add(MultiAttributeLoginConstants.MULTI_ATTRIBUTE_LOGIN_PROPERTY);
+        expectedpropertiesTrue.add(MultiAttributeLoginConstants.ALLOWED_LOGIN_ATTRIBUTES);
+        assertEquals(multiAttributeLoginHandler.getPropertyNames().length,
+                expectedpropertiesTrue.size(), "Valid property description mapping.");
+
+        List<String> expectedpropertiesFalse = new ArrayList<>();
+        expectedpropertiesFalse.add(MultiAttributeLoginConstants.MULTI_ATTRIBUTE_LOGIN_PROPERTY);
+        assertNotEquals(multiAttributeLoginHandler.getPropertyNames().length,
+                expectedpropertiesFalse.size(), "InValid property description mapping.");
+
+    }
+
+    @Test
+    public void testTestGetDefaultPropertyValues() {
+
+        assertEquals(multiAttributeLoginHandler.getOrder(), 0, "Valid order.");
+        assertNotEquals(multiAttributeLoginHandler.getOrder(), null, "Invalid order.");
+    }
+}

--- a/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/test/resources/testng.xml
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/test/resources/testng.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Identity-Governance-Multi-Attribute-Login-Regex-Resolver-Test-Suite">
+    <test name="Util-Tests" preserve-order="true" parallel="false">
+        <parameter name="log-level" value="info"/>
+        <classes>
+            <class name="org.wso2.carbon.identity.multi.attribute.login.handler.MultiAttributeLoginHandlerTest" />
+        </classes>
+    </test>
+</suite>

--- a/features/org.wso2.carbon.identity.multi.attribute.login/pom.xml
+++ b/features/org.wso2.carbon.identity.multi.attribute.login/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>identity-governance</artifactId>
+        <groupId>org.wso2.carbon.identity.governance</groupId>
+        <version>1.4.92-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>org.wso2.carbon.identity.multi.attribute.login</artifactId>
+    <packaging>pom</packaging>
+    <name>WSO2 Carbon - Multi Attribute Aggregator Module</name>
+    <description>
+        This is a Carbon bundle that represent the Multi Attribute Login Aggregator Module.
+    </description>
+    <url>http://wso2.org</url>
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.multi.attribute.login.mgt</artifactId>
+            <version>${carbon.identity.framework.version}</version>
+        </dependency>
+    </dependencies>
+    <modules>
+        <module>org.wso2.carbon.identity.multi.attribute.login.resolver.regex</module>
+        <module>org.wso2.carbon.identity.multi.attribute.login.service</module>
+    </modules>
+</project>

--- a/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.recovery.ui.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.ui.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.recovery.ui.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.ui.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.recovery.ui.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.ui.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.recovery.ui.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.ui.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.recovery.ui.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.ui.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.recovery.ui.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.ui.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.user.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.user.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.user.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.user.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.user.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.user.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.wso2.carbon.identity.governance</groupId>
     <artifactId>identity-governance</artifactId>
-    <version>1.4.92</version>
+    <version>1.4.93-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Governance Module</name>
@@ -37,7 +37,7 @@
         <url>https://github.com/wso2-extensions/identity-governance.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-governance.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-governance.git</connection>
-        <tag>v1.4.92</tag>
+        <tag>v1.1.0-SNAPSHOT</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.wso2.carbon.identity.governance</groupId>
     <artifactId>identity-governance</artifactId>
-    <version>1.4.92-SNAPSHOT</version>
+    <version>1.4.92</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Governance Module</name>
@@ -37,7 +37,7 @@
         <url>https://github.com/wso2-extensions/identity-governance.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-governance.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-governance.git</connection>
-        <tag>v1.1.0-SNAPSHOT</tag>
+        <tag>v1.4.92</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -682,7 +682,7 @@
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>
         <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>
         <jackson-jaxrs-json-provider.version>2.10.5</jackson-jaxrs-json-provider.version>
-        <jackson-databind.version>2.10.5</jackson-databind.version>
+        <jackson-databind.version>2.10.5.1</jackson-databind.version>
         <cxf-bundle.version>3.3.7</cxf-bundle.version>
         <jackson.version>1.9.13</jackson.version>
         <spring-web.version>4.3.29.RELEASE</spring-web.version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.wso2.carbon.identity.governance</groupId>
     <artifactId>identity-governance</artifactId>
-    <version>1.4.93-SNAPSHOT</version>
+    <version>1.4.93</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Governance Module</name>
@@ -37,7 +37,7 @@
         <url>https://github.com/wso2-extensions/identity-governance.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-governance.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-governance.git</connection>
-        <tag>v1.1.0-SNAPSHOT</tag>
+        <tag>v1.4.93</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@
         <module>features/org.wso2.carbon.identity.password.policy.server.feature</module>
         <module>features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature</module>
         <module>features/org.wso2.carbon.identity.tenant.resource.manager.feature</module>
+        <module>features/org.wso2.carbon.identity.multi.attribute.login</module>
     </modules>
 
     <dependencyManagement>
@@ -509,6 +510,11 @@
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.user.core</artifactId>
                 <version>${carbon.kernel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.multi.attribute.login.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
             </dependency>
             <!-- Pax Logging -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.wso2.carbon.identity.governance</groupId>
     <artifactId>identity-governance</artifactId>
-    <version>1.4.93</version>
+    <version>1.4.94-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Governance Module</name>
@@ -37,7 +37,7 @@
         <url>https://github.com/wso2-extensions/identity-governance.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-governance.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-governance.git</connection>
-        <tag>v1.4.93</tag>
+        <tag>v1.1.0-SNAPSHOT</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.wso2.carbon.identity.governance</groupId>
     <artifactId>identity-governance</artifactId>
-    <version>1.4.94</version>
+    <version>1.4.95-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Governance Module</name>
@@ -37,7 +37,7 @@
         <url>https://github.com/wso2-extensions/identity-governance.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-governance.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-governance.git</connection>
-        <tag>v1.4.94</tag>
+        <tag>v1.1.0-SNAPSHOT</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.wso2.carbon.identity.governance</groupId>
     <artifactId>identity-governance</artifactId>
-    <version>1.4.94-SNAPSHOT</version>
+    <version>1.4.94</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Governance Module</name>
@@ -37,7 +37,7 @@
         <url>https://github.com/wso2-extensions/identity-governance.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-governance.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-governance.git</connection>
-        <tag>v1.1.0-SNAPSHOT</tag>
+        <tag>v1.4.94</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -658,7 +658,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.18.206</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.19.53</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.28, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/service-stubs/identity/org.wso2.carbon.identity.recovery.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.recovery.stub/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.identity.recovery.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.recovery.stub/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.identity.recovery.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.recovery.stub/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.identity.recovery.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.recovery.stub/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.identity.recovery.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.recovery.stub/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/org.wso2.carbon.identity.recovery.stub/pom.xml
+++ b/service-stubs/identity/org.wso2.carbon.identity.recovery.stub/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>carbon-service-stubs</artifactId>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/pom.xml
+++ b/service-stubs/identity/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92-SNAPSHOT</version>
+        <version>1.4.92</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/pom.xml
+++ b/service-stubs/identity/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94-SNAPSHOT</version>
+        <version>1.4.94</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/pom.xml
+++ b/service-stubs/identity/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.92</version>
+        <version>1.4.93-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/pom.xml
+++ b/service-stubs/identity/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.94</version>
+        <version>1.4.95-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/pom.xml
+++ b/service-stubs/identity/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93</version>
+        <version>1.4.94-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/identity/pom.xml
+++ b/service-stubs/identity/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.4.93-SNAPSHOT</version>
+        <version>1.4.93</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Resolves: https://github.com/wso2/product-is/issues/8899
### Purpose   
In current IS versions not provide any option to use values other than username as login identifier. Therefore users are required to use only username for authentication scenarios such as user-portal login.
And also users can recover there password only by providing the username. 

### Describe the improvement
There is an option in admin console under “Resident Identity Provider > Login Policies > Multi Attribute Login” to enable or disable the multi attribute login feature and admin can provide a list of claim URIs which are allowed for use as login identifier.
 Then users can use allowed attribute value in the tenant domain as the login identifier without using username. The login identifier is identified by comparing the given regex pattern of claims and then returns resolved username. 
When a user tries to recover the password, the user can use given identifiers without limiting only for username. 
And also there is another option to maintain the uniqueness of the multi attribute login allowed claim values in a tenant domain. To enable this feature admin need to add additional claim property as given below. 

Property Name | Property Value
-- | --
isUnique | ture

### Additional context
Needs to provide regex patterns for each claim which are allowed for multi-attribute-login by admins.
All regexes provided must have different patterns.

### How to reproduce
Resident Identity Provider > Login Policies > Multi Attribute Login
Enable the feature and add the multi attribute login allowed claim URIs.
Ex: http://wso2.org/claims/emailaddress,http://wso2.org/claims/telephone,http://wso2.org/claims/username
Note: If you enable this feature you need to add the username claim URI for login with username. 

