### PR TITLE
Adjusting pre and post listeners for get user with ID and cursor pagination for identity claims.

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
@@ -834,6 +834,32 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
     }
 
     @Override
+    public boolean doPreGetUserListWithID(Condition condition, String domain, String profileName, int limit,
+                   String cursor, String direction, String sortBy, String sortOrder, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        if (!isEnable()) {
+            return true;
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("pre get user user list condition with id is called in IdentityMgtEventListener");
+        }
+        String eventName = IdentityEventConstants.Event.PRE_GET_USER_LIST_CONDITION_WITH_ID;
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put(IdentityEventConstants.EventProperty.CONDITION, condition);
+        properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, domain);
+        properties.put(IdentityEventConstants.EventProperty.PROFILE_NAME, profileName);
+        properties.put(IdentityEventConstants.EventProperty.LIMIT, limit);
+        properties.put(IdentityEventConstants.EventProperty.CURSOR, cursor);
+        properties.put(IdentityEventConstants.EventProperty.DIRECTION, direction);
+        properties.put(IdentityEventConstants.EventProperty.SORT_BY, sortBy);
+        properties.put(IdentityEventConstants.EventProperty.SORT_ORDER, sortOrder);
+
+        handleEvent(eventName, properties, userStoreManager);
+        return true;
+    }
+
+    @Override
     public boolean doPreGetUserListWithID(String claimUri, String claimValue, int limit, int offset,
                                           final List<User> returnUsersList, UserStoreManager userStoreManager) throws UserStoreException {
 
@@ -915,6 +941,33 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
         properties.put(IdentityEventConstants.EventProperty.PROFILE_NAME, profileName);
         properties.put(IdentityEventConstants.EventProperty.LIMIT, limit);
         properties.put(IdentityEventConstants.EventProperty.OFFSET, offset);
+        properties.put(IdentityEventConstants.EventProperty.SORT_BY, sortBy);
+        properties.put(IdentityEventConstants.EventProperty.SORT_ORDER, sortOrder);
+
+        handleEvent(eventName, properties, userStoreManager);
+        return true;
+    }
+
+    @Override
+    public boolean doPostGetUserListWithID(Condition condition, String domain, String profileName, int limit,
+                                           String cursor, String direction, String sortBy, String sortOrder,
+                                           List<User> users, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        if (!isEnable()) {
+            return true;
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("post get user user list condition with id is called in IdentityMgtEventListener");
+        }
+        String eventName = IdentityEventConstants.Event.POST_GET_USER_LIST_CONDITION_WITH_ID;
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put(IdentityEventConstants.EventProperty.CONDITION, condition);
+        properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, domain);
+        properties.put(IdentityEventConstants.EventProperty.PROFILE_NAME, profileName);
+        properties.put(IdentityEventConstants.EventProperty.LIMIT, limit);
+        properties.put(IdentityEventConstants.EventProperty.CURSOR, cursor);
+        properties.put(IdentityEventConstants.EventProperty.DIRECTION, direction);
         properties.put(IdentityEventConstants.EventProperty.SORT_BY, sortBy);
         properties.put(IdentityEventConstants.EventProperty.SORT_ORDER, sortOrder);
 

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
@@ -835,7 +835,8 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
 
     @Override
     public boolean doPreGetUserListWithID(Condition condition, String domain, String profileName, int limit,
-                   String cursor, String direction, String sortBy, String sortOrder, UserStoreManager userStoreManager)
+                   String cursor, UserCoreConstants.PaginationDirection direction, String sortBy, String sortOrder,
+                   UserStoreManager userStoreManager)
             throws UserStoreException {
 
         if (!isEnable()) {
@@ -950,8 +951,8 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
 
     @Override
     public boolean doPostGetUserListWithID(Condition condition, String domain, String profileName, int limit,
-                                           String cursor, String direction, String sortBy, String sortOrder,
-                                           List<User> users, UserStoreManager userStoreManager)
+                   String cursor, UserCoreConstants.PaginationDirection direction, String sortBy, String sortOrder,
+                   List<User> users, UserStoreManager userStoreManager)
             throws UserStoreException {
 
         if (!isEnable()) {

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
@@ -508,7 +508,7 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
 
     public boolean doPreGetPaginatedUserList(Condition condition, List<String> identityClaimFilteredUserNames,
                                              String domain, UserStoreManager userStoreManager, int limit, String cursor,
-                                             String direction)
+                                             UserCoreConstants.PaginationDirection direction)
             throws UserStoreException {
 
         if (!isEnable()) {

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
@@ -486,6 +486,11 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
             return true;
         }
 
+        // No need to separately handle if identity data store is user store based.
+        if (identityDataStore instanceof UserStoreBasedIdentityDataStore) {
+            return true;
+        }
+
         List<ExpressionCondition> identityClaimFilterConditions = new ArrayList<>();
         try {
             // Extract identity Claim filter-conditions from the given conditions.
@@ -493,6 +498,35 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
             if (!identityClaimFilterConditions.isEmpty()) {
                 identityDataStore.listPaginatedUsersNames(identityClaimFilterConditions, identityClaimFilteredUserNames,
                         domain, userStoreManager, limit, offset);
+            }
+        } catch (IdentityException e) {
+            throw new UserStoreException("Error while listing the users for identity claim filters with pagination " +
+                    "parameters.", e);
+        }
+        return true;
+    }
+
+    public boolean doPreGetPaginatedUserList(Condition condition, List<String> identityClaimFilteredUserNames,
+                                             String domain, UserStoreManager userStoreManager, int limit, String cursor,
+                                             String direction)
+            throws UserStoreException {
+
+        if (!isEnable()) {
+            return true;
+        }
+
+        // No need to separately handle if identity data store is user store based.
+        if (identityDataStore instanceof UserStoreBasedIdentityDataStore) {
+            return true;
+        }
+
+        List<ExpressionCondition> identityClaimFilterConditions = new ArrayList<>();
+        try {
+            // Extract identity Claim filter-conditions from the given conditions.
+            extractIdentityClaimFilterConditions(condition, identityClaimFilterConditions);
+            if (!identityClaimFilterConditions.isEmpty()) {
+                identityDataStore.listPaginatedUsersNames(identityClaimFilterConditions, identityClaimFilteredUserNames,
+                        domain, userStoreManager, limit, cursor, direction);
             }
         } catch (IdentityException e) {
             throw new UserStoreException("Error while listing the users for identity claim filters with pagination " +

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/JDBCIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/JDBCIdentityDataStore.java
@@ -389,9 +389,10 @@ public class JDBCIdentityDataStore extends InMemoryIdentityDataStore {
 
     @Override
     public List<String> listPaginatedUsersNames(List<ExpressionCondition> identityClaimFilterExpressionConditions,
-                                                List<String> identityClaimFilteredUserNames, String domain,
-                                                org.wso2.carbon.user.core.UserStoreManager userStoreManager,
-                                                int limit, String cursor, String direction) throws IdentityException {
+                     List<String> identityClaimFilteredUserNames, String domain,
+                     org.wso2.carbon.user.core.UserStoreManager userStoreManager,
+                     int limit, String cursor, UserCoreConstants.PaginationDirection direction)
+            throws IdentityException {
 
         try {
             int tenantId = userStoreManager.getTenantId();
@@ -473,8 +474,8 @@ public class JDBCIdentityDataStore extends InMemoryIdentityDataStore {
     }
 
     private SqlBuilder getQueryString(List<ExpressionCondition> identityClaimFilterExpressionConditions,
-                                      int limit, Integer offset, String cursor, String direction,
-                                      String userStoreDomain, int tenantID, String dbType) {
+                       int limit, Integer offset, String cursor, UserCoreConstants.PaginationDirection direction,
+                       String userStoreDomain, int tenantID, String dbType) {
 
         boolean hitClaimFilter = false;
         String userNameWithDomain;
@@ -491,7 +492,7 @@ public class JDBCIdentityDataStore extends InMemoryIdentityDataStore {
             sqlBuilder.where(" USER_NAME LIKE ? ", userNameWithDomain);
         }
         if (cursor != null) {
-            if (UserCoreConstants.PREVIOUS.equals(direction)) {
+            if (UserCoreConstants.PaginationDirection.PREVIOUS == direction) {
                 if (StringUtils.equalsIgnoreCase(userStoreDomain, UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME)) {
                     sqlBuilder.where("USER_NAME < ?", cursor);
                 } else {
@@ -528,20 +529,20 @@ public class JDBCIdentityDataStore extends InMemoryIdentityDataStore {
 
         // SQL to cover the whole query and reverse the result when querying for the previous page which will be in
         // DESC order.
-        if (UserCoreConstants.PREVIOUS.equals(direction)) {
+        if (UserCoreConstants.PaginationDirection.PREVIOUS == direction) {
             sqlBuilder.prependSql("SELECT * FROM ( ");
         }
 
         if (cursor != null) {
             if (DB2.equals(dbType)) {
-                if (UserCoreConstants.PREVIOUS.equals(direction)) {
+                if (UserCoreConstants.PaginationDirection.PREVIOUS == direction) {
                     sqlBuilder.setTail(" ORDER BY USER_NAME DESC LIMIT ? " +
                             ") AS results ORDER BY results.USER_NAME ASC", limit);
                 } else {
                     sqlBuilder.setTail(" ORDER BY USER_NAME LIMIT ?", limit);
                 }
             } else if (ORACLE.equals(dbType) || POSTGRE_SQL.equals(dbType)) {
-                if (UserCoreConstants.PREVIOUS.equals(direction)) {
+                if (UserCoreConstants.PaginationDirection.PREVIOUS == direction) {
                     sqlBuilder.setTail(" ORDER BY USER_NAME DESC FETCH NEXT ? ROWS ONLY" +
                             ") results ORDER BY results.USER_NAME ASC", limit);
                 } else {
@@ -549,14 +550,14 @@ public class JDBCIdentityDataStore extends InMemoryIdentityDataStore {
                 }
             } else if (MSSQL.equals(dbType)) {
                 // Even with cursor pagination we must use the OFFSET keyword as it is compulsory to LIMIT rows in MSSQL
-                if (UserCoreConstants.PREVIOUS.equals(direction)) {
+                if (UserCoreConstants.PaginationDirection.PREVIOUS == direction) {
                     sqlBuilder.setTail(" ORDER BY USER_NAME DESC OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY" +
                             ") AS results ORDER BY results.USER_NAME ASC", limit);
                 } else {
                     sqlBuilder.setTail(" ORDER BY USER_NAME OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY", limit);
                 }
             } else {
-                if (UserCoreConstants.PREVIOUS.equals(direction)) {
+                if (UserCoreConstants.PaginationDirection.PREVIOUS == direction) {
                     sqlBuilder.setTail(" ORDER BY USER_NAME DESC LIMIT ? " +
                             ") AS results ORDER BY results.USER_NAME ASC;", limit);
                 } else {

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/UserIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/UserIdentityDataStore.java
@@ -113,4 +113,26 @@ public abstract class UserIdentityDataStore {
         // Return an immutable empty list if sub classes do not have any overrides.
         return Collections.emptyList();
     }
+
+    /**
+     * List users according to the given claim URI and value and pagination parameters.
+     *
+     * @param expressionConditions           List of expression conditions.
+     * @param identityClaimFilteredUserNames List to hold filtered usernames.
+     * @param domain                         Userstore domain
+     * @param userStoreManager               UserStoreManager instance.
+     * @param limit                          Number of users to return
+     * @param cursor                         Cursor value for cursor-based pagination
+     * @param direction                      Direction of pagination
+     * @return List of usernames.
+     * @throws IdentityException Identity Exception.
+     */
+    public List<String> listPaginatedUsersNames(List<ExpressionCondition> expressionConditions,
+                        List<String> identityClaimFilteredUserNames, String domain,
+                        org.wso2.carbon.user.core.UserStoreManager userStoreManager, int limit, String cursor,
+                        String direction) throws IdentityException {
+
+        // Return an immutable empty list if sub classes do not have any overrides.
+        return Collections.emptyList();
+    }
 }

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/UserIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/UserIdentityDataStore.java
@@ -130,7 +130,7 @@ public abstract class UserIdentityDataStore {
     public List<String> listPaginatedUsersNames(List<ExpressionCondition> expressionConditions,
                         List<String> identityClaimFilteredUserNames, String domain,
                         org.wso2.carbon.user.core.UserStoreManager userStoreManager, int limit, String cursor,
-                        String direction) throws IdentityException {
+                        UserCoreConstants.PaginationDirection direction) throws IdentityException {
 
         // Return an immutable empty list if sub classes do not have any overrides.
         return Collections.emptyList();


### PR DESCRIPTION
### Proposed changes in this pull request
The purpose of this PR is for;
1. handlePreGetUserListWithID and handlePostGetUserListWithID to be functional and call the necessary listeners when requesting a cursor paginated request instead of an index paginated request.
2. To get cursor paginated results when identity claims are stored in a default identity database.
3. To get cursor paginated results when identity claims are stored in a user store.

## Related Issues
- https://github.com/wso2/product-is/issues/13294

## Dependant PRs

- [ ] https://github.com/wso2/carbon-kernel/pull/3281
PR builder fails as the new enum from carbon-kernel has not been merged yet.

## Test environment
1. Java versions
- JDK 1.8
- Open JDK 11.0.15
2. OS
- Ubuntu 20.04
3. IS:
- WSO2IS-5.12.0-alpha14, 
4. User stores:
- JDBC
  - DB2 - 11.5.7.0
  - Oracle - 19.3.0-ee
  - MSSQL - Microsoft SQL Server 2019 - 15.0.4223.1 (X64) 
  - MySQL - Ver 8.0.29
  - Postgres - PostgreSQL 14.3 
- LDAP
