### PR TITLE
Handle user's multiple userstore existences in password recovery

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtil.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtil.java
@@ -257,8 +257,6 @@ public class RecoveryUtil {
         user.setTenantDomain(userDTO.getTenantDomain());
         if (StringUtils.isNotBlank(userDTO.getRealm())) {
             user.setUserStoreDomain(userDTO.getRealm());
-        } else {
-            user.setUserStoreDomain(IdentityUtil.getPrimaryDomainName());
         }
 
         user.setUserName(userDTO.getUsername());

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
@@ -59,21 +59,6 @@ public class RecoverPasswordApiServiceImpl extends RecoverPasswordApiService {
             userDTO.setUsername(user.getUsername());
             recoveryInitiatingRequest.setUser(userDTO);
         }
-        if (StringUtils.isBlank(user.getRealm())) {
-            String[] userList = RecoveryUtil.getUserList(tenantIdFromContext, user.getUsername());
-
-            if (ArrayUtils.isEmpty(userList)) {
-                String msg = "Unable to find an user with username: " + user.getUsername() + " in the system.";
-                LOG.error(msg);
-            } else if (userList.length == 1) {
-                recoveryInitiatingRequest.getUser().setRealm(IdentityUtil.extractDomainFromName(userList[0]));
-            } else {
-                String msg = "There are multiple users with username: " + user.getUsername() + " in the system, " +
-                        "please send the correct user-store domain along with the username.";
-                LOG.error(msg);
-                RecoveryUtil.handleBadRequest(msg, Constants.ERROR_CODE_MULTIPLE_USERS_MATCHING);
-            }
-        }
 
         NotificationPasswordRecoveryManager notificationPasswordRecoveryManager = RecoveryUtil
                 .getNotificationBasedPwdRecoveryManager();

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -338,6 +338,8 @@ public class IdentityRecoveryConstants {
                 + "recovery request"),
         ERROR_CODE_PASSWORD_RECOVERY_VALIDATION_FAILED("PWR-10009",
                 "Password recovery validation failed for user account : '%s'"),
+        ERROR_CODE_ERROR_HANDLING_THE_EVENT("PWR-10010",
+                "Error encountered while handling the event: '%s'"),
         ERROR_CODE_UNEXPECTED_ERROR_PASSWORD_RESET("PWR-15001", "Unexpected error during "
                 + "password reset"),
         ERROR_CODE_UNSUPPORTED_SMS_OTP_REGEX("PWR-15008", "SMS OTP regex pattern is not supported."),

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -864,10 +864,12 @@ public class NotificationPasswordRecoveryManager {
         int tenantID = IdentityTenantUtil.getTenantId(user.getTenantDomain());
         if (StringUtils.isBlank(user.getUserStoreDomain())) {
             String[] userList = getUserList(tenantID, user.getUserName());
-
             if (ArrayUtils.isEmpty(userList)) {
                 String msg = "Unable to find an user with username: " + user.getUserName() + " in the system.";
-                log.error(msg);
+                if (log.isDebugEnabled()) {
+                    log.debug(msg);
+                }
+                diagnosticLog.error(msg);
             } else if (userList.length == 1) {
                 user.setUserStoreDomain(IdentityUtil.extractDomainFromName(userList[0]));
             } else {


### PR DESCRIPTION
### Propose changes

Improved the event publisher in NotificationPasswordRecoveryManager to trigger an event to handle user's multiple userstore existences in password recovery
Related issue: https://github.com/wso2/product-is/issues/11837


