### PR TITLE
Return different error codes for PENDING_X user in the recovery flow

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -176,6 +176,8 @@ public class IdentityRecoveryConstants {
         ERROR_CODE_INVALID_CREDENTIALS("17002", "Invalid Credentials"),
         ERROR_CODE_LOCKED_ACCOUNT("17003", "User account is locked - '%s.'"),
         ERROR_CODE_DISABLED_ACCOUNT("17004", "user account is disabled '%s.'"),
+        ERROR_CODE_PENDING_SELF_REGISTERED_ACCOUNT("17005", "User account not yet verified - '%s.'"),
+        ERROR_CODE_PENDING_PASSWORD_RESET_ACCOUNT("17006", "Password reset is not yet completed '%s.'"),
         ERROR_CODE_REGISTRY_EXCEPTION_GET_CHALLENGE_QUESTIONS("20001", "Registry exception while getting challenge question"),
         ERROR_CODE_REGISTRY_EXCEPTION_SET_CHALLENGE_QUESTIONS("20002", "Registry exception while setting challenge question"),
         ERROR_CODE_GETTING_CHALLENGE_URIS("20003", "Error while getting challenge question URIs '%s.'"),

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -174,11 +174,42 @@ public class UserAccountRecoveryManager {
                     IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_DISABLED_ACCOUNT.getMessage(),
                     user.getUserName());
         } else if (Utils.isAccountLocked(user)) {
+            // Check user in PENDING_SR or PENDING_AP status.
+            checkAccountPendingStatus(user);
             String errorCode = Utils.prependOperationScenarioToErrorCode(
                     IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_LOCKED_ACCOUNT.getCode(),
                     IdentityRecoveryConstants.USER_ACCOUNT_RECOVERY);
             throw Utils.handleClientException(errorCode,
                     IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_LOCKED_ACCOUNT.getMessage(), user.getUserName());
+        }
+    }
+
+    /**
+     * Check whether the account is pending self signup or pending ask password.
+     *
+     * @param user User.
+     * @throws IdentityRecoveryException If account is in locked or disabled status.
+     */
+    private void checkAccountPendingStatus(User user) throws IdentityRecoveryException {
+
+        String accountState = Utils.getAccountState(user);
+        if (StringUtils.isNotBlank(accountState)) {
+            if (IdentityRecoveryConstants.PENDING_SELF_REGISTRATION.equals(accountState)) {
+                String errorCode = Utils.prependOperationScenarioToErrorCode(
+                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PENDING_SELF_REGISTERED_ACCOUNT.getCode(),
+                        IdentityRecoveryConstants.USER_ACCOUNT_RECOVERY);
+                throw Utils.handleClientException(errorCode,
+                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PENDING_SELF_REGISTERED_ACCOUNT.getMessage(),
+                        user.getUserName());
+            }
+            if (IdentityRecoveryConstants.PENDING_ASK_PASSWORD.equals(accountState)) {
+                String errorCode = Utils.prependOperationScenarioToErrorCode(
+                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PENDING_PASSWORD_RESET_ACCOUNT.getCode(),
+                        IdentityRecoveryConstants.USER_ACCOUNT_RECOVERY);
+                throw Utils.handleClientException(errorCode,
+                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PENDING_PASSWORD_RESET_ACCOUNT.getMessage(),
+                        user.getUserName());
+            }
         }
     }
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -158,6 +158,27 @@ public class NotificationPasswordRecoveryManager {
     }
 
     /**
+     * Check whether the account is pending self signup or pending ask password.
+     *
+     * @param user User.
+     * @throws IdentityRecoveryException If account is in locked or disabled status.
+     */
+    private void checkAccountPendingStatus(User user) throws IdentityRecoveryException {
+
+        String accountState = Utils.getAccountState(user);
+        if (StringUtils.isNotBlank(accountState)) {
+            if (IdentityRecoveryConstants.PENDING_SELF_REGISTRATION.equals(accountState)) {
+                throw Utils.handleClientException(IdentityRecoveryConstants.
+                        ErrorMessages.ERROR_CODE_PENDING_SELF_REGISTERED_ACCOUNT, user.getUserName());
+            }
+            if (IdentityRecoveryConstants.PENDING_ASK_PASSWORD.equals(accountState)) {
+                throw Utils.handleClientException(IdentityRecoveryConstants.
+                        ErrorMessages.ERROR_CODE_PENDING_PASSWORD_RESET_ACCOUNT, user.getUserName());
+            }
+        }
+    }
+
+    /**
      * Generates the new confirmation code details for a corresponding user.
      *
      * @param user Details of the user that needs the confirmation code.
@@ -193,6 +214,8 @@ public class NotificationPasswordRecoveryManager {
             throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_DISABLED_ACCOUNT,
                     user.getUserName());
         } else if (Utils.isAccountLocked(user)) {
+            // Check user in PENDING_SR or PENDING_AP status.
+            checkAccountPendingStatus(user);
             throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_LOCKED_ACCOUNT,
                     user.getUserName());
         }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1114,6 +1114,38 @@ public class Utils {
     }
 
     /**
+     * Return user account state.
+     *
+     * @param user  User.
+     * @return account state.
+     */
+    public static String getAccountState(User user) {
+
+        String accountState = StringUtils.EMPTY;
+        try {
+            org.wso2.carbon.user.core.UserStoreManager userStoreManager = IdentityRecoveryServiceDataHolder.
+                    getInstance().getRealmService().getBootstrapRealm().getUserStoreManager();
+            while (!userStoreManager.isExistingUser(user.getUserName())) {
+                userStoreManager = userStoreManager.getSecondaryUserStoreManager();
+                if (userStoreManager == null) {
+                    return accountState;
+                }
+            }
+            Map<String, String> claimMap =
+                    ((AbstractUserStoreManager) userStoreManager).getUserClaimValues(user.getUserName(),
+                            new String[]{IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI}, "default");
+            if (!claimMap.isEmpty()) {
+                if (claimMap.containsKey(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI)) {
+                    accountState = claimMap.get(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI);
+                }
+            }
+        } catch (org.wso2.carbon.user.core.UserStoreException e) {
+            log.error("Error occurred while retrieving UserStoreManager");
+        }
+        return accountState;
+    }
+
+    /**
      * When updating email/mobile claim value, sending the verification notification can be controlled by sending
      * an additional temporary claim ('verifyEmail'/'verifyMobile') along with the update request.
      * This option can be enabled form identity.xml by setting 'UseVerifyClaim' to true. When this option is enabled,


### PR DESCRIPTION
Resolves: https://github.com/wso2/product-is/issues/11515
Support PR: https://github.com/wso2-support/identity-governance/pull/328
# Purpose
Currently IS returns only "User account is locked" when PENDING_X locked user trying password recovery. But there are several reasons to lock accounts such as PENDING_AP/PENDING_SR.
# Changes 
Returns different error code for PENDING_AP and PENDING_SR accounts in the password recovery flow.  

Account state | Error code
-- | --
PENDING_SR | 17005
PENDING_AP | 17006

