### PR TITLE
[Eventr Handler] [AdminForcedPasswordResetHandler] Handle Update Credentials By Admin

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AdminForcedPasswordResetHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AdminForcedPasswordResetHandler.java
@@ -63,6 +63,28 @@ public class AdminForcedPasswordResetHandler extends UserEmailVerificationHandle
         if (IdentityEventConstants.Event.PRE_AUTHENTICATION.equals(eventName)) {
             handleAuthenticate(eventProperties, userStoreManager);
         }
+        if (IdentityEventConstants.Event.POST_UPDATE_CREDENTIAL_BY_ADMIN.equals(eventName)) {
+            handleUpdateCredentialsByAdmin(eventProperties, userStoreManager);
+        }
+    }
+
+    private void handleUpdateCredentialsByAdmin(Map<String, Object> eventProperties, UserStoreManager userStoreManager)
+            throws IdentityEventException {
+
+        User user = getUser(eventProperties, userStoreManager);
+        if (log.isDebugEnabled()) {
+            log.debug("PostUpdateCredentialsByAdmin - AdminForcedPasswordResetHandler for user : "
+                    + user.toString());
+        }
+
+        UserRecoveryData userRecoveryData = getRecoveryData(user);
+        if (userRecoveryData != null) {
+            invalidateRecoveryData(user);
+            if (log.isDebugEnabled()) {
+                log.debug("PostUpdateCredentialsByAdmin - invalidate Recovery Data for user : "
+                        + user.toString());
+            }
+        }
 
     }
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -315,6 +315,18 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
         }
     }
 
+    protected void invalidateRecoveryData(User user)
+            throws IdentityEventException {
+
+        UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
+
+        try {
+            userRecoveryDataStore.invalidate(user);
+        } catch (IdentityRecoveryException e) {
+            throw new IdentityEventException("Error while invalidate recovery data for user :" + user.getUserName(), e);
+        }
+    }
+
     protected void setRecoveryData(User user, Enum recoveryScenario, Enum recoveryStep, String secretKey)
             throws IdentityEventException {
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -323,7 +323,7 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
         try {
             userRecoveryDataStore.invalidate(user);
         } catch (IdentityRecoveryException e) {
-            throw new IdentityEventException("Error while invalidate recovery data for user :" + user.getUserName(), e);
+            throw new IdentityEventException("Error while invalidate recovery data for user :" + user.toString(), e);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -693,7 +693,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.20.23</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.35</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.28, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
$sub

Issue:
https://github.com/wso2/product-is/issues/11632

Cause:
- When user authenticate, user operation event listener will be triggered for pre-authenticate events.
- AdminForcedPasswordResetHandler will check for any recovery scenario and try to raise an exception.
- This cases the error

Solution:
- When the admin forcefully setss a new password we delete all existing recovery scenarios for the corresponding user.

Procedure:
- Let AdminForcedPasswordResetHandler listen to POST_UPDATE_CREDENTIAL_BY_ADMIN event.
   Note that we don't need to handle POST_UPDATE_CREDENTIAL_BY_ADMIN_WITH_ID event because handling first event will be sufficient
ex: https://github.com/wso2-extensions/identity-governance/blob/9677c8d1397c137728d62bf9238ab7d3d35aca8f/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/IdentityUserMetadataMgtHandler.java#L65

- while handle the event check for any recovery data for the user and delete it.
