### PR TITLE
Not set account_unlocked after confirming the email

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -963,9 +963,6 @@ public class UserSelfRegistrationManager {
         //Set account verified time claim.
         userClaims.put(IdentityRecoveryConstants.ACCOUNT_CONFIRMED_TIME_CLAIM, Instant.now().toString());
 
-        // Set the account state claim to UNLOCKED.
-        userClaims.put(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI,
-                IdentityRecoveryConstants.ACCOUNT_STATE_UNLOCKED);
         return userClaims;
     }
 


### PR DESCRIPTION
Related https://github.com/wso2-enterprise/asgardeo-product/issues/8479

Changes are done to not to set `account state` to` account_unlocked immediately` after confirming the email at self-registration to disable sending account-unlock mail after the self-registration. 

Although we removed the setting the account state claim to `UNLOCKED` with this fix, same state change performed  from here. (Therefore, no final state change difference than existing behavior.)
https://github.com/wso2-extensions/identity-event-handler-account-lock/blob/40fe5e10e64737351372f44e24b888361c89d354/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java#L701-L702