### PR TITLE
Add secure vault support for captcha configs

### DIFF
--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -106,6 +106,10 @@
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.securevault</groupId>
+            <artifactId>org.wso2.securevault</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -171,6 +175,7 @@
                             version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
                             org.wso2.carbon.identity.handler.event.account.lock.exception;
                             version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
+                            org.wso2.securevault.*; version="${org.wso2.securevault.import.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,11 @@
                 <artifactId>org.wso2.carbon.utils</artifactId>
                 <version>${carbon.kernel.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.securevault</groupId>
+                <artifactId>org.wso2.securevault</artifactId>
+                <version>${org.wso2.securevault.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.apache.felix</groupId>
@@ -746,6 +751,9 @@
         <carbon.analytics.common.version.range>[5.2.15,6.0.0)</carbon.analytics.common.version.range>
 
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
+
+        <org.wso2.securevault.version>1.1.3</org.wso2.securevault.version>
+        <org.wso2.securevault.import.version.range>[1.1.0, 2.0.0)</org.wso2.securevault.import.version.range>
     </properties>
 
 </project>


### PR DESCRIPTION
### Proposed changes in this pull request

Adding secure vault support for reCaptcha `site-key`, `site-secret` or any other captcha property. 

### Related issue

https://github.com/wso2-enterprise/asgardeo-product/issues/3264#issuecomment-831867431