### PR TITLE
Fixed the issue where filtering with identity claims (stored in user stores) returns 0 results.

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
@@ -486,6 +486,11 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
             return true;
         }
 
+        // No need to separately handle if identity data store is user store based.
+        if (identityDataStore instanceof UserStoreBasedIdentityDataStore) {
+            return true;
+        }
+
         List<ExpressionCondition> identityClaimFilterConditions = new ArrayList<>();
         try {
             // Extract identity Claim filter-conditions from the given conditions.


### PR DESCRIPTION
### Proposed changes in this pull request
By doing this change, if the identity claims of users are stored in a user store instead of the IDN_IDENTITY_USER table, the code will return true instead of running the search on the IDN_IDENTITY_USER table and removing the search conditions (expressionConditions) in the process.

Related issue: https://github.com/wso2/product-is/issues/13711
