### PR TITLE
Add recovery and user APIs as jars inside the identity rest dispatcher

### DIFF
--- a/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
@@ -44,6 +44,36 @@
                 <!--</configuration>-->
             <!--</plugin>-->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-a-jar</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>Add-2-local-repository</id>
+                        <phase>package</phase>
+                        <configuration>
+                            <packaging>jar</packaging>
+                            <file>${project.build.directory}\${artifactId}-${version}.jar</file>
+                        </configuration>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>

--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/main/resources/META-INF/cxf/user-recovery-v0-9-cxf.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/main/resources/META-INF/cxf/user-recovery-v0-9-cxf.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~  WSO2 Inc. licenses this file to you under the Apache License,
+  ~  Version 2.0 (the "License"); you may not use this file except
+  ~  in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:jaxrs="http://cxf.apache.org/jaxrs" xmlns:context="http://www.springframework.org/schema/context" xsi:schemaLocation=" http://www.springframework.org/schema/beans  http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd http://cxf.apache.org/jaxrs http://cxf.apache.org/schemas/jaxrs.xsd">
+
+
+    <bean class="org.wso2.carbon.identity.recovery.endpoint.impl.CaptchaApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.recovery.endpoint.impl.ClaimsApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.recovery.endpoint.impl.RecoverPasswordApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.recovery.endpoint.impl.RecoverUsernameApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.recovery.endpoint.impl.SecurityQuestionApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.recovery.endpoint.impl.SecurityQuestionsApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.recovery.endpoint.impl.SetPasswordApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.recovery.endpoint.impl.ValidateAnswerApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.recovery.endpoint.impl.ValidateCodeApiServiceImpl"/>
+
+</beans>

--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/main/webapp/WEB-INF/beans.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/main/webapp/WEB-INF/beans.xml
@@ -5,6 +5,8 @@
     <context:annotation-config/>
     <bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer"/>
     <bean class="org.springframework.beans.factory.config.PreferencesPlaceholderConfigurer"/>
+    <!-- For Identity Server, the jaxrs:server configuration is maintained in beans.xml of wso2/identity-rest-dispatcher
+         These configuration is maintained here as other products packing this webapp was .war -->
     <jaxrs:server id="services" address="/">
         <jaxrs:serviceBeans>
             <bean class="org.wso2.carbon.identity.recovery.endpoint.ClaimsApi"/>

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -34,7 +34,36 @@
                     <warName>api#identity#user#v1.0</warName>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-a-jar</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>Add-2-local-repository</id>
+                        <phase>package</phase>
+                        <configuration>
+                            <packaging>jar</packaging>
+                            <file>${project.build.directory}\${artifactId}-${version}.jar</file>
+                        </configuration>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 <!--            <plugin>-->
 <!--                <groupId>org.wso2.maven.plugins</groupId>-->
 <!--                <artifactId>swagger2cxf-maven-plugin</artifactId>-->

--- a/components/org.wso2.carbon.identity.user.endpoint/src/main/resources/META-INF/cxf/user-governance-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/main/resources/META-INF/cxf/user-governance-v1-cxf.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~  WSO2 Inc. licenses this file to you under the Apache License,
+  ~  Version 2.0 (the "License"); you may not use this file except
+  ~  in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:jaxrs="http://cxf.apache.org/jaxrs" xmlns:context="http://www.springframework.org/schema/context" xsi:schemaLocation=" http://www.springframework.org/schema/beans  http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd http://cxf.apache.org/jaxrs http://cxf.apache.org/schemas/jaxrs.xsd">
+
+    <bean class="org.wso2.carbon.identity.user.endpoint.impl.IntrospectCodeApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.user.endpoint.impl.LiteApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.user.endpoint.impl.MeApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.user.endpoint.impl.PiInfoApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.user.endpoint.impl.ResendCodeApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.user.endpoint.impl.UpdateUsernameApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.user.endpoint.impl.ValidateCodeApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.user.endpoint.impl.ValidateUsernameApiServiceImpl"/>
+
+</beans>

--- a/components/org.wso2.carbon.identity.user.endpoint/src/main/webapp/WEB-INF/beans.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/src/main/webapp/WEB-INF/beans.xml
@@ -5,6 +5,8 @@
     <context:annotation-config/>
     <bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer"/>
     <bean class="org.springframework.beans.factory.config.PreferencesPlaceholderConfigurer"/>
+    <!-- For Identity Server, the jaxrs:server configuration is maintained in beans.xml of wso2/identity-rest-dispatcher
+     These configuration is maintained here as other products packing this webapp as .war -->
     <jaxrs:server id="services" address="/">
         <jaxrs:serviceBeans>
             <bean class="org.wso2.carbon.identity.user.endpoint.IntrospectCodeApi"/>

--- a/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
@@ -45,6 +45,12 @@
             <version>${project.version}</version>
             <type>war</type>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.recovery.endpoint</artifactId>
+            <version>${project.version}</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -69,6 +75,13 @@
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${basedir}/src/main/resources/</outputDirectory>
                                     <destFileName>api#identity#recovery#v0.9.war</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.wso2.carbon.identity.governance</groupId>
+                                    <artifactId>org.wso2.carbon.identity.recovery.endpoint</artifactId>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${basedir}/src/main/resources/api_resources</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/features/org.wso2.carbon.identity.recovery.server.feature/resources/p2.inf
+++ b/features/org.wso2.carbon.identity.recovery.server.feature/resources/p2.inf
@@ -1,2 +1,3 @@
 instructions.configure = \
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.identity.recovery.server_${feature.version}/api#identity#recovery#v0.9.war,target:${installFolder}/../../deployment/server/webapps/api#identity#recovery#v0.9.war,overwrite:true);\
+org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.identity.recovery.server_${feature.version}/api_resources/,target:${installFolder}/../../deployment/server/webapps/api_resources/,overwrite:true);\

--- a/features/org.wso2.carbon.identity.user.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.server.feature/pom.xml
@@ -55,6 +55,12 @@
             <version>${project.version}</version>
             <type>war</type>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.user.endpoint</artifactId>
+            <version>${project.version}</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -79,6 +85,13 @@
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${basedir}/src/main/resources/</outputDirectory>
                                     <destFileName>api#identity#user#v1.0.war</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.wso2.carbon.identity.governance</groupId>
+                                    <artifactId>org.wso2.carbon.identity.user.endpoint</artifactId>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${basedir}/src/main/resources/api_resources</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/features/org.wso2.carbon.identity.user.server.feature/resources/p2.inf
+++ b/features/org.wso2.carbon.identity.user.server.feature/resources/p2.inf
@@ -1,2 +1,3 @@
 instructions.configure = \
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.identity.user.server_${feature.version}/api#identity#user#v1.0.war,target:${installFolder}/../../deployment/server/webapps/api#identity#user#v1.0.war,overwrite:true);\
+org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.identity.user.server_${feature.version}/api_resources/,target:${installFolder}/../../deployment/server/webapps/api_resources/,overwrite:true);\


### PR DESCRIPTION
Add recovery and user APIs as jars and deploy them as jars inside API rest dispatcher 
Related to https://github.com/wso2/product-is/issues/11425



As `api#identity#user#v1.0.war` and `api#identity#recovery#v0.9.war` are packed by other products, those wars will be kept as it is in the features and new jars will be copied inside `api_resources` then moved to api-dispatcher and wars will be removed in the product-is. Other products can remove `api_resources` folder and keep the wars.