### PR TITLE
Support removing event publisher config from a tenant

### DIFF
--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/constants/TenantResourceConstants.java
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/constants/TenantResourceConstants.java
@@ -46,7 +46,9 @@ public class TenantResourceConstants {
                 + " publisher configuration for the tenant domain: %s"),
         ERROR_CODE_ERROR_WHEN_CREATING_TENANT_EVENT_PUBLISHER_CONFIGURATION_USING_SUPER_TENANT_CONFIG(
                 "TRM-10009", "Error occurred while creating tenant event publisher configuration: %s.Using super"
-                + "tenant configuration, for the tenant domain: %s");
+                + "tenant configuration, for the tenant domain: %s"),
+        ERROR_CODE_ERROR_WHEN_FETCHING_EVENT_PUBLISHER_RESOURCE("TRM-10010", "Error occurred when fetching the "
+                + "event publisher resource with name: %s., for the tenant domain: %s");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/core/ResourceManager.java
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/core/ResourceManager.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.tenant.resource.manager.core;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceFile;
 import org.wso2.carbon.identity.tenant.resource.manager.exception.TenantResourceManagementException;
 
@@ -34,4 +35,16 @@ public interface ResourceManager {
      */
     void addEventPublisherConfiguration(ResourceFile resourceFile) throws TenantResourceManagementException;
 
+    /**
+     * This API is used to remove an EventPublisher from a particular tenant.
+     *
+     * @param resourceTypeName Resource type name
+     * @param resourceName Resource name
+     * @throws TenantResourceManagementException
+     */
+    default void removeEventPublisherConfiguration(String resourceTypeName, String resourceName)
+            throws TenantResourceManagementException {
+
+        throw new NotImplementedException("Method is not implemented.");
+    }
 }

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/exception/TenantResourceManagementClientException.java
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/exception/TenantResourceManagementClientException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.tenant.resource.manager.exception;
+
+/**
+ * This class is used to define the client errors which needs to be handled.
+ */
+public class TenantResourceManagementClientException extends TenantResourceManagementException {
+
+    public TenantResourceManagementClientException(String message, String code, Throwable e) {
+
+        super(message, code, e);
+    }
+
+    public TenantResourceManagementClientException(String message, String code) {
+
+        super(message, code);
+    }
+}

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/util/ResourceUtils.java
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/util/ResourceUtils.java
@@ -20,8 +20,20 @@ package org.wso2.carbon.identity.tenant.resource.manager.util;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.event.publisher.core.config.EventPublisherConfiguration;
+import org.wso2.carbon.event.publisher.core.exception.EventPublisherConfigurationException;
+import org.wso2.carbon.event.stream.core.EventStreamConfiguration;
+import org.wso2.carbon.event.stream.core.exception.EventStreamConfigurationException;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.tenant.resource.manager.constants.TenantResourceConstants;
 import org.wso2.carbon.identity.tenant.resource.manager.exception.TenantResourceManagementServerException;
+import org.wso2.carbon.identity.tenant.resource.manager.internal.TenantResourceManagerDataHolder;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import java.util.List;
+
+import static org.wso2.carbon.identity.tenant.resource.manager.constants.TenantResourceConstants.ErrorMessages.ERROR_CODE_ERROR_WHEN_CREATING_TENANT_EVENT_PUBLISHER_CONFIGURATION_USING_SUPER_TENANT_CONFIG;
 
 /**
  * Utility methods for tenant resource management.
@@ -61,5 +73,70 @@ public class ResourceUtils {
             message = error.getMessage();
         }
         return message;
+    }
+
+    /**
+     * This method creates event publisher configurations tenant wise by using super tenant publisher configurations.
+     *
+     * @param activeEventPublisherConfigurations list of active super tenant publisher configurations.
+     */
+    public static void loadTenantPublisherConfigurationFromSuperTenantConfig(
+            List<EventPublisherConfiguration> activeEventPublisherConfigurations) {
+
+        for (EventPublisherConfiguration eventPublisherConfiguration : activeEventPublisherConfigurations) {
+            try {
+                if (TenantResourceManagerDataHolder.getInstance().getCarbonEventPublisherService()
+                        .getActiveEventPublisherConfiguration(eventPublisherConfiguration.getEventPublisherName())
+                        == null) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Super tenant event publisher configuration for the: " + eventPublisherConfiguration
+                                .getEventPublisherName() + " will be used for the tenant domain: "
+                                + PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+                    }
+                    TenantResourceManagerDataHolder.getInstance().getCarbonEventPublisherService()
+                            .addEventPublisherConfiguration(eventPublisherConfiguration);
+                }
+            } catch (EventPublisherConfigurationException e) {
+                log.error(populateMessageWithData(
+                        ERROR_CODE_ERROR_WHEN_CREATING_TENANT_EVENT_PUBLISHER_CONFIGURATION_USING_SUPER_TENANT_CONFIG,
+                        eventPublisherConfiguration.getEventPublisherName(),
+                        PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()), e);
+            }
+        }
+    }
+
+    /**
+     * This method returns super tenant event publisher configurations.
+     *
+     * @return list of event publisher configurations.
+     */
+    public static List<EventPublisherConfiguration> getSuperTenantEventPublisherConfigurations() {
+
+        List<EventPublisherConfiguration> activeEventPublisherConfigurations = null;
+        try {
+            activeEventPublisherConfigurations = TenantResourceManagerDataHolder.getInstance()
+                    .getCarbonEventPublisherService().getAllActiveEventPublisherConfigurations();
+        } catch (EventPublisherConfigurationException e) {
+            log.error(populateMessageWithData(
+                    TenantResourceConstants.ErrorMessages.ERROR_CODE_ERROR_WHEN_FETCHING_SUPER_TENANT_EVENT_PUBLISHER_CONFIGURATION,
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()), e);
+        }
+        return activeEventPublisherConfigurations;
+    }
+
+    public static void startTenantFlow(int tenantId) {
+
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(tenantId);
+        PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .setTenantDomain(IdentityTenantUtil.getTenantDomain(tenantId));
+    }
+
+    public static void startSuperTenantFlow() {
+
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+        carbonContext.setTenantId(MultitenantConstants.SUPER_TENANT_ID);
+        carbonContext.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request
- This PR adds the capability to remove an event publisher configuration from a tenant to the ResourceManager interface.
- In such removal operation, super tenant configuration is loaded to the tenant.

Refers https://github.com/wso2-enterprise/asgardeo-product/issues/8718