### PR TITLE
Disable legacy audit logs based of a property

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1042,13 +1042,16 @@ public class Utils {
      */
     public static void createAuditMessage(String action, String target, JSONObject dataObject, String result) {
 
-        String loggedInUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
-        if (StringUtils.isBlank(loggedInUser)) {
-            loggedInUser = CarbonConstants.REGISTRY_SYSTEM_USERNAME;
+        if (!Boolean.parseBoolean(System.getProperty(CarbonConstants.DISABLE_LEGACY_LOGS))) {
+            String loggedInUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
+            if (StringUtils.isBlank(loggedInUser)) {
+                loggedInUser = CarbonConstants.REGISTRY_SYSTEM_USERNAME;
+            }
+            String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+            loggedInUser = UserCoreUtil.addTenantDomainToEntry(loggedInUser, tenantDomain);
+            AUDIT_LOG.info(String
+                    .format(AuditConstants.AUDIT_MESSAGE, loggedInUser, action, target, dataObject, result));
         }
-        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-        loggedInUser = UserCoreUtil.addTenantDomainToEntry(loggedInUser, tenantDomain);
-        AUDIT_LOG.info(String.format(AuditConstants.AUDIT_MESSAGE, loggedInUser, action, target, dataObject, result));
     }
 
     /**

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -82,6 +82,8 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
+import static org.wso2.carbon.utils.CarbonUtils.isLegacyAuditLogsDisabled;
+
 /**
  * Class which contains the Utils for user recovery.
  */
@@ -1042,7 +1044,7 @@ public class Utils {
      */
     public static void createAuditMessage(String action, String target, JSONObject dataObject, String result) {
 
-        if (!Boolean.parseBoolean(System.getProperty(CarbonConstants.DISABLE_LEGACY_LOGS))) {
+        if (!isLegacyAuditLogsDisabled()) {
             String loggedInUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
             if (StringUtils.isBlank(loggedInUser)) {
                 loggedInUser = CarbonConstants.REGISTRY_SYSTEM_USERNAME;

--- a/pom.xml
+++ b/pom.xml
@@ -615,7 +615,7 @@
         <identity.data.publisher.authentication.version>5.3.0</identity.data.publisher.authentication.version>
 
         <!--Carbon Kernel Version-->
-        <carbon.kernel.version>4.6.2-m4</carbon.kernel.version>
+        <carbon.kernel.version>4.6.3-m5</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.1</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request
Fix part of wso2/product-is#5037

This is the deployment.toml config to disable legacy audit logs. The default value for the disableLegacyAuditLogs is set to true once the new audit logs are added to every component.
```
[system.parameter]
disableLegacyAuditLogs=true
```
### Depends on
- [x]  https://github.com/wso2/carbon-kernel/pull/3021. bump Kernel version