### PR TITLE
Fix error message for self registered users when an invalid password is provided

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AccountConfirmationValidationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AccountConfirmationValidationHandler.java
@@ -31,7 +31,11 @@ import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
+import org.wso2.carbon.identity.recovery.RecoveryScenarios;
+import org.wso2.carbon.identity.recovery.model.UserRecoveryData;
 import org.wso2.carbon.identity.recovery.signup.UserSelfRegistrationManager;
+import org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStore;
+import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.util.Utils;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreException;
@@ -98,25 +102,74 @@ public class AccountConfirmationValidationHandler extends AbstractEventHandler {
             } catch (UserStoreException e) {
                 throw new IdentityEventException("Error while retrieving account lock claim value", e);
             }
-            if ((Boolean) event.getEventProperties().get(IdentityEventConstants.EventProperty.OPERATION_STATUS) &&
-                    isAccountLocked && !isUserAccountConfirmed(user)) {
+            if (!isAccountLocked) {
+                // User account is unlocked. No need to process further.
+                return;
+            }
+            boolean operationStatus =
+                    (Boolean) event.getEventProperties().get(IdentityEventConstants.EventProperty.OPERATION_STATUS);
+            if (operationStatus && !isUserAccountConfirmed(user)) {
                 IdentityErrorMsgContext customErrorMessageContext = new IdentityErrorMsgContext(
                         IdentityCoreConstants.USER_ACCOUNT_NOT_CONFIRMED_ERROR_CODE);
                 IdentityUtil.setIdentityErrorMsg(customErrorMessageContext);
                 throw new IdentityEventException(IdentityCoreConstants.USER_ACCOUNT_NOT_CONFIRMED_ERROR_CODE,
                         "User : " + userName + " not confirmed yet.");
+            } else if (isInvalidCredentialsScenario(operationStatus, user)) {
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("Account unconfirmed user: %s in userstore: %s in tenant: %s is trying " +
+                            "to log in with an invalid password", userName, domainName, tenantDomain));
+                }
+                IdentityErrorMsgContext customErrorMessageContext =
+                        new IdentityErrorMsgContext(IdentityCoreConstants.USER_INVALID_CREDENTIALS);
+                IdentityUtil.setIdentityErrorMsg(customErrorMessageContext);
+                throw new IdentityEventException(IdentityCoreConstants.USER_INVALID_CREDENTIALS,
+                        "Invalid login attempt by self registered user: " + userName);
             }
         }
     }
 
+    /**
+     * Check whether this is an user self registered to this userstore and verify whether this is a invalid password
+     * provided by the user scenario.
+     *
+     * @param authOperationStatus User authentication operation state.
+     * @param user                User.
+     * @return True if this is an invalid password by the self registered user.
+     * @throws IdentityEventException If an error occurred while checking for the user recovery data.
+     */
+    private boolean isInvalidCredentialsScenario(boolean authOperationStatus, User user) throws IdentityEventException {
+
+        if (authOperationStatus) {
+            // User has provided the correct username and the password.
+            return false;
+        }
+        UserRecoveryData userRecoveryData = getRecoveryData(user);
+        return userRecoveryData != null &&
+                RecoveryScenarios.SELF_SIGN_UP.equals(userRecoveryData.getRecoveryScenario());
+    }
+
+    private UserRecoveryData getRecoveryData(User user) throws IdentityEventException {
+
+        UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
+        UserRecoveryData recoveryData;
+        try {
+            recoveryData = userRecoveryDataStore.loadWithoutCodeExpiryValidation(user);
+        } catch (IdentityRecoveryException e) {
+            throw new IdentityEventException("Error while loading recovery data for user ", e);
+        }
+        return recoveryData;
+    }
+
     @Override
     public void init(InitConfig configuration) throws IdentityRuntimeException {
+
         super.init(configuration);
     }
 
     @Override
     public int getPriority(MessageContext messageContext) {
-        return 50 ;
+
+        return 50;
     }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -622,8 +622,8 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.20.209</carbon.identity.framework.version>
-        <carbon.identity.framework.imp.pkg.version.range>[5.20.209, 6.0.0)
+        <carbon.identity.framework.version>5.20.211</carbon.identity.framework.version>
+        <carbon.identity.framework.imp.pkg.version.range>[5.20.211, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 
         <!--Carbon Identity Extension Versions-->

--- a/pom.xml
+++ b/pom.xml
@@ -622,8 +622,8 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.20.184</carbon.identity.framework.version>
-        <carbon.identity.framework.imp.pkg.version.range>[5.15.28, 6.0.0)
+        <carbon.identity.framework.version>5.20.209</carbon.identity.framework.version>
+        <carbon.identity.framework.imp.pkg.version.range>[5.20.209, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 
         <!--Carbon Identity Extension Versions-->


### PR DESCRIPTION
### Purpose
Send a more meaningful error message when a self-registered, account unconfirmed user tries a login with an invalid password. With the fix, the following error will be displayed for the user.
```
Login failed! Please check your username and password and try again.
```
**Associated PR:** https://github.com/wso2/carbon-identity-framework/pull/3765

### Before merging

- [x] Merge https://github.com/wso2/carbon-identity-framework/pull/3765
- [x] Bump framework version in product-is
- [x] Bump framework version in governance.