### PR TITLE
Allow password recovery flow related connectors to read user data from request body

### DIFF
--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/filter/CaptchaFilter.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/filter/CaptchaFilter.java
@@ -50,8 +50,6 @@ public class CaptchaFilter implements Filter {
 
     private static final Log log = LogFactory.getLog(CaptchaFilter.class);
 
-    private static final String RECOVER_PASSWORD_URL = "/api/identity/recovery/v0.9/recover-password";
-
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
 
@@ -77,7 +75,8 @@ public class CaptchaFilter implements Filter {
                 String currentPath = ((HttpServletRequest) servletRequest).getRequestURI();
 
                 if (StringUtils.isNotBlank(currentPath) &&
-                        CaptchaUtil.isPathAvailable(currentPath, RECOVER_PASSWORD_URL)) {
+                        CaptchaUtil.isPathAvailable(currentPath, CaptchaDataHolder.getInstance()
+                                .getReCaptchaRequestWrapUrls())) {
                     servletRequest = new CaptchaHttpServletRequestWrapper((HttpServletRequest) servletRequest);
                 }
             }

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaDataHolder.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaDataHolder.java
@@ -47,6 +47,8 @@ public class CaptchaDataHolder {
 
     private String reCaptchaErrorRedirectUrls;
 
+    private String reCaptchaRequestWrapUrls;
+
     private IdentityGovernanceService identityGovernanceService;
 
     private RealmService realmService;
@@ -107,6 +109,14 @@ public class CaptchaDataHolder {
 
     public void setReCaptchaSecretKey(String reCaptchaSecretKey) {
         this.reCaptchaSecretKey = reCaptchaSecretKey;
+    }
+
+    public String getReCaptchaRequestWrapUrls() {
+        return reCaptchaRequestWrapUrls;
+    }
+
+    public void setReCaptchaRequestWrapUrls(String reCaptchaRequestWrapUrls) {
+        this.reCaptchaRequestWrapUrls = reCaptchaRequestWrapUrls;
     }
 
     public String getReCaptchaErrorRedirectUrls() {

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaConstants.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaConstants.java
@@ -41,6 +41,8 @@ public class CaptchaConstants {
 
     public static final String RE_CAPTCHA_SECRET_KEY = "recaptcha.secret.key";
 
+    public static final String RE_CAPTCHA_REQUEST_WRAP_URLS = "recaptcha.request.wrap.urls";
+
     public static final String FAIL_LOGIN_ATTEMPT_VALIDATOR_ENABLED = "failLoginAttemptValidator.enable";
 
     public static final String RE_CAPTCHA_FAILED_REDIRECT_URLS = "recaptcha.failed.redirect.urls";

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaUtil.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaUtil.java
@@ -379,6 +379,12 @@ public class CaptchaUtil {
             throw new RuntimeException(getValidationErrorMessage(CaptchaConstants.RE_CAPTCHA_SECRET_KEY));
         }
         CaptchaDataHolder.getInstance().setReCaptchaSecretKey(reCaptchaSecretKey);
+
+        String reCaptchaRequestWrapUrls = properties.getProperty(CaptchaConstants.RE_CAPTCHA_REQUEST_WRAP_URLS);
+        if (reCaptchaRequestWrapUrls == null) {
+            throw new RuntimeException(getValidationErrorMessage(CaptchaConstants.RE_CAPTCHA_REQUEST_WRAP_URLS));
+        }
+        CaptchaDataHolder.getInstance().setReCaptchaRequestWrapUrls(reCaptchaRequestWrapUrls);
     }
 
     private static void setSSOLoginConnectorConfigs(Properties properties) {

--- a/features/org.wso2.carbon.identity.captcha.server.feature/resources/conf/captcha-config.properties
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/resources/conf/captcha-config.properties
@@ -35,3 +35,6 @@ recaptcha.secret.key=6LeL8iATAAAAAJUgXu_ZgEm_dOC3AT4gmWRstil4
 
 # reCaptcha failed redirect urls
 #recaptcha.failed.redirect.urls=
+
+# recaptcha request wrapping paths comma separated
+recaptcha.request.wrap.urls=""

--- a/features/org.wso2.carbon.identity.captcha.server.feature/resources/conf/captcha-config.properties.j2
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/resources/conf/captcha-config.properties.j2
@@ -41,3 +41,6 @@ recaptcha.failed.redirect.urls={{recaptcha.redirect_urls}}
 # reCaptcha failed redirect urls
 #recaptcha.failed.redirect.urls=
 []
+
+# recaptcha request wrapping paths comma separated
+recaptcha.request.wrap.urls={{recaptcha.request_wrap_urls}}

--- a/features/org.wso2.carbon.identity.captcha.server.feature/resources/conf/org.wso2.carbon.identity.captcha.server.feature.default.json
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/resources/conf/org.wso2.carbon.identity.captcha.server.feature.default.json
@@ -1,5 +1,6 @@
 {
   "recaptcha.enabled": false,
   "recaptcha.api_url": "https://www.google.com/recaptcha/api.js",
-  "recaptcha.verify_url": "https://www.google.com/recaptcha/api/siteverify"
+  "recaptcha.verify_url": "https://www.google.com/recaptcha/api/siteverify",
+  "recaptcha.request_wrap_urls": ""
 }


### PR DESCRIPTION
### Proposed changes in this pull request

In password recovery flow, when using captcha filter, the user data cannot be read from the filter as `ServletRequest` only allows to read body data once.
In the password recovery flow, the `HttpServletRequest` should be wrapped in a `CaptchaHttpServletRequestWrapper` in order to read body data multiple times.
