### PR TITLE
Add metadata properties to identity governance connectors

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceServiceImpl.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceServiceImpl.java
@@ -172,6 +172,7 @@ public class IdentityGovernanceServiceImpl implements IdentityGovernanceService 
                         if (metaData != null && metaData.containsKey(resourceName)) {
                             configProperties[j].setType(metaData.get(resourceName).getType());
                             configProperties[j].setRegex(metaData.get(resourceName).getRegex());
+                            configProperties[j].setGroupId(metaData.get(resourceName).getGroupId());
                         }
                         if (confidentialProperties != null &&
                                 confidentialProperties.contains(configProperties[j].getName())) {

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceServiceImpl.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceServiceImpl.java
@@ -35,6 +35,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * IdentityGovernanceServiceImpl.
+ */
 public class IdentityGovernanceServiceImpl implements IdentityGovernanceService {
 
     private static final Log log = LogFactory.getLog(IdentityGovernanceServiceImpl.class);
@@ -150,6 +153,9 @@ public class IdentityGovernanceServiceImpl implements IdentityGovernanceService 
             ConnectorConfig config = new ConnectorConfig();
             Map<String, String> propertyFriendlyNames = list.get(i).getPropertyNameMapping();
             Map<String, String> propertyDescriptions = list.get(i).getPropertyDescriptionMapping();
+
+            Map<String, Property> metaData = list.get(i).getMetaData();
+
             List<String> confidentialProperties = list.get(i).getConfidentialPropertyValues(tenantDomain);
             config.setFriendlyName(list.get(i).getFriendlyName());
             config.setName(list.get(i).getName());
@@ -162,8 +168,17 @@ public class IdentityGovernanceServiceImpl implements IdentityGovernanceService 
                 for (Property property : properties) {
                     if (connectorProperties[j].equals(property.getName())) {
                         configProperties[j] = property;
-                        configProperties[j].setDisplayName(propertyFriendlyNames.get(configProperties[j].getName()));
-                        configProperties[j].setDescription(propertyDescriptions.get(configProperties[j].getName()));
+                        String resourceName = configProperties[j].getName();
+                        configProperties[j].setDisplayName(propertyFriendlyNames.get(resourceName));
+                        configProperties[j].setDescription(propertyDescriptions.get(resourceName));
+
+                        if (metaData != null && metaData.containsKey(resourceName)) {
+
+                            configProperties[j].setType(metaData.get(resourceName).getType());
+                            configProperties[j].setRegex(metaData.get(resourceName).getRegex());
+
+                        }
+
                         if (confidentialProperties != null &&
                                 confidentialProperties.contains(configProperties[j].getName())) {
                             configProperties[j].setConfidential(true);

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceServiceImpl.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceServiceImpl.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * IdentityGovernanceServiceImpl.
+ * Class which contains exposed identity governance services.
  */
 public class IdentityGovernanceServiceImpl implements IdentityGovernanceService {
 
@@ -153,9 +153,7 @@ public class IdentityGovernanceServiceImpl implements IdentityGovernanceService 
             ConnectorConfig config = new ConnectorConfig();
             Map<String, String> propertyFriendlyNames = list.get(i).getPropertyNameMapping();
             Map<String, String> propertyDescriptions = list.get(i).getPropertyDescriptionMapping();
-
             Map<String, Property> metaData = list.get(i).getMetaData();
-
             List<String> confidentialProperties = list.get(i).getConfidentialPropertyValues(tenantDomain);
             config.setFriendlyName(list.get(i).getFriendlyName());
             config.setName(list.get(i).getName());
@@ -171,14 +169,10 @@ public class IdentityGovernanceServiceImpl implements IdentityGovernanceService 
                         String resourceName = configProperties[j].getName();
                         configProperties[j].setDisplayName(propertyFriendlyNames.get(resourceName));
                         configProperties[j].setDescription(propertyDescriptions.get(resourceName));
-
                         if (metaData != null && metaData.containsKey(resourceName)) {
-
                             configProperties[j].setType(metaData.get(resourceName).getType());
                             configProperties[j].setRegex(metaData.get(resourceName).getRegex());
-
                         }
-
                         if (confidentialProperties != null &&
                                 confidentialProperties.contains(configProperties[j].getName())) {
                             configProperties[j].setConfidential(true);

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceUtil.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceUtil.java
@@ -152,7 +152,7 @@ public class IdentityGovernanceUtil {
      * @param type, Type of property object.
      * @param regex, Regex string of the property object if it has.
      * @param groupId, Group id of the element.
-     * @return Property object that contains type and regex.
+     * @return Property object that contains type, groupID and regex.
      */
     public static Property getPropertyObject(String type, String regex, int groupId) {
 
@@ -165,11 +165,26 @@ public class IdentityGovernanceUtil {
         return property;
     }
 
+
+    /**
+     * Get the meta data property object.
+     *
+     * @param type, Type of property object.
+     * @param regex, Regex string of the property object if it has.
+     * @return Property object that contains type, groupID and regex.
+     */
     public static Property getPropertyObject(String type, String regex) {
 
     return getPropertyObject(type, regex, 0);
     }
 
+
+    /**
+     * Get the meta data property object.
+     *
+     * @param type, Type of property object.
+     * @return Property object that contains, groupID type and regex.
+     */
     public static Property getPropertyObject(String type) {
 
         return getPropertyObject(type, null, 0);

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceUtil.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceUtil.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.identity.governance;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.IdentityProviderProperty;
@@ -143,5 +144,22 @@ public class IdentityGovernanceUtil {
             return NotificationChannels.EMAIL_CHANNEL.getChannelType();
         }
         return defaultNotificationChannel;
+    }
+
+    /**
+     * Get the meta data property object.
+     *
+     * @param type, Type of property object.
+     * @param regex, Regex string of the property object if it has.
+     * @return Property object that contains type and regex.
+     */
+    public static Property getPropertyObject(String type, String regex) {
+
+        Property property = new Property();
+        property.setType(type);
+        if (regex != null) {
+            property.setRegex(regex);
+        }
+        return property;
     }
 }

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceUtil.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceUtil.java
@@ -151,15 +151,28 @@ public class IdentityGovernanceUtil {
      *
      * @param type, Type of property object.
      * @param regex, Regex string of the property object if it has.
+     * @param groupId, Group id of the element.
      * @return Property object that contains type and regex.
      */
-    public static Property getPropertyObject(String type, String regex) {
+    public static Property getPropertyObject(String type, String regex, int groupId) {
 
         Property property = new Property();
         property.setType(type);
+        property.setGroupId(groupId);
         if (regex != null) {
             property.setRegex(regex);
         }
         return property;
     }
+
+    public static Property getPropertyObject(String type, String regex) {
+
+    return getPropertyObject(type, regex, 0);
+    }
+
+    public static Property getPropertyObject(String type) {
+
+        return getPropertyObject(type, null, 0);
+    }
+
 }

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityMgtConstants.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityMgtConstants.java
@@ -26,6 +26,29 @@ public class IdentityMgtConstants {
     public static final String USER_IDENTITY_CLAIMS = "UserIdentityClaims";
     public static final String ERROR_CODE_DELIMITER = "-";
 
+    /**.
+     * DataType Constants
+     */
+    public enum DataTypes {
+
+        STRING("string"),
+        INTEGER("integer"),
+        FLOATING("float"),
+        BOOLEAN("boolean");
+
+        private final String value;
+
+        DataTypes(String values) {
+            this.value = values;
+        }
+
+        public String getValue() {
+            return this.value;
+        }
+
+    }
+
+
     /**
      * User account states.
      */

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityMgtConstants.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityMgtConstants.java
@@ -35,7 +35,9 @@ public class IdentityMgtConstants {
         STRING("string"),
         INTEGER("integer"),
         FLOATING("float"),
-        BOOLEAN("boolean");
+        BOOLEAN("boolean"),
+        // Data type for complex objects.
+        COMPLEX("complex");
 
         private final String value;
 

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityMgtConstants.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityMgtConstants.java
@@ -36,8 +36,7 @@ public class IdentityMgtConstants {
         INTEGER("integer"),
         FLOATING("float"),
         BOOLEAN("boolean"),
-        // Data type for complex objects.
-        COMPLEX("complex");
+        URI("uri");
 
         private final String value;
 

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityMgtConstants.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityMgtConstants.java
@@ -21,13 +21,14 @@ package org.wso2.carbon.identity.governance;
  */
 public class IdentityMgtConstants {
 
-    private IdentityMgtConstants(){}
-
     public static final String USER_IDENTITY_CLAIMS = "UserIdentityClaims";
     public static final String ERROR_CODE_DELIMITER = "-";
+    private IdentityMgtConstants() {
 
-    /**.
-     * DataType Constants
+    }
+
+    /**
+     * Data Types used in "Type" property attribute in connectors.
      */
     public enum DataTypes {
 
@@ -39,100 +40,14 @@ public class IdentityMgtConstants {
         private final String value;
 
         DataTypes(String values) {
+
             this.value = values;
         }
 
         public String getValue() {
+
             return this.value;
         }
-
-    }
-
-
-    /**
-     * User account states.
-     */
-    public class AccountStates {
-
-        private AccountStates() {}
-
-        public static final String PENDING_ADMIN_FORCED_USER_PASSWORD_RESET = "PENDING_FUPR";
-    }
-
-    /**
-     * Class that contains the error scenarios.
-     */
-    public static class Error_Scenario {
-
-        public static final String NOTIFICATION_CHANNEL_MANAGER = "NCM";
-        public static final String NOTIFICATION_TEMPLATE_MANAGER = "NTM";
-    }
-
-    public static class PropertyConfig {
-
-        private PropertyConfig(){}
-
-        // Enable notification channel resolver.
-        public static final String RESOLVE_NOTIFICATION_CHANNELS = "Notification.ResolveNotificationChannels.Enable";
-        public static final String CONFIG_FILE_NAME = "identity-mgt.properties";
-        public static final String ACCOUNT_LOCK_ENABLE = "Account.Lock.Enable";
-        public static final String AUTH_POLICY_ENABLE = "Authentication.Policy.Enable";
-        public static final String AUTH_POLICY_ACCOUNT_EXIST = "Authentication.Policy.Check.Account.Exist";
-        public static final String AUTH_POLICY_ACCOUNT_LOCKING_FAIL_ATTEMPTS = "Authentication.Policy.Account.Lock.On.Failure.Max.Attempts";
-        public static final String PASSWORD_POLICY_EXTENSIONS = "Password.policy.extensions";
-        public static final String EXTENSION_USER_DATA_STORE = "Identity.Mgt.User.Data.Store";
-        public static final String EXTENSION_USER_RECOVERY_DATA_STORE = "Identity.Mgt.User.Recovery.Data.Store";
-        public static final String NOTIFICATION_LINK_EXPIRE_TIME = "Notification.Expire.Time";
-
-    }
-
-    public static class Event {
-
-        private Event(){}
-
-        public static final String PRE_AUTHENTICATION = "PRE_AUTHENTICATION";
-
-    }
-
-
-    public static class EventProperty {
-
-        private EventProperty(){}
-
-        public static final String MODULE = "module";
-        public static final String USER_NAME = "userName";
-        public static final String USER_STORE_MANAGER = "userStoreManager";
-        public static final String IDENTITY_MGT_CONFIG = "identityMgtConfig";
-
-    }
-
-    public static class ErrorMessage {
-
-        private ErrorMessage(){}
-
-        public static final String FAILURE = "Failure";
-        public static final String FAILED_AUTHENTICATION = "Authentication Failed.";
-        public static final String FAILED_ENCRYPTION = "Encryption Failed";
-
-    }
-
-    public static class Claim {
-
-        private Claim(){}
-
-        public static final String FAIL_LOGIN_ATTEMPTS = "http://wso2.org/claims/identity/failedLoginAttempts";
-        public static final String UNLOCKING_TIME = "http://wso2.org/claims/identity/unlockTime";
-        public static final String ACCOUNT_LOCK = "http://wso2.org/claims/identity/accountLocked";
-        public static final String PREFERED_CHANNEL_CLAIM = "http://wso2.org/claims/identity/preferredChannel";
-
-    }
-
-    public static class NotificationChannelConstants {
-
-        private NotificationChannelConstants() {
-        }
-
-        public static final String DEFAULT_NOTIFICATION_CHANNEL = "Notification.DefaultNotificationChannel";
     }
 
     public enum LockedReason {
@@ -153,50 +68,148 @@ public class IdentityMgtConstants {
         ERROR_CODE_DEFAULT_UNEXPECTED_ERROR("65000", "Unexpected Error"),
 
         // NCM - notification Channel Manager.
-        ERROR_CODE_UNSUPPORTED_PREFERRED_CHANNEL("NCM-10001","Channel not supported"),
+        ERROR_CODE_UNSUPPORTED_PREFERRED_CHANNEL("NCM-10001", "Channel not supported"),
         ERROR_CODE_NO_CLAIM_MATCHED_FOR_PREFERRED_CHANNEL("NCM-10002",
                 "No claim matched for preferred channel"),
-        ERROR_CODE_NO_NOTIFICATION_CHANNELS("NCM-10003","User has no notification channels"),
+        ERROR_CODE_NO_NOTIFICATION_CHANNELS("NCM-10003", "User has no notification channels"),
         ERROR_CODE_BAD_REQUEST("NCM-10004", "Bad Request"),
         ERROR_CODE_SERVER_ERROR("NCM-15001", "Server Error"),
 
         // NTM - Notification Template Manager.
-        ERROR_CODE_NO_CONTENT_IN_TEMPLATE("NTM-10001","Unable to find any content in %s:%s "
+        ERROR_CODE_NO_CONTENT_IN_TEMPLATE("NTM-10001", "Unable to find any content in %s:%s "
                 + "email template"),
-        ERROR_CODE_INVALID_EMAIL_TEMPLATE_CONTENT("NTM-10002","Template %s:%s body is in "
+        ERROR_CODE_INVALID_EMAIL_TEMPLATE_CONTENT("NTM-10002", "Template %s:%s body is in "
                 + "invalid format. Missing subject,body or footer"),
-        ERROR_CODE_INVALID_SMS_TEMPLATE_CONTENT("NTM-10003","Template %s:%s body is in a "
+        ERROR_CODE_INVALID_SMS_TEMPLATE_CONTENT("NTM-10003", "Template %s:%s body is in a "
                 + "invalid format. Should have only a SMS body"),
-        ERROR_CODE_NO_TEMPLATE_FOUND("NTM-10004","Cannot find '%s' template in the default '%s' "
+        ERROR_CODE_NO_TEMPLATE_FOUND("NTM-10004", "Cannot find '%s' template in the default '%s' "
                 + "locale for '%s' tenant"),
-        ERROR_CODE_INVALID_NOTIFICATION_TEMPLATE("NTM-10005","Invalid notification template"),
-        ERROR_CODE_DESERIALIZING_TEMPLATE_FROM_TENANT_REGISTRY("NTM-65001","Error deserializing '%s:%s' "
+        ERROR_CODE_INVALID_NOTIFICATION_TEMPLATE("NTM-10005", "Invalid notification template"),
+        ERROR_CODE_DESERIALIZING_TEMPLATE_FROM_TENANT_REGISTRY("NTM-65001", "Error deserializing '%s:%s' "
                 + "template from tenant registry"),
-        ERROR_CODE_ERROR_RETRIEVING_TEMPLATE_FROM_REGISTRY("NTM-65002","Error when retrieving '%s:%s' "
+        ERROR_CODE_ERROR_RETRIEVING_TEMPLATE_FROM_REGISTRY("NTM-65002", "Error when retrieving '%s:%s' "
                 + "template from %s tenant registry"),
-        ERROR_CODE_ERROR_RETRIEVING_TEMPLATE_OBJECT_FROM_REGISTRY("NTM-65003","Error retrieving a "
+        ERROR_CODE_ERROR_RETRIEVING_TEMPLATE_OBJECT_FROM_REGISTRY("NTM-65003", "Error retrieving a "
                 + "template object from the registry resource");
 
         private final String code;
         private final String message;
 
         ErrorMessages(String code, String message) {
+
             this.code = code;
             this.message = message;
         }
 
         public String getCode() {
+
             return code;
         }
 
         public String getMessage() {
+
             return message;
         }
 
         @Override
         public String toString() {
+
             return code + " - " + message;
         }
 
+    }
+
+    /**
+     * Class that contains the error scenarios.
+     */
+    public static class Error_Scenario {
+
+        public static final String NOTIFICATION_CHANNEL_MANAGER = "NCM";
+        public static final String NOTIFICATION_TEMPLATE_MANAGER = "NTM";
+    }
+
+    public static class PropertyConfig {
+
+        // Enable notification channel resolver.
+        public static final String RESOLVE_NOTIFICATION_CHANNELS = "Notification.ResolveNotificationChannels.Enable";
+        public static final String CONFIG_FILE_NAME = "identity-mgt.properties";
+        public static final String ACCOUNT_LOCK_ENABLE = "Account.Lock.Enable";
+        public static final String AUTH_POLICY_ENABLE = "Authentication.Policy.Enable";
+        public static final String AUTH_POLICY_ACCOUNT_EXIST = "Authentication.Policy.Check.Account.Exist";
+        public static final String AUTH_POLICY_ACCOUNT_LOCKING_FAIL_ATTEMPTS = "Authentication.Policy.Account.Lock.On.Failure.Max.Attempts";
+        public static final String PASSWORD_POLICY_EXTENSIONS = "Password.policy.extensions";
+        public static final String EXTENSION_USER_DATA_STORE = "Identity.Mgt.User.Data.Store";
+        public static final String EXTENSION_USER_RECOVERY_DATA_STORE = "Identity.Mgt.User.Recovery.Data.Store";
+        public static final String NOTIFICATION_LINK_EXPIRE_TIME = "Notification.Expire.Time";
+        private PropertyConfig() {
+
+        }
+
+    }
+
+    public static class Event {
+
+        public static final String PRE_AUTHENTICATION = "PRE_AUTHENTICATION";
+
+        private Event() {
+
+        }
+
+    }
+
+    public static class EventProperty {
+
+        public static final String MODULE = "module";
+        public static final String USER_NAME = "userName";
+        public static final String USER_STORE_MANAGER = "userStoreManager";
+        public static final String IDENTITY_MGT_CONFIG = "identityMgtConfig";
+        private EventProperty() {
+
+        }
+
+    }
+
+    public static class ErrorMessage {
+
+        public static final String FAILURE = "Failure";
+        public static final String FAILED_AUTHENTICATION = "Authentication Failed.";
+        public static final String FAILED_ENCRYPTION = "Encryption Failed";
+        private ErrorMessage() {
+
+        }
+
+    }
+
+    public static class Claim {
+
+        public static final String FAIL_LOGIN_ATTEMPTS = "http://wso2.org/claims/identity/failedLoginAttempts";
+        public static final String UNLOCKING_TIME = "http://wso2.org/claims/identity/unlockTime";
+        public static final String ACCOUNT_LOCK = "http://wso2.org/claims/identity/accountLocked";
+        public static final String PREFERED_CHANNEL_CLAIM = "http://wso2.org/claims/identity/preferredChannel";
+        private Claim() {
+
+        }
+
+    }
+
+    public static class NotificationChannelConstants {
+
+        public static final String DEFAULT_NOTIFICATION_CHANNEL = "Notification.DefaultNotificationChannel";
+
+        private NotificationChannelConstants() {
+
+        }
+    }
+
+    /**
+     * User account states.
+     */
+    public class AccountStates {
+
+        public static final String PENDING_ADMIN_FORCED_USER_PASSWORD_RESET = "PENDING_FUPR";
+
+        private AccountStates() {
+
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/common/IdentityConnectorConfig.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/common/IdentityConnectorConfig.java
@@ -41,7 +41,8 @@ public interface IdentityConnectorConfig extends ConnectorConfig {
 
     /**
      * Override this method to set meta data properties.
-     * @return Map<String, Property>
+     *
+     * @return Map object, key as property name and value as Property Object
      */
     default Map<String, Property> getMetaData() {
 

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/common/IdentityConnectorConfig.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/common/IdentityConnectorConfig.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.Properties;
 
 /**
- * IdentityConnectorConfig.
+ * This interface is used for create connectors.
  */
 public interface IdentityConnectorConfig extends ConnectorConfig {
 
@@ -39,8 +39,9 @@ public interface IdentityConnectorConfig extends ConnectorConfig {
         return null;
     }
 
-    //meta method
+    //Override this method to set meta data properties.
     default Map<String, Property> getMetaData() {
+
         return null;
     }
 }

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/common/IdentityConnectorConfig.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/common/IdentityConnectorConfig.java
@@ -42,7 +42,7 @@ public interface IdentityConnectorConfig extends ConnectorConfig {
     /**
      * Override this method to set meta data properties.
      *
-     * @return Map object, key as property name and value as Property Object
+     * @return Map object, key as property name and value as Property Object.
      */
     default Map<String, Property> getMetaData() {
 

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/common/IdentityConnectorConfig.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/common/IdentityConnectorConfig.java
@@ -39,7 +39,10 @@ public interface IdentityConnectorConfig extends ConnectorConfig {
         return null;
     }
 
-    //Override this method to set meta data properties.
+    /**
+     * Override this method to set meta data properties.
+     * @return Map<String, Property>
+     */
     default Map<String, Property> getMetaData() {
 
         return null;

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/common/IdentityConnectorConfig.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/common/IdentityConnectorConfig.java
@@ -16,6 +16,7 @@
 
 package org.wso2.carbon.identity.governance.common;
 
+import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.core.ConnectorConfig;
 import org.wso2.carbon.identity.governance.IdentityGovernanceException;
 
@@ -23,6 +24,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+/**
+ * IdentityConnectorConfig.
+ */
 public interface IdentityConnectorConfig extends ConnectorConfig {
 
     Properties getDefaultPropertyValues(String tenantDomain) throws IdentityGovernanceException;
@@ -32,6 +36,11 @@ public interface IdentityConnectorConfig extends ConnectorConfig {
 
     default List<String> getConfidentialPropertyValues(String tenantDomain) {
 
+        return null;
+    }
+
+    //meta method
+    default Map<String, Property> getMetaData() {
         return null;
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/AdminForcedPasswordResetConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/AdminForcedPasswordResetConfigImpl.java
@@ -154,11 +154,11 @@ public class AdminForcedPasswordResetConfigImpl implements IdentityConnectorConf
 
         Map<String, Property> meta = new HashMap<>();
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_ADMIN_PASSWORD_RESET_WITH_RECOVERY_LINK,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_ADMIN_PASSWORD_RESET_WITH_OTP,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_ADMIN_PASSWORD_RESET_OFFLINE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
         return meta;
     }
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/AdminForcedPasswordResetConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/AdminForcedPasswordResetConfigImpl.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.wso2.carbon.identity.governance.IdentityGovernanceUtil.getPropertyObject;
+
 /**
  * Class which contains Admin forced password reset configs.
  */
@@ -145,16 +147,6 @@ public class AdminForcedPasswordResetConfigImpl implements IdentityConnectorConf
             throws IdentityGovernanceException {
 
         return null;
-    }
-
-    private Property getPropertyObject(String type, String regex) {
-
-        Property property = new Property();
-        property.setType(type);
-        if (regex != null) {
-            property.setRegex(regex);
-        }
-        return property;
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/AdminForcedPasswordResetConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/AdminForcedPasswordResetConfigImpl.java
@@ -147,10 +147,13 @@ public class AdminForcedPasswordResetConfigImpl implements IdentityConnectorConf
         return null;
     }
 
-    private Property getPropertyObject(String type) {
+    private Property getPropertyObject(String type, String regex) {
 
         Property property = new Property();
         property.setType(type);
+        if (regex != null) {
+            property.setRegex(regex);
+        }
         return property;
     }
 
@@ -159,11 +162,11 @@ public class AdminForcedPasswordResetConfigImpl implements IdentityConnectorConf
 
         Map<String, Property> meta = new HashMap<>();
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_ADMIN_PASSWORD_RESET_WITH_RECOVERY_LINK,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_ADMIN_PASSWORD_RESET_WITH_OTP,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_ADMIN_PASSWORD_RESET_OFFLINE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
         return meta;
     }
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/AdminForcedPasswordResetConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/AdminForcedPasswordResetConfigImpl.java
@@ -16,8 +16,10 @@
 package org.wso2.carbon.identity.recovery.connector;
 
 import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.governance.IdentityGovernanceException;
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
 import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 
@@ -27,37 +29,46 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+/**
+ * AdminForcedPasswordResetConfigImpl.
+ */
 public class AdminForcedPasswordResetConfigImpl implements IdentityConnectorConfig {
 
     private static final String connectorName = "admin-forced-password-reset";
 
     @Override
     public String getName() {
+
         return connectorName;
     }
 
     @Override
     public String getFriendlyName() {
+
         return "Password Reset";
     }
 
     @Override
     public String getCategory() {
+
         return "Account Management";
     }
 
     @Override
     public String getSubCategory() {
+
         return "DEFAULT";
     }
 
     @Override
     public int getOrder() {
+
         return 0;
     }
 
     @Override
     public Map<String, String> getPropertyNameMapping() {
+
         Map<String, String> nameMapping = new HashMap<>();
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_ADMIN_PASSWORD_RESET_WITH_RECOVERY_LINK,
                 "Enable password reset via recovery e-mail");
@@ -70,6 +81,7 @@ public class AdminForcedPasswordResetConfigImpl implements IdentityConnectorConf
 
     @Override
     public Map<String, String> getPropertyDescriptionMapping() {
+
         Map<String, String> descriptionMapping = new HashMap<>();
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_ADMIN_PASSWORD_RESET_WITH_RECOVERY_LINK,
                 "User gets notified with a link to reset password");
@@ -133,6 +145,24 @@ public class AdminForcedPasswordResetConfigImpl implements IdentityConnectorConf
             throws IdentityGovernanceException {
 
         return null;
+    }
+
+    private Property getPropertyObject(String type) {
+        Property property = new Property();
+        property.setType(type);
+        return property;
+    }
+
+    @Override
+    public Map<String, Property> getMetaData() {
+        Map<String, Property> meta = new HashMap<>();
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_ADMIN_PASSWORD_RESET_WITH_RECOVERY_LINK,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_ADMIN_PASSWORD_RESET_WITH_OTP,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_ADMIN_PASSWORD_RESET_OFFLINE,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+        return meta;
     }
 
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/AdminForcedPasswordResetConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/AdminForcedPasswordResetConfigImpl.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.Properties;
 
 /**
- * AdminForcedPasswordResetConfigImpl.
+ * Class which contains Admin forced password reset configs.
  */
 public class AdminForcedPasswordResetConfigImpl implements IdentityConnectorConfig {
 
@@ -148,6 +148,7 @@ public class AdminForcedPasswordResetConfigImpl implements IdentityConnectorConf
     }
 
     private Property getPropertyObject(String type) {
+
         Property property = new Property();
         property.setType(type);
         return property;
@@ -155,6 +156,7 @@ public class AdminForcedPasswordResetConfigImpl implements IdentityConnectorConf
 
     @Override
     public Map<String, Property> getMetaData() {
+
         Map<String, Property> meta = new HashMap<>();
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_ADMIN_PASSWORD_RESET_WITH_RECOVERY_LINK,
                 getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/LiteRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/LiteRegistrationConfigImpl.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.wso2.carbon.identity.governance.IdentityGovernanceUtil.getPropertyObject;
+
 /**
  * Class which contains Lite user sign-up configs.
  */
@@ -220,16 +222,6 @@ public class LiteRegistrationConfigImpl implements IdentityConnectorConfig {
             throws IdentityGovernanceException {
 
         return null;
-    }
-
-    private Property getPropertyObject(String type, String regex) {
-
-        Property property = new Property();
-        property.setType(type);
-        if (regex != null) {
-            property.setRegex(regex);
-        }
-        return property;
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/LiteRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/LiteRegistrationConfigImpl.java
@@ -16,8 +16,10 @@
 package org.wso2.carbon.identity.recovery.connector;
 
 import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.governance.IdentityGovernanceException;
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
 import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 
@@ -30,6 +32,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+/**
+ * LiteRegistrationConfigImpl.
+ */
 public class LiteRegistrationConfigImpl implements IdentityConnectorConfig {
 
     private static final String connectorName = "lite-user-sign-up";
@@ -45,26 +50,31 @@ public class LiteRegistrationConfigImpl implements IdentityConnectorConfig {
 
     @Override
     public String getName() {
+
         return connectorName;
     }
 
     @Override
     public String getFriendlyName() {
+
         return FRIENDLY_NAME;
     }
 
     @Override
     public String getCategory() {
+
         return CATEGORY;
     }
 
     @Override
     public String getSubCategory() {
+
         return "DEFAULT";
     }
 
     @Override
     public int getOrder() {
+
         return 0;
     }
 
@@ -210,6 +220,40 @@ public class LiteRegistrationConfigImpl implements IdentityConnectorConfig {
             throws IdentityGovernanceException {
 
         return null;
+    }
+
+    private Property getPropertyObject(String type) {
+        Property property = new Property();
+        property.setType(type);
+        return property;
+    }
+
+    @Override
+    public Map<String, Property> getMetaData() {
+
+        Map<String, Property> meta = new HashMap<>();
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_LITE_SIGN_UP,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_ACCOUNT_LOCK_ON_CREATION,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_REGISTRATION_RE_CAPTCHA,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME,
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME,
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+
+        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
+
+        return meta;
     }
 
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/LiteRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/LiteRegistrationConfigImpl.java
@@ -247,10 +247,10 @@ public class LiteRegistrationConfigImpl implements IdentityConnectorConfig {
         meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME,
                 getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
 
-        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
+        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.COMPLEX.getValue()));
+
         meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_REGISTRATION_CALLBACK_REGEX,
-                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(),
-                        IdentityRecoveryConstants.DEFAULT_CALLBACK_REGEX));
+                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
 
         return meta;
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/LiteRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/LiteRegistrationConfigImpl.java
@@ -222,10 +222,13 @@ public class LiteRegistrationConfigImpl implements IdentityConnectorConfig {
         return null;
     }
 
-    private Property getPropertyObject(String type) {
+    private Property getPropertyObject(String type, String regex) {
 
         Property property = new Property();
         property.setType(type);
+        if (regex != null) {
+            property.setRegex(regex);
+        }
         return property;
     }
 
@@ -235,24 +238,28 @@ public class LiteRegistrationConfigImpl implements IdentityConnectorConfig {
         Map<String, Property> meta = new HashMap<>();
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_LITE_SIGN_UP,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_ACCOUNT_LOCK_ON_CREATION,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_REGISTRATION_RE_CAPTCHA,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
 
-        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
+        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(),
+                null));
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_REGISTRATION_CALLBACK_REGEX,
+                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(),
+                        IdentityRecoveryConstants.DEFAULT_CALLBACK_REGEX));
 
         return meta;
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/LiteRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/LiteRegistrationConfigImpl.java
@@ -247,7 +247,7 @@ public class LiteRegistrationConfigImpl implements IdentityConnectorConfig {
         meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME,
                 getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
 
-        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.COMPLEX.getValue()));
+        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.URI.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_REGISTRATION_CALLBACK_REGEX,
                 getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/LiteRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/LiteRegistrationConfigImpl.java
@@ -230,25 +230,24 @@ public class LiteRegistrationConfigImpl implements IdentityConnectorConfig {
         Map<String, Property> meta = new HashMap<>();
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_LITE_SIGN_UP,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_ACCOUNT_LOCK_ON_CREATION,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_REGISTRATION_RE_CAPTCHA,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
 
-        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(),
-                null));
+        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
         meta.put(IdentityRecoveryConstants.ConnectorConfig.LITE_REGISTRATION_CALLBACK_REGEX,
                 getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(),
                         IdentityRecoveryConstants.DEFAULT_CALLBACK_REGEX));

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/LiteRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/LiteRegistrationConfigImpl.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.Properties;
 
 /**
- * LiteRegistrationConfigImpl.
+ * Class which contains Lite user sign-up configs.
  */
 public class LiteRegistrationConfigImpl implements IdentityConnectorConfig {
 
@@ -223,6 +223,7 @@ public class LiteRegistrationConfigImpl implements IdentityConnectorConfig {
     }
 
     private Property getPropertyObject(String type) {
+
         Property property = new Property();
         property.setType(type);
         return property;

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.wso2.carbon.identity.governance.IdentityGovernanceUtil.getPropertyObject;
+
 /**
  * Class which contains account recovery configs.
  */
@@ -344,16 +346,6 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
             throws IdentityGovernanceException {
 
         return null;
-    }
-
-    private Property getPropertyObject(String type, String regex) {
-
-        Property property = new Property();
-        property.setType(type);
-        if (regex != null) {
-            property.setRegex(regex);
-        }
-        return property;
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
@@ -16,8 +16,10 @@
 package org.wso2.carbon.identity.recovery.connector;
 
 import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.governance.IdentityGovernanceException;
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
 import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 
@@ -36,26 +38,31 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
 
     @Override
     public String getName() {
+
         return connectorName;
     }
 
     @Override
     public String getFriendlyName() {
+
         return "Account Recovery";
     }
 
     @Override
     public String getCategory() {
+
         return "Account Management";
     }
 
     @Override
     public String getSubCategory() {
+
         return "DEFAULT";
     }
 
     @Override
     public int getOrder() {
+
         return 0;
     }
 
@@ -108,6 +115,7 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
 
     @Override
     public Map<String, String> getPropertyDescriptionMapping() {
+
         Map<String, String> descriptionMapping = new HashMap<>();
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE,
                 "Disable if the client application handles notification sending");
@@ -336,6 +344,71 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
             throws IdentityGovernanceException {
 
         return null;
+    }
+
+    private Property getPropertyObject(String type) {
+        Property property = new Property();
+        property.setType(type);
+        return property;
+    }
+
+    @Override
+    public Map<String, Property> getMetaData() {
+
+        Map<String, Property> meta = new HashMap<>();
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_RECAPTCHA_ENABLE,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.QUESTION_BASED_PW_RECOVERY,
+                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.QUESTION_MIN_NO_ANSWER,
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.ENFORCE_CHALLENGE_QUESTION_ANSWER_UNIQUENESS,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_QUESTION_PASSWORD_RECAPTCHA_ENABLE,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_QUESTION_PASSWORD_RECAPTCHA_MAX_FAILED_ATTEMPTS,
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.USERNAME_RECOVERY_ENABLE,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.USERNAME_RECOVERY_RECAPTCHA_ENABLE,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.EXPIRY_TIME,
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_EXPIRY_TIME,
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_SEND_RECOVERY_NOTIFICATION_SUCCESS,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_SEND_RECOVERY_SECURITY_START,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.FORCE_ADD_PW_RECOVERY_QUESTION,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.FORCE_MIN_NO_QUESTION_ANSWERED,
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_AUTO_LGOIN_AFTER_PASSWORD_RESET,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        return meta;
     }
 
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
@@ -354,55 +354,55 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         Map<String, Property> meta = new HashMap<>();
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_RECAPTCHA_ENABLE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.QUESTION_BASED_PW_RECOVERY,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.QUESTION_MIN_NO_ANSWER,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENFORCE_CHALLENGE_QUESTION_ANSWER_UNIQUENESS,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_QUESTION_PASSWORD_RECAPTCHA_ENABLE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_QUESTION_PASSWORD_RECAPTCHA_MAX_FAILED_ATTEMPTS,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.USERNAME_RECOVERY_ENABLE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.USERNAME_RECOVERY_RECAPTCHA_ENABLE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_SEND_RECOVERY_NOTIFICATION_SUCCESS,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_SEND_RECOVERY_SECURITY_START,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.FORCE_ADD_PW_RECOVERY_QUESTION,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.FORCE_MIN_NO_QUESTION_ANSWERED,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_AUTO_LGOIN_AFTER_PASSWORD_RESET,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.CHALLENGE_QUESTION_ANSWER_REGEX,
                 getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(),

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
@@ -347,6 +347,7 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
     }
 
     private Property getPropertyObject(String type) {
+
         Property property = new Property();
         property.setType(type);
         return property;

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
@@ -368,7 +368,7 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
                 getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.QUESTION_BASED_PW_RECOVERY,
-                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.QUESTION_MIN_NO_ANSWER,
                 getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
@@ -346,10 +346,13 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         return null;
     }
 
-    private Property getPropertyObject(String type) {
+    private Property getPropertyObject(String type, String regex) {
 
         Property property = new Property();
         property.setType(type);
+        if (regex != null) {
+            property.setRegex(regex);
+        }
         return property;
     }
 
@@ -359,55 +362,63 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         Map<String, Property> meta = new HashMap<>();
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_RECAPTCHA_ENABLE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.QUESTION_BASED_PW_RECOVERY,
-                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.QUESTION_MIN_NO_ANSWER,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENFORCE_CHALLENGE_QUESTION_ANSWER_UNIQUENESS,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_QUESTION_PASSWORD_RECAPTCHA_ENABLE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_QUESTION_PASSWORD_RECAPTCHA_MAX_FAILED_ATTEMPTS,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.USERNAME_RECOVERY_ENABLE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.USERNAME_RECOVERY_RECAPTCHA_ENABLE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_SEND_RECOVERY_NOTIFICATION_SUCCESS,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_SEND_RECOVERY_SECURITY_START,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.FORCE_ADD_PW_RECOVERY_QUESTION,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.FORCE_MIN_NO_QUESTION_ANSWERED,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_AUTO_LGOIN_AFTER_PASSWORD_RESET,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.CHALLENGE_QUESTION_ANSWER_REGEX,
+                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(),
+                        IdentityRecoveryConstants.DEFAULT_REGEX));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_CALLBACK_REGEX,
+                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(),
+                        IdentityRecoveryConstants.DEFAULT_CALLBACK_REGEX));
 
         return meta;
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
@@ -405,12 +405,10 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
                 getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.CHALLENGE_QUESTION_ANSWER_REGEX,
-                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(),
-                        IdentityRecoveryConstants.DEFAULT_REGEX));
+                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_CALLBACK_REGEX,
-                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(),
-                        IdentityRecoveryConstants.DEFAULT_CALLBACK_REGEX));
+                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
 
         return meta;
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
@@ -292,10 +292,13 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
         return null;
     }
 
-    private Property getPropertyObject(String type) {
+    private Property getPropertyObject(String type, String regex) {
 
         Property property = new Property();
         property.setType(type);
+        if (regex != null) {
+            property.setRegex(regex);
+        }
         return property;
     }
 
@@ -304,39 +307,44 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
 
         Map<String, Property> meta = new HashMap<>();
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_AUTO_LOGIN,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_AUTO_LOGIN_ALIAS_NAME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_NOTIFY_ACCOUNT_CONFIRMATION,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.RESEND_CONFIRMATION_RECAPTCHA_ENABLE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
-        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
+        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(),
+                null));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_CALLBACK_REGEX,
+                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(),
+                        IdentityRecoveryConstants.DEFAULT_CALLBACK_REGEX));
 
         return meta;
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.wso2.carbon.identity.governance.IdentityGovernanceUtil.getPropertyObject;
+
 /**
  * Class which contains self sign up configs.
  */
@@ -290,16 +292,6 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
             throws IdentityGovernanceException {
 
         return null;
-    }
-
-    private Property getPropertyObject(String type, String regex) {
-
-        Property property = new Property();
-        property.setType(type);
-        if (regex != null) {
-            property.setRegex(regex);
-        }
-        return property;
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
@@ -299,40 +299,39 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
 
         Map<String, Property> meta = new HashMap<>();
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_AUTO_LOGIN,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_AUTO_LOGIN_ALIAS_NAME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_NOTIFY_ACCOUNT_CONFIRMATION,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.RESEND_CONFIRMATION_RECAPTCHA_ENABLE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
-        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(),
-                null));
+        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_CALLBACK_REGEX,
                 getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(),

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
@@ -330,7 +330,7 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
         meta.put(IdentityRecoveryConstants.ConnectorConfig.RESEND_CONFIRMATION_RECAPTCHA_ENABLE,
                 getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
-        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.COMPLEX.getValue()));
+        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.URI.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_CALLBACK_REGEX,
                 getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.Properties;
 
 /**
- * SelfRegistrationConfigImpl.
+ * Class which contains self sign up configs.
  */
 
 public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
@@ -292,8 +292,8 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
         return null;
     }
 
-
     private Property getPropertyObject(String type) {
+
         Property property = new Property();
         property.setType(type);
         return property;

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
@@ -37,7 +37,6 @@ import static org.wso2.carbon.identity.governance.IdentityGovernanceUtil.getProp
 /**
  * Class which contains self sign up configs.
  */
-
 public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
 
     private static final String CONNECTOR_NAME = "self-sign-up";
@@ -331,11 +330,10 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
         meta.put(IdentityRecoveryConstants.ConnectorConfig.RESEND_CONFIRMATION_RECAPTCHA_ENABLE,
                 getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
-        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
+        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.COMPLEX.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_CALLBACK_REGEX,
-                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(),
-                        IdentityRecoveryConstants.DEFAULT_CALLBACK_REGEX));
+                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
 
         return meta;
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
@@ -16,8 +16,10 @@
 package org.wso2.carbon.identity.recovery.connector;
 
 import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.governance.IdentityGovernanceException;
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
 import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 
@@ -30,6 +32,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+/**
+ * SelfRegistrationConfigImpl.
+ */
+
 public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
 
     private static final String CONNECTOR_NAME = "self-sign-up";
@@ -40,31 +46,36 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
     private static final String SIGNUP_PURPOSE_GROUP_TYPE = "SYSTEM";
     private static final String CALLBACK_URL = "/carbon/idpmgt/idp-mgt-edit-local.jsp?category=" + CATEGORY +
             "&subCategory=" + FRIENDLY_NAME;
-    private static final String consentListURL = "/carbon/consent/list-purposes.jsp?purposeGroup=" + SYSTEM_PURPOSE_GROUP +
-            "&purposeGroupType=" + SIGNUP_PURPOSE_GROUP_TYPE;
+    private static final String consentListURL = "/carbon/consent/list-purposes.jsp?purposeGroup=" +
+            SYSTEM_PURPOSE_GROUP + "&purposeGroupType=" + SIGNUP_PURPOSE_GROUP_TYPE;
 
     @Override
     public String getName() {
+
         return CONNECTOR_NAME;
     }
 
     @Override
     public String getFriendlyName() {
+
         return FRIENDLY_NAME;
     }
 
     @Override
     public String getCategory() {
+
         return CATEGORY;
     }
 
     @Override
     public String getSubCategory() {
+
         return "DEFAULT";
     }
 
     @Override
     public int getOrder() {
+
         return 0;
     }
 
@@ -178,7 +189,7 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
                 IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP);
         String accountLockProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION);
-        String SendNotificationOnCreationProperty = IdentityUtil.getProperty(
+        String sendNotificationOnCreationProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION);
         String notificationInternallyMangedProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE);
@@ -205,8 +216,8 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
         if (StringUtils.isNotEmpty(accountLockProperty)) {
             enableAccountLockOnCreation = accountLockProperty;
         }
-        if (StringUtils.isNotEmpty(SendNotificationOnCreationProperty)) {
-            enableSendNotificationOnCreation = SendNotificationOnCreationProperty;
+        if (StringUtils.isNotEmpty(sendNotificationOnCreationProperty)) {
+            enableSendNotificationOnCreation = sendNotificationOnCreationProperty;
         }
         if (StringUtils.isNotEmpty(notificationInternallyMangedProperty)) {
             enableNotificationInternallyManage = notificationInternallyMangedProperty;
@@ -262,7 +273,8 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
         } catch (UnsupportedEncodingException e) {
             throw new IdentityGovernanceException("Error while encoding callback url: " + CALLBACK_URL, e);
         }
-        defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_CALLBACK_REGEX, selfRegistrationCallbackRegex);
+        defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_CALLBACK_REGEX,
+                selfRegistrationCallbackRegex);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_NOTIFY_ACCOUNT_CONFIRMATION,
                 enableSelfSignUpConfirmationNotification);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.RESEND_CONFIRMATION_RECAPTCHA_ENABLE,
@@ -278,6 +290,55 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
             throws IdentityGovernanceException {
 
         return null;
+    }
+
+
+    private Property getPropertyObject(String type) {
+        Property property = new Property();
+        property.setType(type);
+        return property;
+    }
+
+    @Override
+    public Map<String, Property> getMetaData() {
+
+        Map<String, Property> meta = new HashMap<>();
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.SEND_CONFIRMATION_NOTIFICATION,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_RE_CAPTCHA,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_VERIFICATION_CODE_EXPIRY_TIME,
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME,
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_AUTO_LOGIN,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_AUTO_LOGIN_ALIAS_NAME,
+                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_NOTIFY_ACCOUNT_CONFIRMATION,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.RESEND_CONFIRMATION_RECAPTCHA_ENABLE,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
+
+        return meta;
     }
 
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImpl.java
@@ -254,10 +254,13 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
         }
     }
 
-    private Property getPropertyObject(String type) {
+    private Property getPropertyObject(String type, String regex) {
 
         Property property = new Property();
         property.setType(type);
+        if (regex != null) {
+            property.setRegex(regex);
+        }
         return property;
     }
 
@@ -267,19 +270,19 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
         Map<String, Property> meta = new HashMap<>();
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION_ON_UPDATE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_NOTIFICATION_ON_EMAIL_UPDATE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_NUM_VERIFICATION_ON_UPDATE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
 
         return meta;
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImpl.java
@@ -255,11 +255,11 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
     }
 
     private Property getPropertyObject(String type) {
+
         Property property = new Property();
         property.setType(type);
         return property;
     }
-
 
     @Override
     public Map<String, Property> getMetaData() {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImpl.java
@@ -18,9 +18,11 @@ package org.wso2.carbon.identity.recovery.connector;
 import org.apache.axiom.om.OMElement;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.governance.IdentityGovernanceException;
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
 import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 
@@ -250,5 +252,35 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
                 }
             }
         }
+    }
+
+    private Property getPropertyObject(String type) {
+        Property property = new Property();
+        property.setType(type);
+        return property;
+    }
+
+
+    @Override
+    public Map<String, Property> getMetaData() {
+
+        Map<String, Property> meta = new HashMap<>();
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION_ON_UPDATE,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_NOTIFICATION_ON_EMAIL_UPDATE,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_NUM_VERIFICATION_ON_UPDATE,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_EXPIRY_TIME,
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME,
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+
+        return meta;
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImpl.java
@@ -262,19 +262,19 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
         Map<String, Property> meta = new HashMap<>();
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION_ON_UPDATE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_NOTIFICATION_ON_EMAIL_UPDATE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_NUM_VERIFICATION_ON_UPDATE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
 
         return meta;
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImpl.java
@@ -34,6 +34,8 @@ import java.util.Map;
 import java.util.Properties;
 import javax.xml.namespace.QName;
 
+import static org.wso2.carbon.identity.governance.IdentityGovernanceUtil.getPropertyObject;
+
 /**
  * Class which contains user claim update configs.
  */
@@ -254,16 +256,6 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
         }
     }
 
-    private Property getPropertyObject(String type, String regex) {
-
-        Property property = new Property();
-        property.setType(type);
-        if (regex != null) {
-            property.setRegex(regex);
-        }
-        return property;
-    }
-
     @Override
     public Map<String, Property> getMetaData() {
 
@@ -286,4 +278,5 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
 
         return meta;
     }
+
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImpl.java
@@ -235,8 +235,7 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ASK_PASSWORD_TEMP_PASSWORD_GENERATOR,
                 getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
 
-        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(),
-                null, 0));
+        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.COMPLEX.getValue()));
 
         return meta;
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImpl.java
@@ -31,8 +31,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+
 /**
- * UserEmailVerificationConfigImpl.
+ * Class which contains user email verification configs.
  */
 public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig {
 
@@ -49,31 +50,37 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
 
     @Override
     public String getName() {
+
         return connectorName;
     }
 
     @Override
     public String getFriendlyName() {
+
         return FRIENDLY_NAME;
     }
 
     @Override
     public String getCategory() {
+
         return CATEGORY;
     }
 
     @Override
     public String getSubCategory() {
+
         return "DEFAULT";
     }
 
     @Override
     public int getOrder() {
+
         return 0;
     }
 
     @Override
     public Map<String, String> getPropertyNameMapping() {
+
         Map<String, String> nameMapping = new HashMap<>();
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION,
                 "Enable user email verification");
@@ -93,6 +100,7 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
 
     @Override
     public Map<String, String> getPropertyDescriptionMapping() {
+
         Map<String, String> descriptionMapping = new HashMap<>();
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION,
                 "A verification notification will be triggered during user creation.");
@@ -203,6 +211,7 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
     }
 
     private Property getPropertyObject(String type) {
+
         Property property = new Property();
         property.setType(type);
         return property;
@@ -210,7 +219,6 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
 
     @Override
     public Map<String, Property> getMetaData() {
-
 
         Map<String, Property> meta = new HashMap<>();
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImpl.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.wso2.carbon.identity.governance.IdentityGovernanceUtil.getPropertyObject;
+
 /**
  * Class which contains user email verification configs.
  */
@@ -210,16 +212,6 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
         return null;
     }
 
-    private Property getPropertyObject(String type, String regex) {
-
-        Property property = new Property();
-        property.setType(type);
-        if (regex != null) {
-            property.setRegex(regex);
-        }
-        return property;
-    }
-
     @Override
     public Map<String, Property> getMetaData() {
 
@@ -248,4 +240,5 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
 
         return meta;
     }
+
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImpl.java
@@ -235,7 +235,7 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ASK_PASSWORD_TEMP_PASSWORD_GENERATOR,
                 getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
 
-        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.COMPLEX.getValue()));
+        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.URI.getValue()));
 
         return meta;
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImpl.java
@@ -210,10 +210,13 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
         return null;
     }
 
-    private Property getPropertyObject(String type) {
+    private Property getPropertyObject(String type, String regex) {
 
         Property property = new Property();
         property.setType(type);
+        if (regex != null) {
+            property.setRegex(regex);
+        }
         return property;
     }
 
@@ -223,25 +226,25 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
         Map<String, Property> meta = new HashMap<>();
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ASK_PASSWORD_EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_ACCOUNT_LOCK_ON_CREATION,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_INTERNALLY_MANAGE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ASK_PASSWORD_TEMP_PASSWORD_GENERATOR,
-                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
+                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(), null));
 
