### PR TITLE
Improve the validateEmailUsername method logic

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -101,7 +101,7 @@ public class NotificationPasswordRecoveryManager {
                         RecoveryScenarios.NOTIFICATION_BASED_PW_RECOVERY, RecoverySteps.UPDATE_PASSWORD));
 
         validateUserStoreDomain(user);
-        Utils.validateEmailUsername(user.getUserName());
+        Utils.validateEmailUsername(user);
 
         // Resolve user attributes.
         resolveUserAttributes(user);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/SecurityQuestionPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/SecurityQuestionPasswordRecoveryManager.java
@@ -102,7 +102,7 @@ public class SecurityQuestionPasswordRecoveryManager {
 
     public ChallengeQuestionResponse initiateUserChallengeQuestion(User user) throws IdentityRecoveryException {
 
-        Utils.validateEmailUsername(user.getUserName());
+        Utils.validateEmailUsername(user);
         if (StringUtils.isBlank(user.getTenantDomain())) {
             user.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
             log.info("initiateUserChallengeQuestion :Tenant domain is not in the request. set to default for user : " +

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -948,8 +948,8 @@ public class Utils {
         if (!IdentityUtil.isEmailUsernameEnabled()) {
             // Doesn't need to check for the username if "email address as the username" option is disabled.
             return;
-        } else if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(user.getTenantDomain()),
-                MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
+        }
+        if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(user.getTenantDomain())) {
             // Super tenant user should be able to log in with both email username or non-email username.
             return;
         }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -948,9 +948,9 @@ public class Utils {
         if (!IdentityUtil.isEmailUsernameEnabled()) {
             // Doesn't need to check for the username if "email address as the username" option is disabled.
             return;
-        } if (StringUtils.equals(user.getTenantDomain(),
+        } else if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(user.getTenantDomain()),
                 MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
-            // Super tenant user can be log in with both email username or non-email username.
+            // Super tenant user should be able to log in with both email username or non-email username.
             return;
         }
         if (StringUtils.countMatches(user.getUserName(), "@") == 0) {


### PR DESCRIPTION
### Purpose
* $subject
* Update `validateEmailUsername` logic to prevent checking the `@` symbol in the usernames of the super tenant. Since the super tenants users can use email usernames and non-email usernames when the `email address as the username` option is enabled.
* Fix https://github.com/wso2/product-is/issues/13498