### PR TITLE
Return 410 GONE response for update-username API

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.governance/src/gen/java/org/wso2/carbon/identity/user/endpoint/UpdateUsernameApi.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/gen/java/org/wso2/carbon/identity/user/endpoint/UpdateUsernameApi.java
@@ -27,7 +27,7 @@ public class UpdateUsernameApi  {
    private final UpdateUsernameApiService delegate = UpdateUsernameApiServiceFactory.getUpdateUsernameApi();
 
     @PUT
-    
+    @Deprecated
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
     @io.swagger.annotations.ApiOperation(value = "Update username\n", notes = "This API is used to update the username of a User.\n", response = void.class)
@@ -40,11 +40,13 @@ public class UpdateUsernameApi  {
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found"),
         
-        @io.swagger.annotations.ApiResponse(code = 500, message = "Server Error") })
+        @io.swagger.annotations.ApiResponse(code = 500, message = "Server Error"),
+
+        @io.swagger.annotations.ApiResponse(code = 410, message = "Gone") })
 
     public Response updateUsernamePut(@ApiParam(value = "User to be updated." ,required=true ) UsernameUpdateRequestDTO user)
     {
-    return delegate.updateUsernamePut(user);
+    return Response.status(Response.Status.GONE).build();
     }
 }
 


### PR DESCRIPTION
### Proposed changes in this pull request
$subject.
Fixes https://github.com/wso2/product-is/issues/12606

`/t/{tenant-domain}/api/identity/user/v1.0/update-username` route is no longer supported. Hence, returning 410 status for the API call and marking it as deprecated.