### PR TITLE
Fix account state update in ask password recovery scenario

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -607,7 +607,8 @@ public class NotificationPasswordRecoveryManager {
         // If the scenario is initiated by the admin, set the account locked claim to TRUE.
         if (RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_EMAIL_LINK.equals(userRecoveryData.getRecoveryScenario())
                 || RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_OTP.
-                equals(userRecoveryData.getRecoveryScenario())) {
+                equals(userRecoveryData.getRecoveryScenario()) ||
+                RecoveryScenarios.ASK_PASSWORD.equals(userRecoveryData.getRecoveryScenario())) {
             userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.FALSE.toString());
             userClaims.remove(IdentityRecoveryConstants.ACCOUNT_LOCKED_REASON_CLAIM);
             userClaims.remove(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI);
@@ -869,3 +870,4 @@ public class NotificationPasswordRecoveryManager {
         return userList;
     }
 }
+


### PR DESCRIPTION
### Proposed changes in this pull request

Fix account state update during the ask password recovery scenario. This is used to resolve sending two emails during the ask password recovery scenario.
 
https://github.com/wso2-extensions/identity-event-handler-account-lock/pull/97 