### PR TITLE
Send account creation notification conditionally

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -64,6 +64,7 @@ public class IdentityRecoveryConstants {
     public static final String NOTIFICATION_TYPE_PASSWORD_RESET_INITIATE = "initiaterecovery";
     public static final String NOTIFICATION_ACCOUNT_ID_RECOVERY = "accountidrecovery";
     public static final String NOTIFICATION_TYPE_SELF_SIGNUP_SUCCESS = "selfSignUpSuccess";
+    public static final String NOTIFICATION_TYPE_SELF_SIGNUP_NOTIFY = "selfSignUpNotify";
     public static final String RECOVERY_STATUS_INCOMPLETE = "INCOMPLETE";
     public static final String RECOVERY_STATUS_COMPLETE = "COMPLETE";
     public static final String TEMPLATE_TYPE = "TEMPLATE_TYPE";


### PR DESCRIPTION
### Proposed changes in this pull request

If notify confirmation is enabled and both AccountLockOnCreation && EnableConfirmationOnCreation are disabled then send account creation notification. Enabling AccountLockOnCreation or EnableConfirmationOnCreation will preserve the earlier behaviour.

### Follow up actions

- Add the new email template to the system.


