### PR TITLE
[Governance] Add correlationID in body for error responses

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.governance/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/ErrorDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/gen/java/org/wso2/carbon/identity/user/endpoint/dto/ErrorDTO.java
@@ -23,6 +23,8 @@ public class ErrorDTO  {
   
   private String description = null;
 
+  private String ref = null;
+
   
   /**
    **/
@@ -59,7 +61,12 @@ public class ErrorDTO  {
     this.description = description;
   }
 
-  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("traceId")
+  public String getRef() {return ref;}
+  public void setRef(String ref) {this.ref = ref;}
 
   @Override
   public String toString()  {
@@ -69,6 +76,9 @@ public class ErrorDTO  {
     sb.append("  code: ").append(code).append("\n");
     sb.append("  message: ").append(message).append("\n");
     sb.append("  description: ").append(description).append("\n");
+    if (!ref.isEmpty()) {
+      sb.append("  traceId: ").append(ref).append("\n");
+    }
     sb.append("}\n");
     return sb.toString();
   }

--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/Constants.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/Constants.java
@@ -43,6 +43,8 @@ public final class Constants {
             + "an internal error. Please contact administrator.";
     public static final String TENANT_NAME_FROM_CONTEXT = "TenantNameFromContext";
 
+    public static final String CORRELATION_ID_MDC = "Correlation-ID";
+
     // Response Configurations.
     public static final String ENABLE_DETAILED_API_RESPONSE =
             "SelfRegistration.API.EnableDetailedResponseBody";

--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/MeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/MeApiServiceImpl.java
@@ -76,7 +76,10 @@ public class MeApiServiceImpl extends MeApiService {
             userAttributes = Utils.getUserInformationService().getRetainedUserInformation(username, userStoreDomain,
                     tenantId);
         } catch (UserExportException e) {
-            return Response.serverError().entity(e.getMessage()).build();
+            ErrorDTO errorDTO = new ErrorDTO();
+            errorDTO.setRef(Utils.getCorrelation());
+            errorDTO.setMessage(e.getMessage());
+            return Response.serverError().entity(errorDTO).build();
         }
         return Response.ok().status(Response.Status.OK).entity(userAttributes).build();
     }

--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/PiInfoApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/PiInfoApiServiceImpl.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.user.endpoint.impl;
 
 import org.wso2.carbon.identity.user.endpoint.PiInfoApiService;
+import org.wso2.carbon.identity.user.endpoint.dto.ErrorDTO;
 import org.wso2.carbon.identity.user.endpoint.util.Utils;
 import org.wso2.carbon.identity.user.export.core.UserExportException;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -49,14 +50,20 @@ public class PiInfoApiServiceImpl extends PiInfoApiService {
         try {
             tenantId = Utils.getRealmService().getTenantManager().getTenantId(tenantDomain);
         } catch (UserStoreException e) {
+            ErrorDTO errorDTO = new ErrorDTO();
+            errorDTO.setRef(Utils.getCorrelation());
+            errorDTO.setMessage("Invalid tenant domain provided in username.");
             return Response
                     .status(Response.Status.BAD_REQUEST)
-                    .entity("Invalid tenant domain provided in username.")
+                    .entity(errorDTO)
                     .build();
         } catch (UserExportException e) {
+            ErrorDTO errorDTO = new ErrorDTO();
+            errorDTO.setRef(Utils.getCorrelation());
+            errorDTO.setMessage(e.getMessage());
             return Response
                     .status(Response.Status.INTERNAL_SERVER_ERROR)
-                    .entity(e.getMessage())
+                    .entity(errorDTO)
                     .build();
         }
         Map userAttributes = null;
@@ -74,6 +81,7 @@ public class PiInfoApiServiceImpl extends PiInfoApiService {
 
         return Response
                 .status(Response.Status.NOT_IMPLEMENTED)
+                .entity(Utils.getCorrelation())
                 .build();
     }
 }

--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImpl.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.recovery.model.UserRecoveryData;
 import org.wso2.carbon.identity.recovery.signup.UserSelfRegistrationManager;
 import org.wso2.carbon.identity.user.endpoint.Constants;
 import org.wso2.carbon.identity.user.endpoint.ResendCodeApiService;
+import org.wso2.carbon.identity.user.endpoint.dto.ErrorDTO;
 import org.wso2.carbon.identity.user.endpoint.dto.PropertyDTO;
 import org.wso2.carbon.identity.user.endpoint.util.Utils;
 import org.wso2.carbon.identity.user.endpoint.dto.ResendCodeRequestDTO;
@@ -77,7 +78,10 @@ public class ResendCodeApiServiceImpl extends ResendCodeApiService {
         }
 
         if (notificationResponseBean == null) {
-            return Response.status(Response.Status.NOT_IMPLEMENTED).build();
+            ErrorDTO errorDTO = new ErrorDTO();
+            errorDTO.setRef(Utils.getCorrelation());
+            errorDTO.setMessage("This service is not yet implemented.");
+            return Response.status(Response.Status.NOT_IMPLEMENTED).entity(errorDTO).build();
         }
 
         //when notifications internally managed key might not be set.

--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/util/Utils.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/util/Utils.java
@@ -209,6 +209,7 @@ public class Utils {
             ref = MDC.get(Constants.CORRELATION_ID_MDC).toString();
         } else {
             ref = UUID.randomUUID().toString();
+            MDC.put(Constants.CORRELATION_ID_MDC, ref);
 
         }
         return ref;

--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/util/Utils.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/util/Utils.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.user.endpoint.util;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
+import org.apache.log4j.MDC;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -52,6 +53,7 @@ import org.wso2.carbon.user.core.service.RealmService;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.UUID;
 
 public class Utils {
 
@@ -188,6 +190,31 @@ public class Utils {
     }
 
     /**
+     * Check whether correlation id present in the log MDC
+     *
+     * @return whether the correlation id is present
+     */
+    public static boolean isCorrelationIDPresent() {
+        return MDC.get(Constants.CORRELATION_ID_MDC) != null;
+    }
+
+    /**
+     * Get correlation id of current thread
+     *
+     * @return correlation-id
+     */
+    public static String getCorrelation() {
+        String ref;
+        if (isCorrelationIDPresent()) {
+            ref = MDC.get(Constants.CORRELATION_ID_MDC).toString();
+        } else {
+            ref = UUID.randomUUID().toString();
+
+        }
+        return ref;
+    }
+
+    /**
      * Returns a generic errorDTO
      *
      * @param message specifies the error message
@@ -198,6 +225,7 @@ public class Utils {
         errorDTO.setCode(code);
         errorDTO.setMessage(message);
         errorDTO.setDescription(description);
+        errorDTO.setRef(getCorrelation());
         return errorDTO;
     }
 

--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/util/Utils.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/util/Utils.java
@@ -204,13 +204,9 @@ public class Utils {
      * @return correlation-id
      */
     public static String getCorrelation() {
-        String ref;
+        String ref = null;
         if (isCorrelationIDPresent()) {
             ref = MDC.get(Constants.CORRELATION_ID_MDC).toString();
-        } else {
-            ref = UUID.randomUUID().toString();
-            MDC.put(Constants.CORRELATION_ID_MDC, ref);
-
         }
         return ref;
     }

--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/resources/api.identity.user.yaml
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/resources/api.identity.user.yaml
@@ -540,6 +540,8 @@ definitions:
         type: string
       description:
         type: string
+      traceId:
+        type: string
 
 
 #-----------------------------------------------------

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/gen/java/org/wso2/carbon/identity/recovery/endpoint/dto/ErrorDTO.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/gen/java/org/wso2/carbon/identity/recovery/endpoint/dto/ErrorDTO.java
@@ -23,6 +23,8 @@ public class ErrorDTO  {
   
   private String description = null;
 
+  private String ref = null;
+
   
   /**
    **/
@@ -59,7 +61,14 @@ public class ErrorDTO  {
     this.description = description;
   }
 
-  
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("traceId")
+  public String getRef() {return ref;}
+  public void setRef(String ref) {this.ref = ref;}
+
 
   @Override
   public String toString()  {
@@ -69,6 +78,9 @@ public class ErrorDTO  {
     sb.append("  code: ").append(code).append("\n");
     sb.append("  message: ").append(message).append("\n");
     sb.append("  description: ").append(description).append("\n");
+    if (!ref.isEmpty()) {
+      sb.append("  traceId: ").append(ref).append("\n");
+    }
     sb.append("}\n");
     return sb.toString();
   }

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtil.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtil.java
@@ -172,7 +172,7 @@ public class RecoveryUtil {
             ref = MDC.get(IdentityRecoveryConstants.CORRELATION_ID_MDC).toString();
         } else {
             ref = UUID.randomUUID().toString();
-
+            MDC.put(IdentityRecoveryConstants.CORRELATION_ID_MDC, ref);
         }
         return ref;
     }

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtil.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtil.java
@@ -9,6 +9,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
+import org.apache.log4j.MDC;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.common.model.User;
@@ -61,6 +62,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.UUID;
 
 public class RecoveryUtil {
     private static final String USERNAME_CLAIM = "http://wso2.org/claims/username";
@@ -150,6 +152,31 @@ public class RecoveryUtil {
         ErrorDTO errorDTO = getErrorDTO(Constants.STATUS_BAD_REQUEST_MESSAGE_DEFAULT, code, description);
         return new BadRequestException(errorDTO);
     }
+    /**
+     * Check whether correlation id present in the log MDC
+     *
+     * @return whether the correlation id is present
+     */
+    public static boolean isCorrelationIDPresent() {
+        return MDC.get(IdentityRecoveryConstants.CORRELATION_ID_MDC) != null;
+    }
+
+    /**
+     * Get correlation id of current thread
+     *
+     * @return correlation-id
+     */
+    public static String getCorrelation() {
+        String ref;
+        if (isCorrelationIDPresent()) {
+            ref = MDC.get(IdentityRecoveryConstants.CORRELATION_ID_MDC).toString();
+        } else {
+            ref = UUID.randomUUID().toString();
+
+        }
+        return ref;
+    }
+
 
     /**
      * Returns a generic errorDTO
@@ -162,6 +189,7 @@ public class RecoveryUtil {
         errorDTO.setCode(code);
         errorDTO.setMessage(message);
         errorDTO.setDescription(description);
+        errorDTO.setRef(getCorrelation());
         return errorDTO;
     }
 

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtil.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtil.java
@@ -167,12 +167,9 @@ public class RecoveryUtil {
      * @return correlation-id
      */
     public static String getCorrelation() {
-        String ref;
+        String ref= null;
         if (isCorrelationIDPresent()) {
             ref = MDC.get(IdentityRecoveryConstants.CORRELATION_ID_MDC).toString();
-        } else {
-            ref = UUID.randomUUID().toString();
-            MDC.put(IdentityRecoveryConstants.CORRELATION_ID_MDC, ref);
         }
         return ref;
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -176,6 +176,8 @@ public class IdentityRecoveryConstants {
     public static final String ENTITY_TYPE_USER = "USER";
     public static final String ADD_USER_EVENT = "ADD_USER";
 
+    public static final String CORRELATION_ID_MDC = "Correlation-ID";
+
     private IdentityRecoveryConstants() {
 
     }


### PR DESCRIPTION
### Proposed changes in this pull request
This PR adds **traceId** in the body of error response so that the client can keep track of the error and this sorted out. 