-        meta.put(LIST_PURPOSE_PROPERTY_KEY,
-                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
+        meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(),
+                null));
 
         return meta;
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImpl.java
@@ -16,8 +16,10 @@
 package org.wso2.carbon.identity.recovery.connector;
 
 import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.governance.IdentityGovernanceException;
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
 import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 
@@ -29,7 +31,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-
+/**
+ * UserEmailVerificationConfigImpl.
+ */
 public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig {
 
     private static final String connectorName = "user-email-verification";
@@ -198,4 +202,39 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
         return null;
     }
 
+    private Property getPropertyObject(String type) {
+        Property property = new Property();
+        property.setType(type);
+        return property;
+    }
+
+    @Override
+    public Map<String, Property> getMetaData() {
+
+
+        Map<String, Property> meta = new HashMap<>();
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_EXPIRY_TIME,
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.ASK_PASSWORD_EXPIRY_TIME,
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_ACCOUNT_LOCK_ON_CREATION,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_INTERNALLY_MANAGE,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.ASK_PASSWORD_TEMP_PASSWORD_GENERATOR,
+                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
+
+        meta.put(LIST_PURPOSE_PROPERTY_KEY,
+                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
+
+        return meta;
+    }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImpl.java
@@ -218,25 +218,25 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
         Map<String, Property> meta = new HashMap<>();
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ASK_PASSWORD_EXPIRY_TIME,
-                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_ACCOUNT_LOCK_ON_CREATION,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_INTERNALLY_MANAGE,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ASK_PASSWORD_TEMP_PASSWORD_GENERATOR,
-                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(), null));
+                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
 
         meta.put(LIST_PURPOSE_PROPERTY_KEY, getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue(),
-                null));
+                null, 0));
 
         return meta;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -698,7 +698,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.20.39</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.84</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.28, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Purpose 
Adding metadata properties to identity governance connectors.

### Changes in this pull request
This PR  has added new `` default `` method to `` IdentityConnectorConfig`` interface  which returns meta data property object to `` IdentityGovernanceServiceImpl `` .

Related issue [10084](https://github.com/wso2/product-is/issues/10084)