### PR TITLE
Fix the error while retrieving the user information

### DIFF
--- a/components/org.wso2.carbon.identity.user.export.core/src/main/java/org/wso2/carbon/identity/user/export/core/internal/service/impl/SecurityInformationProvider.java
+++ b/components/org.wso2.carbon.identity.user.export.core/src/main/java/org/wso2/carbon/identity/user/export/core/internal/service/impl/SecurityInformationProvider.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.user.export.core.dto.SecurityInformationDTO;
 import org.wso2.carbon.identity.user.export.core.dto.UserInformationDTO;
 import org.wso2.carbon.identity.user.export.core.service.UserInformationProvider;
 import org.wso2.carbon.registry.core.service.RegistryService;
+import org.wso2.carbon.user.api.Claim;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -52,12 +53,17 @@ public class SecurityInformationProvider extends BasicUserInformationProvider {
     public UserInformationDTO getRetainedUserInformation(String username, String userStoreDomain, int tenantId)
             throws UserExportException {
 
-        String challengeQuestionClaimValue;
+        String challengeQuestionClaimValue = null;
         UserStoreManager userStoreManager;
         try {
             userStoreManager = getUserStoreManager(tenantId, userStoreDomain);
-            challengeQuestionClaimValue = userStoreManager.getUserClaimValue(username, CHALLENGE_QUESTION_URIS_CLAIM,
-                    null);
+            Claim[] userClaims = userStoreManager.getUserClaimValues(username, null);
+            for (Claim claim : userClaims) {
+                if (CHALLENGE_QUESTION_URIS_CLAIM.equals(claim.getClaimUri())) {
+                    challengeQuestionClaimValue = userStoreManager.getUserClaimValue(username, 
+                            CHALLENGE_QUESTION_URIS_CLAIM, null);
+                }
+            }
         } catch (UserStoreException e) {
             throw new UserExportException("Error while retrieving the user information.", e);
         }

--- a/components/org.wso2.carbon.identity.user.export.core/src/main/java/org/wso2/carbon/identity/user/export/core/internal/service/impl/SecurityInformationProvider.java
+++ b/components/org.wso2.carbon.identity.user.export.core/src/main/java/org/wso2/carbon/identity/user/export/core/internal/service/impl/SecurityInformationProvider.java
@@ -89,6 +89,10 @@ public class SecurityInformationProvider extends BasicUserInformationProvider {
             }
 
             return new UserInformationDTO(securityInformationDTO);
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Challenge question claim is not available in the tenant: " + tenantId);
+            }
         }
         return new UserInformationDTO();
     }


### PR DESCRIPTION
### Proposed changes in this pull request

In case if the claim: "http://wso2.org/claims/challengeQuestionUris" is not available, trying to retrieve the claim value causes an error when calling export user information API[1]. Therefore with this PR changes, it will check whether the above-mentioned claim is available first and then retrieve the claim value.

[1] https://docs.wso2.com/display/IS511/apidocs/self-registration/#!/operations#UserExport#getMe

