### PR TITLE
Fix JDBCNotificationReceiversRetrieval class to use identity claim for account suspension if configured

### DIFF
--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/handler/AccountSuspensionNotificationHandler.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/handler/AccountSuspensionNotificationHandler.java
@@ -80,7 +80,7 @@ public class AccountSuspensionNotificationHandler extends AbstractEventHandler i
 
                     if (log.isDebugEnabled()) {
                         log.debug("Property " + NotificationConstants.USE_IDENTITY_CLAIM_FOR_LAST_LOGIN_TIME +
-                                " is enabled in identity.xml file hence using last login time as default claim");
+                                " is disabled in identity.xml file. Hence using last login time as default claim.");
                     }
                     String currentTime = getLastLoginTimeValue(userStoreManager);
                     userClaims.put(NotificationConstants.LAST_LOGIN_TIME, currentTime);

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/jdbc/JDBCNotificationReceiversRetrieval.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/jdbc/JDBCNotificationReceiversRetrieval.java
@@ -82,18 +82,18 @@ public class JDBCNotificationReceiversRetrieval implements NotificationReceivers
                     getProperty(NotificationConstants.USE_IDENTITY_CLAIM_FOR_LAST_LOGIN_TIME);
             boolean useIdentityClaimForLastLoginTime = StringUtils.isBlank(identityClaimForLastLoginTime) ||
                     Boolean.parseBoolean(identityClaimForLastLoginTime);
-            String lastLoginClaim = NotificationConstants.LAST_LOGIN_TIME_IDENTITY_CLAIM;
 
-            if (!useIdentityClaimForLastLoginTime) {
+            if (useIdentityClaimForLastLoginTime) {
                 if (log.isDebugEnabled()) {
                     log.debug("Property " + NotificationConstants.USE_IDENTITY_CLAIM_FOR_LAST_LOGIN_TIME +
-                            " is enabled in identity.xml file hence using last login time as default claim");
+                            " is enabled in identity.xml file. Hence treating last login time as identity claim.");
                 }
                 return NotificationReceiversRetrievalUtil.getNotificationReceiversFromIdentityClaim(lookupMin,
                         lookupMax, delayForSuspension, realmService, tenantDomain, userStoreDomain);
             }
-            String lastLoginTimeAttribute = claimManager
-                    .getAttributeName(userStoreDomain, lastLoginClaim);
+
+            String lastLoginClaim = NotificationConstants.LAST_LOGIN_TIME;
+            String lastLoginTimeAttribute = claimManager.getAttributeName(userStoreDomain, lastLoginClaim);
 
             try (Connection dbConnection = getDBConnection(realmConfiguration)) {
                 String sqlStmt = NotificationConstants.GET_USERS_FILTERED_BY_LAST_LOGIN_TIME;

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/ldap/LDAPNotificationReceiversRetrieval.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/ldap/LDAPNotificationReceiversRetrieval.java
@@ -181,8 +181,9 @@ public class LDAPNotificationReceiversRetrieval implements NotificationReceivers
     protected String getSearchFilter(long lookupMin, long lookupMax, String lastLoginTimeAttribute) {
 
         // The lastLoginTimeAttribute is the mapped LDAP attribute for LastLoginTime claim.
-        String searchFilter = "(&(" + lastLoginTimeAttribute + ">=" + lookupMin + ")(" + lastLoginTimeAttribute + "<="
-                + lookupMax + "))";
+        String searchFilter = "(&(" + lastLoginTimeAttribute + ">=" + lookupMin + ")(|(!(" +
+                lastLoginTimeAttribute + ">=" + lookupMax + "))(" + lastLoginTimeAttribute + "="
+                + lookupMax + ")))";
 
         // If the user-store uses a different timestamp than WSO2 format.
         String timeStampFormat = realmConfiguration.getUserStoreProperty(UserStoreConfigConstants.dateAndTimePattern);

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/ldap/LDAPNotificationReceiversRetrieval.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/ldap/LDAPNotificationReceiversRetrieval.java
@@ -88,7 +88,7 @@ public class LDAPNotificationReceiversRetrieval implements NotificationReceivers
                 if (useIdentityClaimForLastLoginTime) {
                     if (log.isDebugEnabled()) {
                         log.debug("Property " + NotificationConstants.USE_IDENTITY_CLAIM_FOR_LAST_LOGIN_TIME +
-                                " is enabled in identity.xml file hence using last login time as default claim");
+                                " is enabled in identity.xml file. Hence treating last login time as identity claim.");
                     }
                     return NotificationReceiversRetrievalUtil.getNotificationReceiversFromIdentityClaim(lookupMin,
                             lookupMax, delayForSuspension, realmService, tenantDomain, userStoreDomain);


### PR DESCRIPTION
Resolves [wso2/product-is #12727](https://github.com/wso2/product-is/issues/12727)

Currently [JDBCNotificationReceiversRetrieval](https://github.com/wso2-extensions/identity-governance/blob/master/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/jdbc/JDBCNotificationReceiversRetrieval.java) checks the non identity claim `http://wso2.org/claims/lastLoginTime` for retrieving the notification receivers for account suspension even if the `identity_mgt_account_suspension.use_identity_claims` config is set to true.

This PR fixes the JDBCNotificationReceiversRetrieval class to use identity claim 
`http://wso2.org/claims/identity/lastLoginTime`
for retrieving notification receivers for account suspension if the above config is enabled.