### PR TITLE
Add secure vault support for captcha config loading in recovery endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.recovery/pom.xml
@@ -249,6 +249,10 @@
             <groupId>org.wso2.carbon.identity.governance</groupId>
             <artifactId>org.wso2.carbon.identity.recovery</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.securevault</groupId>
+            <artifactId>org.wso2.securevault</artifactId>
+        </dependency>
     </dependencies>
     
 </project>


### PR DESCRIPTION
### Proposed changes in this pull request

$subject

**Related issue**

https://github.com/wso2/product-is/issues/11693

There is an issue that the api reads the `captcha-config.properties` file in each request. It will be addressed with https://github.com/wso2/product-is/issues/11699