### PR TITLE
Rename account lock on failed login attempts config

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/SecurityQuestionPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/SecurityQuestionPasswordRecoveryManager.java
@@ -78,7 +78,7 @@ public class SecurityQuestionPasswordRecoveryManager {
 
     private static final Log log = LogFactory.getLog(SecurityQuestionPasswordRecoveryManager.class);
 
-    private static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE = "account.lock.handler.enable";
+    private static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE = "account.lock.handler.lock.on.max.failed.attempts.enable";
 
     private static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX = "account.lock.handler.On.Failure.Max.Attempts";
 


### PR DESCRIPTION
### Proposed changes in this pull request

Change the general account lock enable config to a max failed attempts based lock specific config. (With this PR the existing `account.lock.handler.enable` config will be replaced with `account.lock.handler.lock.on.max.failed.attempts.enable`.)

### When should this PR be merged
After https://github.com/wso2/carbon-identity-framework/pull/3648