### PR TITLE
Remove CAPTCHA parameters from authentication endpoint URL

### DIFF
--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/SSOLoginReCaptchaConfig.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/SSOLoginReCaptchaConfig.java
@@ -176,8 +176,6 @@ public class SSOLoginReCaptchaConfig extends AbstractReCaptchaConnector implemen
             preValidationResponse.setOnCaptchaFailRedirectUrls(getFailedUrlList());
             Map<String, String> params = new HashMap<>();
             params.put("reCaptcha", "true");
-            params.put("reCaptchaKey", CaptchaDataHolder.getInstance().getReCaptchaSiteKey());
-            params.put("reCaptchaAPI", CaptchaDataHolder.getInstance().getReCaptchaAPIUrl());
             params.put("authFailure", "true");
             params.put("authFailureMsg", "recaptcha.fail.message");
             preValidationResponse.setCaptchaAttributes(params);
@@ -200,8 +198,6 @@ public class SSOLoginReCaptchaConfig extends AbstractReCaptchaConnector implemen
             validationResponse.setEnableCaptchaResponsePath(true);
             Map<String, String> params = new HashMap<>();
             params.put("reCaptcha", "true");
-            params.put("reCaptchaKey", CaptchaDataHolder.getInstance().getReCaptchaSiteKey());
-            params.put("reCaptchaAPI", CaptchaDataHolder.getInstance().getReCaptchaAPIUrl());
             validationResponse.setCaptchaAttributes(params);
             return validationResponse;
         }


### PR DESCRIPTION
Remove `recaptchaKey` and `recaptchaAPI` parameters from the authentication endpoint URL.