### PR TITLE
Handle password recovery for multi-attribute login enabled case

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
@@ -1,13 +1,9 @@
 package org.wso2.carbon.identity.recovery.endpoint.impl;
 
-import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.base.MultitenantConstants;
-import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
-import org.wso2.carbon.identity.application.common.model.User;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
@@ -24,9 +20,6 @@ import org.wso2.carbon.identity.recovery.endpoint.dto.RecoveryInitiatingRequestD
 import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
 import org.wso2.carbon.identity.recovery.password.NotificationPasswordRecoveryManager;
 import org.wso2.carbon.identity.recovery.util.Utils;
-import org.wso2.carbon.user.api.UserStoreException;
-import org.wso2.carbon.user.core.service.RealmService;
-import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import javax.ws.rs.core.Response;
 

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
@@ -55,13 +56,13 @@ public class RecoverPasswordApiServiceImpl extends RecoverPasswordApiService {
                                 .resolveUser(user.getUsername(), user.getTenantDomain());
                 if (resolvedUserResult != null && ResolvedUserResult.UserResolvedStatus.SUCCESS.
                         equals(resolvedUserResult.getResolvedStatus())) {
-                    user.setUsername(resolvedUserResult.getUser().getUsername());
-                    UserDTO userDTO = recoveryInitiatingRequest.getUser();
-                    userDTO.setUsername(user.getUsername());
-                    recoveryInitiatingRequest.setUser(userDTO);
-                    notificationResponseBean = notificationPasswordRecoveryManager.sendRecoveryNotification(
-                            RecoveryUtil.getUser(recoveryInitiatingRequest.getUser()), type, notify,
-                            RecoveryUtil.getProperties(recoveryInitiatingRequest.getProperties()));
+                    User resolvedUser = new User();
+                    resolvedUser.setUserName(resolvedUserResult.getUser().getUsername());
+                    resolvedUser.setUserStoreDomain(resolvedUserResult.getUser().getUserStoreDomain());
+                    resolvedUser.setTenantDomain(resolvedUserResult.getUser().getTenantDomain());
+                    notificationResponseBean =
+                            notificationPasswordRecoveryManager.sendRecoveryNotification(resolvedUser, type, notify,
+                                    RecoveryUtil.getProperties(recoveryInitiatingRequest.getProperties()));
                 } else {
                     /* If the user couldn't resolve, Check for NOTIFY_USER_EXISTENCE property. If the property is not
                     enabled, notify with an empty NotificationResponseBean.*/

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
@@ -414,7 +414,7 @@ public class IdentityRecoveryServiceComponent {
     }
 
     /**
-     * unset multi attribute login service.
+     * Unset multi attribute login service.
      *
      * @param multiAttributeLoginService Multi-attribute login service.
      */

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
 import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.recovery.ChallengeQuestionManager;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.confirmation.ResendConfirmationManager;
@@ -394,5 +395,31 @@ public class IdentityRecoveryServiceComponent {
             log.debug("Configuration Manager service is unset in the Template Manager component.");
         }
         dataHolder.getInstance().setConfigurationManager(null);
+    }
+
+    /**
+     * Set multi attribute login service.
+     *
+     * @param multiAttributeLoginService Multi-attribute login service.
+     */
+    @Reference(
+            name = "MultiAttributeLoginService",
+            service = MultiAttributeLoginService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetMultiAttributeLoginService")
+    protected void setMultiAttributeLoginService(MultiAttributeLoginService multiAttributeLoginService) {
+
+        dataHolder.getInstance().setMultiAttributeLoginService(multiAttributeLoginService);
+    }
+
+    /**
+     * unset multi attribute login service.
+     *
+     * @param multiAttributeLoginService Multi-attribute login service.
+     */
+    protected void unsetMultiAttributeLoginService(MultiAttributeLoginService multiAttributeLoginService) {
+
+        dataHolder.getInstance().setMultiAttributeLoginService(null);
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceDataHolder.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceDataHolder.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.core.persistence.registry.RegistryResourceMgtSer
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.user.functionality.mgt.UserFunctionalityManager;
 import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
@@ -44,6 +45,7 @@ public class IdentityRecoveryServiceDataHolder {
     private ConsentUtilityService consentUtilityService;
     private ClaimMetadataManagementService claimMetadataManagementService;
     private UserFunctionalityManager userFunctionalityManagerService;
+    private MultiAttributeLoginService multiAttributeLoginService;
     public static IdentityRecoveryServiceDataHolder getInstance() {
 
         return instance;
@@ -221,5 +223,25 @@ public class IdentityRecoveryServiceDataHolder {
     public void setConfigurationManager(ConfigurationManager configurationManager) {
 
         this.configurationManager = configurationManager;
+    }
+
+    /**
+     * Set the multi attribute login service.
+     *
+     * @param multiAttributeLoginService Multi attribute login service.
+     */
+    public void setMultiAttributeLoginService(MultiAttributeLoginService multiAttributeLoginService) {
+
+        this.multiAttributeLoginService = multiAttributeLoginService;
+    }
+
+    /**
+     * Get the multi attribute login service.
+     *
+     * @return Multi attribute login service
+     */
+    public MultiAttributeLoginService getMultiAttributeLoginService() {
+
+        return this.multiAttributeLoginService;
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request
Fixes https://github.com/wso2/product-is/issues/13242 and https://github.com/wso2/product-is/issues/13266
Refer comment: https://github.com/wso2/product-is/issues/13242#issuecomment-1078815652

If multi-attribute login is enabled:
**mobile is the configured allowed login claim**
**1. Default behavior**
```
[identity_mgt.recovery]
notify_user_existence=false
```

- `user1` is an existing user's username
No recovery mail received to user
![Screenshot - 2022-03-25T095729 699](https://user-images.githubusercontent.com/25483865/160054986-d51b964f-4ccb-43c6-9ef5-0c28c2b77308.png)

- `user3` is a nonexisting user's username
No recovery mail
![Screenshot - 2022-03-25T100407 760](https://user-images.githubusercontent.com/25483865/160055036-cca99e3a-e016-45ae-913b-2522f4d6fad9.png)

- `0711122333` is an existing user's mobile
User will get a recovery mail

![Screenshot - 2022-03-25T100427 741](https://user-images.githubusercontent.com/25483865/160055057-9532c2b9-1fa5-4ead-accb-3edd69f4e27c.png)

![Screenshot - 2022-03-25T100523 594](https://user-images.githubusercontent.com/25483865/160055062-967b7e11-4abb-40f7-aefe-18ac13eee62b.png)


- `0719988777` is not a mobile number of any user
No recovery mail
![Screenshot - 2022-03-25T100449 450](https://user-images.githubusercontent.com/25483865/160055067-d94a1ab7-5f4d-4ad7-98b7-80bf585c4c98.png)


-----------------------------------------------------------------------------------------------------------------
**2.notify_user_existence = true**
```
[identity_mgt.recovery]
notify_user_existence=true
```
- `user1` is an existing user's username
No recovery mail received to user

![Screenshot - 2022-03-25T101115 664](https://user-images.githubusercontent.com/25483865/160055883-ec4658f9-650d-4378-a23d-91c47616b96b.png)


- `user3` is a nonexisting user's username
No recovery mail

![Screenshot - 2022-03-25T101151 699](https://user-images.githubusercontent.com/25483865/160055899-173dc44b-c362-4356-94c3-e7bf85b3b1a2.png)


- `0711122333` is an existing user's mobile
User will get a recovery mail

![Screenshot - 2022-03-25T101213 457](https://user-images.githubusercontent.com/25483865/160055918-c3e36680-1a70-48fe-8b1f-19dc2f7ce08d.png)

![Screenshot - 2022-03-25T101254 370](https://user-images.githubusercontent.com/25483865/160055928-7e589609-ba34-4055-968a-ea51c2afc3fb.png)


- `0719988777` is not a mobile number of any user
No recovery mail
![Screenshot - 2022-03-25T101233 937](https://user-images.githubusercontent.com/25483865/160055942-d72942cc-0a37-4899-a405-b5157507e2a0.png)


