### PR TITLE
Ignore User Store Domain Name Case during Idle Account Suspension 

### DIFF
--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationReceiversRetrievalUtil.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationReceiversRetrievalUtil.java
@@ -216,7 +216,7 @@ public class NotificationReceiversRetrievalUtil {
                                     (IdentityTenantUtil.getTenantId(tenantDomain)).getUserStoreManager();
 
                             if (userStoreDomain != null &&
-                                    userStoreDomain.equals(UserCoreUtil.extractDomainFromName(userName))) {
+                                    userStoreDomain.equalsIgnoreCase(UserCoreUtil.extractDomainFromName(userName))) {
 
                                 Map<String, String> map = userStoreManager.getUserClaimValues(userName, claims, null);
                                 NotificationReceiver receiver = new NotificationReceiver();


### PR DESCRIPTION
Fixes: https://github.com/wso2/product-is/issues/12882

This PR will ignore the case of the secondary user store domain name during idle account suspension flow.