### PR TITLE
Username domain qualified for secondary userstores during mobile number verification

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -80,6 +80,7 @@ import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.Permission;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.UserStoreConfigConstants;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
@@ -977,7 +978,12 @@ public class UserSelfRegistrationManager {
 
         validateContextTenantDomainWithUserTenantDomain(user);
         String contextUsername = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
-        String username = user.getUserName();
+        String username;
+        if (!UserStoreConfigConstants.PRIMARY.equals(user.getUserStoreDomain())) {
+            username = user.getUserStoreDomain() + CarbonConstants.DOMAIN_SEPARATOR + user.getUserName();
+        } else {
+            username = user.getUserName();
+        }
         if (!StringUtils.equalsIgnoreCase(contextUsername, username)) {
             throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_USER,
                     contextUsername);


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/product-is/issues/12106
> Mobile number verification fails for users of secondary userstores during user validation. This is because usernames from the request auth and carbon context that are being compared are not similar. The username returned from the context is domain qualified, but the username from the request is not.
This PR domain qualifies that username as well if the user is from a secondary userstore.