### PR TITLE
Fix Identity claim filtering

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/UserIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/UserIdentityDataStore.java
@@ -20,6 +20,7 @@ import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.governance.model.UserIdentityClaim;
 import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.model.ExpressionCondition;
 
 import java.util.Collections;
 import java.util.List;
@@ -91,6 +92,25 @@ public abstract class UserIdentityDataStore {
 
         // This method should be overridden by the sub classes. Adding a non-abstract method to give backward
         // compatibility. Return an immutable empty list if sub classes do not have any overrides.
+        return Collections.emptyList();
+    }
+
+    /**
+     * List users according to the given claim URI and value and pagination parameters.
+     *
+     * @param expressionConditions           List of expression conditions.
+     * @param userStoreManager               UserStoreManager instance.
+     * @param identityClaimFilteredUserNames List to hold filtered usernames.
+     * @return List of usernames.
+     * @throws IdentityException Identity Exception.
+     */
+    public List<String> listPaginatedUsersNames(List<ExpressionCondition> expressionConditions,
+                                                List<String> identityClaimFilteredUserNames,
+                                                String domain,
+                                                org.wso2.carbon.user.core.UserStoreManager userStoreManager, int limit,
+                                                int offset) throws IdentityException {
+
+        // Return an immutable empty list if sub classes do not have any overrides.
         return Collections.emptyList();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -620,7 +620,7 @@
         <identity.data.publisher.authentication.version>5.3.0</identity.data.publisher.authentication.version>
 
         <!--Carbon Kernel Version-->
-        <carbon.kernel.version>4.7.0-m3</carbon.kernel.version>
+        <carbon.kernel.version>4.7.0-m11</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.1</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>


### PR DESCRIPTION
**This PR fixes:**
1. https://github.com/wso2/product-is/issues/11766		

Support PR - 	https://github.com/wso2-support/identity-governance/pull/414

**Description of the Issue**
--
Filtering with Identity claims does not work on the SCIM2 Users endpoint 
1. **without count**  query param : `totalResults` is correct but results are not displayed
2. **with count** query param : `totalResults` also not correct.

**Cause**
--
1. `userStoreDomainName` was not set and hence unable to get through **scimEnabled** check
2. With count param - the flow is through new API leading to point where there is **no support to handle filters with Identity claims** when the configured datastore is JDBC. 

**Fix**
--
1. Added the `userStoreDomainName` for user.
2. Branch the flow for filters with Identity Claims. 
3. Supports filtering with identity claims and mixed set of claims (identity/non identity)
4. Supports pagination for filtering with only identity claim filtering and filtering with mixed claim filters


 **Merge https://github.com/wso2/carbon-kernel/pull/3163 before merging current PR.**
