### PR TITLE
Fix error handling in password recovery flows for readonly users

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -185,6 +185,8 @@ public class IdentityRecoveryConstants {
         ERROR_CODE_EXPIRED_CODE("18002", "Expired Code '%s.'"),
         ERROR_CODE_INVALID_USER("18003", "Invalid User '%s.'"),
         ERROR_CODE_FEDERATED_USER("18004", "User %s doesn't have a password for local account."),
+        ERROR_CODE_READ_ONLY_USER("18005",
+                "You are not allowed to change the password. Please contact your organization administrator."),
         ERROR_CODE_UNEXPECTED("18013", "Unexpected error"),
         ERROR_CODE_RECOVERY_NOTIFICATION_FAILURE("18015", "Error sending recovery notification"),
         ERROR_CODE_INVALID_TENANT("18016", "Invalid tenant'%s.'"),
@@ -483,6 +485,7 @@ public class IdentityRecoveryConstants {
         public static final String NOTIFICATION_INTERNALLY_MANAGE = "Recovery.Notification.InternallyManage";
         public static final String NOTIFY_USER_EXISTENCE = "Recovery.NotifyUserExistence";
         public static final String NOTIFY_USER_ACCOUNT_STATUS = "Recovery.NotifyUserAccountStatus";
+        public static final String NOTIFY_PASSWORD_RECOVERY_ERROR = "Recovery.NotifyPasswordRecoveryError";
         public static final String NOTIFICATION_SEND_RECOVERY_NOTIFICATION_SUCCESS = "Recovery.NotifySuccess";
         public static final String NOTIFICATION_SEND_RECOVERY_SECURITY_START = "Recovery.Question.Password.NotifyStart";
         public static final String NOTIFICATION_BASED_PW_RECOVERY = "Recovery.Notification.Password.Enable";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -556,6 +556,7 @@ public class NotificationPasswordRecoveryManager {
             if (log.isDebugEnabled()) {
                 log.debug("Password reset not allowed to read only user: " + domainQualifiedName);
             }
+            userRecoveryDataStore.invalidate(userRecoveryData.getUser());
             throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_READ_ONLY_USER, null);
         }
         // Update the password.
@@ -854,13 +855,6 @@ public class NotificationPasswordRecoveryManager {
                 .addDomainToName(user.getUserName(), userRecoveryData.getUser().getUserStoreDomain());
         if (log.isDebugEnabled()) {
             log.debug("Valid confirmation code for user: " + domainQualifiedName);
-        }
-        // This will be removed once the recovery email for readonly users onboarded.
-        if (Utils.isReadOnlyUser(userRecoveryData.getUser())) {
-            if (log.isDebugEnabled()) {
-                log.debug("Password reset not allowed to read only users. User: " + domainQualifiedName);
-            }
-            throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_READ_ONLY_USER, null);
         }
         return user;
     }


### PR DESCRIPTION
### Proposed changes in this pull request

Purpose is to fix error handling in recovery flows of read only users. Configured showing the password recovery error to the end users.

To disable showing password recovery errors to the end users.
```
[identity_mgt.recovery]
notify_password_recovery_error = false

```

## Before Merge

- Merge https://github.com/wso2/carbon-identity-framework/pull/3826
- Bump framework version in product-is