### PR TITLE
Consider tenant domain sent as query param in validateUsernamePost

### DIFF
--- a/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImpl.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.CarbonException;
 import org.wso2.carbon.core.util.AnonymousSessionUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.mgt.constants.SelfRegistrationStatusCodes;
+import org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
@@ -65,6 +66,8 @@ public class ValidateUsernameApiServiceImpl extends ValidateUsernameApiService {
                 for (PropertyDTO propertyDTO : propertyDTOList) {
                     if (SKIP_SIGN_UP_ENABLE_CHECK_KEY.equalsIgnoreCase(propertyDTO.getKey())) {
                         skipSelfSignUpEnabledCheck = Boolean.parseBoolean(propertyDTO.getValue());
+                    } else if (IdentityManagementEndpointConstants.TENANT_DOMAIN.equals(propertyDTO.getKey())) {
+                        tenantDomain = propertyDTO.getValue();
                     }
                 }
             }


### PR DESCRIPTION
### Proposed changes in this pull request
Fix integration test failures due to https://github.com/wso2-extensions/identity-governance/pull/482
Consider the tenant domain sent as a query param for validateUsernamePost