### PR TITLE
Trigger the identity listener for update user list of hybrid role

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
@@ -607,6 +607,25 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
         return true;
     }
 
+    @Override
+    public boolean doPostUpdateUserListOfInternalRole(String roleName, String deletedUsers[],
+                                              String[] newUsers, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        if (!isEnable()) {
+            return true;
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("post update user list of internal role is called in IdentityMgtEventListener");
+        }
+        String eventName = IdentityEventConstants.Event.POST_UPDATE_USER_LIST_OF_HYBRID_ROLE;
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put(IdentityEventConstants.EventProperty.DELETED_USERS, deletedUsers);
+        properties.put(IdentityEventConstants.EventProperty.NEW_USERS, newUsers);
+        handleEvent(null, userStoreManager, eventName, roleName, properties);
+        return true;
+    }
+
     public boolean doPreUpdateRoleListOfUser(String userName, String[] deletedRoles,
                                              String[] newRoles,
                                              UserStoreManager userStoreManager)
@@ -1544,6 +1563,26 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
             log.debug("post update user list of role with id is called in IdentityMgtEventListener");
         }
         String eventName = IdentityEventConstants.Event.POST_UPDATE_USER_LIST_OF_ROLE_WITH_ID;
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put(IdentityEventConstants.EventProperty.ROLE_NAME, roleName);
+        properties.put(IdentityEventConstants.EventProperty.DELETED_USERS, deletedUsers);
+        properties.put(IdentityEventConstants.EventProperty.NEW_USERS, newUsers);
+
+        handleEvent(eventName, properties, userStoreManager);
+        return true;
+    }
+
+    @Override
+    public boolean doPostUpdateUserListOfInternalRoleWithID(String roleName, String[] deletedUsers, String[] newUsers,
+                                                    UserStoreManager userStoreManager) throws UserStoreException {
+
+        if (!isEnable()) {
+            return true;
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("post update user list of role with id is called in IdentityMgtEventListener");
+        }
+        String eventName = IdentityEventConstants.Event.POST_UPDATE_USER_LIST_OF_HYBRID_ROLE_WITH_ID;
         HashMap<String, Object> properties = new HashMap<>();
         properties.put(IdentityEventConstants.EventProperty.ROLE_NAME, roleName);
         properties.put(IdentityEventConstants.EventProperty.DELETED_USERS, deletedUsers);

--- a/pom.xml
+++ b/pom.xml
@@ -615,14 +615,14 @@
         <identity.data.publisher.authentication.version>5.3.0</identity.data.publisher.authentication.version>
 
         <!--Carbon Kernel Version-->
-        <carbon.kernel.version>4.6.3-m5</carbon.kernel.version>
+        <carbon.kernel.version>4.6.2-m4</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.1</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.20.142</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.39</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.28, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -615,14 +615,14 @@
         <identity.data.publisher.authentication.version>5.3.0</identity.data.publisher.authentication.version>
 
         <!--Carbon Kernel Version-->
-        <carbon.kernel.version>4.6.2-m4</carbon.kernel.version>
+        <carbon.kernel.version>4.7.0-m3</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.1</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.20.39</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.183</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.28, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -622,7 +622,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.20.183</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.184</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.28, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request

Resolves https://github.com/wso2/product-is/issues/12115
Depends on https://github.com/wso2/carbon-identity-framework/pull/3708

If you want to trigger the new event **POST_UPDATE_USER_LIST_OF_HYBRID_ROLE**, you should add the subscription through deployment.toml file. 

For example if you want to trigger the event **POST_UPDATE_USER_LIST_OF_HYBRID_ROLE** for account lock handler then you should add the below to deployment.toml file.

[identity_mgt.events.schemes.'account.lock.handler']
subscriptions = ["PRE_AUTHENTICATION",
    "POST_AUTHENTICATION",
    "PRE_SET_USER_CLAIMS",
    "POST_SET_USER_CLAIMS",
"POST_UPDATE_USER_LIST_OF_HYBRID_ROLE"]
