### PR TITLE
Set tenant domain to the resolved user

### DIFF
--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
@@ -71,6 +71,7 @@ public class RegexResolver implements MultiAttributeLoginResolver {
                         resolvedUserResult.setResolvedValue(loginAttribute);
                         User user = userList.get(0);
                         user.setUsername(user.getDomainQualifiedUsername());
+                        user.setTenantDomain(tenantDomain);
                         resolvedUserResult.setUser(user);
                         break;
                     } else if (userList.size() > 1) {


### PR DESCRIPTION
### Proposed changes in this pull request
Set tenant domain to the resolved user.
It is used to identified the tenant domain of the resolved user in multi-attribute login flow.

Related to: wso2/product-is#12548