### PR TITLE
Fix 'notify=false' NOT giving same code in password recovery REST API

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1190,8 +1190,7 @@ public class Utils {
     public static boolean reIssueExistingConfirmationCode(UserRecoveryData recoveryDataDO, String notificationChannel) {
 
         int codeToleranceInMinutes = getEmailCodeToleranceInMinutes();
-        if (recoveryDataDO != null && codeToleranceInMinutes != 0 &&
-                NotificationChannels.EMAIL_CHANNEL.getChannelType().equals(notificationChannel)) {
+        if (recoveryDataDO != null && codeToleranceInMinutes != 0) {
             if (RecoveryScenarios.NOTIFICATION_BASED_PW_RECOVERY.toString().
                     equals(recoveryDataDO.getRecoveryScenario().toString())) {
                 long codeToleranceTimeInMillis = recoveryDataDO.getTimeCreated().getTime() +


### PR DESCRIPTION
**Purpose**
Fix different confirmation codes(secret) are issued for back-to-back API calls when 'type=email&notify=false' is used in the password recovery flow through REST API.

Fixes https://github.com/wso2/product-is/issues/12134
