### PR TITLE
Introduce a new system wide configuration to enable reCaptcha

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/CaptchaApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/CaptchaApiServiceImpl.java
@@ -55,9 +55,12 @@ public class CaptchaApiServiceImpl extends CaptchaApiService {
 
         Properties properties = RecoveryUtil.getValidatedCaptchaConfigs();
         boolean reCaptchaEnabled = Boolean.valueOf(properties.getProperty(CaptchaConstants.RE_CAPTCHA_ENABLED));
+        boolean forcefullyEnabledRecaptchaForAllTenants =
+                Boolean.valueOf(properties.getProperty(CaptchaConstants.FORCEFULLY_ENABLED_RECAPTCHA_FOR_ALL_TENANTS));
         ReCaptchaPropertiesDTO reCaptchaPropertiesDTO = new ReCaptchaPropertiesDTO();
 
-        if (reCaptchaEnabled && RecoveryUtil.checkCaptchaEnabledResidentIdpConfiguration(tenantDomain, recoveryType)) {
+        if (reCaptchaEnabled && (forcefullyEnabledRecaptchaForAllTenants ||
+                RecoveryUtil.checkCaptchaEnabledResidentIdpConfiguration(tenantDomain, recoveryType))) {
             reCaptchaPropertiesDTO.setReCaptchaEnabled(true);
             reCaptchaPropertiesDTO.setReCaptchaKey(properties.getProperty(CaptchaConstants.RE_CAPTCHA_SITE_KEY));
             reCaptchaPropertiesDTO.setReCaptchaAPI(properties.getProperty(CaptchaConstants.RE_CAPTCHA_API_URL));

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/ResendConfirmationReCaptchaConnector.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/ResendConfirmationReCaptchaConnector.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.identity.captcha.connector.CaptchaPostValidationResponse;
 import org.wso2.carbon.identity.captcha.connector.CaptchaPreValidationResponse;
 import org.wso2.carbon.identity.captcha.exception.CaptchaClientException;
 import org.wso2.carbon.identity.captcha.exception.CaptchaException;
+import org.wso2.carbon.identity.captcha.internal.CaptchaDataHolder;
 import org.wso2.carbon.identity.captcha.util.CaptchaUtil;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 
@@ -62,30 +63,17 @@ public class ResendConfirmationReCaptchaConnector extends AbstractReCaptchaConne
     public boolean canHandle(ServletRequest servletRequest, ServletResponse servletResponse) throws CaptchaException {
 
         String path = ((HttpServletRequest) servletRequest).getRequestURI();
-        Property[] connectorConfigs;
-        String enable = null;
 
         if (StringUtils.isBlank(path) || !(CaptchaUtil.isPathAvailable(path, RESEND_CONFIRMATION_URL))) {
             return false;
         }
 
-        try {
-            connectorConfigs = CaptchaUtil.getConnectorConfigs(servletRequest, identityGovernanceService,
-                    RESEND_CONFIRMATION_RECAPTCHA_ENABLE);
-        } catch (Exception e) {
-            // Can happen due to invalid tenant/ invalid configuration.
-            if (log.isDebugEnabled()) {
-                log.debug("Unable to load connector configuration.", e);
-            }
-            return false;
+        if (CaptchaDataHolder.getInstance().isForcefullyEnabledRecaptchaForAllTenants()) {
+            return true;
         }
 
-        for (Property connectorConfig : connectorConfigs) {
-            if ((RESEND_CONFIRMATION_RECAPTCHA_ENABLE).equals(connectorConfig.getName())) {
-                enable = connectorConfig.getValue();
-            }
-        }
-        return Boolean.parseBoolean(enable);
+        return CaptchaUtil.isRecaptchaEnabledForConnector(identityGovernanceService, servletRequest,
+                RESEND_CONFIRMATION_RECAPTCHA_ENABLE);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/SelfSignUpReCaptchaConnector.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/SelfSignUpReCaptchaConnector.java
@@ -76,27 +76,12 @@ public class SelfSignUpReCaptchaConnector extends AbstractReCaptchaConnector {
             return false;
         }
 
-        Property[] connectorConfigs;
-        try {
-            connectorConfigs = CaptchaUtil.getConnectorConfigs(servletRequest, identityGovernanceService,
-                    PROPERTY_ENABLE_RECAPTCHA);
-        } catch (Exception e) {
-            // Can happen due to invalid tenant/ invalid configuration
-            if (log.isDebugEnabled()) {
-                log.debug("Unable to load connector configuration.", e);
-            }
-            return false;
+        if (CaptchaDataHolder.getInstance().isForcefullyEnabledRecaptchaForAllTenants()) {
+            return true;
         }
 
-        String enable = null;
-        for (Property connectorConfig : connectorConfigs) {
-            if ((PROPERTY_ENABLE_RECAPTCHA).equals(connectorConfig.getName())) {
-                enable = connectorConfig.getValue();
-            }
-        }
-
-        return Boolean.parseBoolean(enable);
-
+        return CaptchaUtil.isRecaptchaEnabledForConnector(identityGovernanceService, servletRequest,
+                PROPERTY_ENABLE_RECAPTCHA);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaDataHolder.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaDataHolder.java
@@ -63,6 +63,8 @@ public class CaptchaDataHolder {
 
     private Map<String, String> passwordRecoveryReCaptchaConnectorPropertyMap = new HashMap<>();
 
+    private boolean forcefullyEnabledRecaptchaForAllTenants;
+
     private CaptchaDataHolder() {
 
     }
@@ -185,5 +187,15 @@ public class CaptchaDataHolder {
 
     public void setAccountLockService(AccountLockService accountLockService) {
         this.accountLockService = accountLockService;
+    }
+
+    public boolean isForcefullyEnabledRecaptchaForAllTenants() {
+
+        return forcefullyEnabledRecaptchaForAllTenants;
+    }
+
+    public void setForcefullyEnabledRecaptchaForAllTenants(boolean forcefullyEnabledRecaptchaForAllTenants) {
+
+        this.forcefullyEnabledRecaptchaForAllTenants = forcefullyEnabledRecaptchaForAllTenants;
     }
 }

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaConstants.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaConstants.java
@@ -33,6 +33,9 @@ public class CaptchaConstants {
 
     public static final String RE_CAPTCHA_ENABLED = "recaptcha.enabled";
 
+    public static final String FORCEFULLY_ENABLED_RECAPTCHA_FOR_ALL_TENANTS = "recaptcha" +
+            ".forcefullyEnabledForAllTenants";
+
     public static final String RE_CAPTCHA_API_URL = "recaptcha.api.url";
 
     public static final String RE_CAPTCHA_VERIFY_URL = "recaptcha.verify.url";

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaUtil.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaUtil.java
@@ -416,6 +416,11 @@ public class CaptchaUtil {
             throw new RuntimeException(getValidationErrorMessage(CaptchaConstants.RE_CAPTCHA_REQUEST_WRAP_URLS));
         }
         CaptchaDataHolder.getInstance().setReCaptchaRequestWrapUrls(reCaptchaRequestWrapUrls);
+
+        String forcefullyEnableRecaptchaForAllTenants =
+                properties.getProperty(CaptchaConstants.FORCEFULLY_ENABLED_RECAPTCHA_FOR_ALL_TENANTS);
+        CaptchaDataHolder.getInstance().setForcefullyEnabledRecaptchaForAllTenants(
+                Boolean.parseBoolean(forcefullyEnableRecaptchaForAllTenants));
     }
 
     private static void setSSOLoginConnectorConfigs(Properties properties) {
@@ -624,5 +629,37 @@ public class CaptchaUtil {
         }
 
         return !Boolean.FALSE.toString().equalsIgnoreCase(configValue);
+    }
+
+    /**
+     * Check resident IDP reCaptcha configuration for the given property.
+     *
+     * @param identityGovernanceService Identity governance service.
+     * @param servletRequest            Servlet request.
+     * @param propertyName              Property name.
+     * @return true if reCaptcha is enabled, false otherwise.
+     */
+    public static boolean isRecaptchaEnabledForConnector(IdentityGovernanceService identityGovernanceService,
+                                                         ServletRequest servletRequest, String propertyName) {
+
+        Property[] connectorConfigs;
+        try {
+            connectorConfigs = CaptchaUtil.getConnectorConfigs(servletRequest, identityGovernanceService,
+                    propertyName);
+        } catch (Exception e) {
+            // Can happen due to invalid tenant/ invalid configuration
+            if (log.isDebugEnabled()) {
+                log.debug("Unable to load connector configuration.", e);
+            }
+            return false;
+        }
+
+        String enable = null;
+        for (Property connectorConfig : connectorConfigs) {
+            if ((propertyName).equals(connectorConfig.getName())) {
+                enable = connectorConfig.getValue();
+            }
+        }
+        return Boolean.parseBoolean(enable);
     }
 }

--- a/features/org.wso2.carbon.identity.captcha.server.feature/resources/conf/captcha-config.properties
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/resources/conf/captcha-config.properties
@@ -21,6 +21,9 @@
 # Enable Google reCAPTCHA
 recaptcha.enabled=false
 
+# Forcefully enable Google reCAPTCHA for all tenants
+recaptcha.forcefullyEnabledForAllTenants=false
+
 # reCaptcha API URL
 recaptcha.api.url=https://www.google.com/recaptcha/api.js
 

--- a/features/org.wso2.carbon.identity.captcha.server.feature/resources/conf/captcha-config.properties.j2
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/resources/conf/captcha-config.properties.j2
@@ -21,6 +21,9 @@
 # Enable Google reCAPTCHA
 recaptcha.enabled={{recaptcha.enabled}}
 
+# Forcefully enable Google reCAPTCHA for all tenants
+recaptcha.forcefullyEnabledForAllTenants={{recaptcha.forcefully_enabled_for_all_tenants}}
+
 # reCaptcha API URL
 recaptcha.api.url={{recaptcha.api_url}}
 

--- a/features/org.wso2.carbon.identity.captcha.server.feature/resources/conf/org.wso2.carbon.identity.captcha.server.feature.default.json
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/resources/conf/org.wso2.carbon.identity.captcha.server.feature.default.json
@@ -1,5 +1,6 @@
 {
   "recaptcha.enabled": false,
+  "recaptcha.forcefully_enabled_for_all_tenants": false,
   "recaptcha.api_url": "https://www.google.com/recaptcha/api.js",
   "recaptcha.verify_url": "https://www.google.com/recaptcha/api/siteverify",
   "recaptcha.request_wrap_urls": ""


### PR DESCRIPTION
Resolves part of [product-is #13525](https://github.com/wso2/product-is/issues/13525)

**Do not merge until [product-is #13810](https://github.com/wso2/product-is/issues/13810) is resolved as recaptcha for self sign up flows is not properly tested due to the mentioned issue.**

This PR introduces a new system wide configuration to enable reCaptcha for all the flows irrespective of the tenant domain. If this configuration is enabled, reCaptcha will be applied to SSO login, password recovery, username recovery and self sign up flows in all the tenants. If this is not enabled tenant wise configurations will be applied accordingly in each flow. This configuration is set to _**false**_ by default.

This configuration can be enabled by adding the following line under recaptcha configurations in deployment.toml file.
```
forcefully_enabled_for_all_tenants = true
```

Example of a complete reCaptcha configuration to be added to the deployment.toml file is given below.
```
# Google reCAPTCHA settings

# Enable Google reCAPTCHA
[recaptcha]
enabled = true

forcefully_enabled_for_all_tenants = true

# reCaptcha API URL
api_url="https://www.google.com/recaptcha/api.js"

# reCaptcha verification URL
verify_url="https://www.google.com/recaptcha/api/siteverify"

# reCaptcha site key
site_key="6LfXZ_kfAAAAANdNoyl5F7vfbvFzuwhZzZwhkBy6"

# reCaptcha secret key
secret_key="6LfXZ_kfAAAAACiAmwZKcDZlcXQTToVnYI7HZ7Y4"
```