### PR TITLE
Process resolveUser and authenticateWithIdentifier if username is the only allowed claim and no claim regex is configured

### DIFF
--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
@@ -50,12 +50,12 @@ public class RegexResolver implements MultiAttributeLoginResolver {
 
         ResolvedUserResult resolvedUserResult = new ResolvedUserResult(ResolvedUserResult.UserResolvedStatus.FAIL);
         try {
-            UserRealm userRealm = UserResolverUtil.getUserRealm(tenantDomain);
-            UniqueIDUserStoreManager userStoreManager = UserResolverUtil.getUserStoreManager(tenantDomain);
-            ClaimManager claimManager = userRealm.getClaimManager();
             if (allowedAttributes == null) {
                 return resolvedUserResult;
             }
+            UserRealm userRealm = UserResolverUtil.getUserRealm(tenantDomain);
+            UniqueIDUserStoreManager userStoreManager = UserResolverUtil.getUserStoreManager(tenantDomain);
+            ClaimManager claimManager = userRealm.getClaimManager();
             for (String claimURI : allowedAttributes) {
                 Claim claim = claimManager.getClaim(claimURI);
                 if (claim == null) {
@@ -121,12 +121,12 @@ public class RegexResolver implements MultiAttributeLoginResolver {
                 new AuthenticationResult(AuthenticationResult.AuthenticationStatus.FAIL);
         ClaimManager claimManager;
         try {
-            UserRealm userRealm = UserResolverUtil.getUserRealm(tenantDomain);
-            UniqueIDUserStoreManager userStoreManager = UserResolverUtil.getUserStoreManager(tenantDomain);
-            claimManager = userRealm.getClaimManager();
             if (allowedAttributes == null) {
                 return authenticationResult;
             }
+            UserRealm userRealm = UserResolverUtil.getUserRealm(tenantDomain);
+            UniqueIDUserStoreManager userStoreManager = UserResolverUtil.getUserStoreManager(tenantDomain);
+            claimManager = userRealm.getClaimManager();
             for (String claimURI : allowedAttributes) {
                 Claim claim = claimManager.getClaim(claimURI);
                 if (claim == null) {


### PR DESCRIPTION
### Proposed changes in this pull request
Fixes https://github.com/wso2/product-is/issues/13282


- In governance connector property updates it's hard to mandate/validate property inputs. None of the governance properties are validated when updating via mgt console.
- Currently under Multi-attribute login, If allowed claim attribute list is empty, and Enable Multi-attribute login is ticketed users even can't log in using username. (only in the default pack)
- If the allowed claim list is empty Username claim is set by default https://github.com/wso2-extensions/identity-governance/blob/68e3f2d5e246b6a75f48e314ee1019230c662b55/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/service/MultiAttributeLoginServiceServiceImpl.java#L86-L87
- But in the default pack we don't have a configured regex for username. If username has a regex, this case works.
- As the solution, now we resolve user if allowed attributes has only username claim, but username claim has no configured regex pattern. 
