### PR TITLE
Resend code support for mobile number confirmation by a privileged user

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImpl.java
@@ -181,6 +181,13 @@ public class ResendCodeApiServiceImpl extends ResendCodeApiService {
             notificationResponseBean = setNotificationResponseBean(resendConfirmationManager,
                     RecoveryScenarios.EMAIL_VERIFICATION_ON_UPDATE.toString(), RecoverySteps.VERIFY_EMAIL.toString(),
                     IdentityRecoveryConstants.NOTIFICATION_TYPE_RESEND_VERIFY_EMAIL_ON_UPDATE, resendCodeRequestDTO);
+        } else if (RecoveryScenarios.MOBILE_VERIFICATION_ON_UPDATE.toString().equals(recoveryScenario) &&
+                RecoveryScenarios.MOBILE_VERIFICATION_ON_UPDATE.equals(userRecoveryData.getRecoveryScenario()) &&
+                RecoverySteps.VERIFY_MOBILE_NUMBER.equals(userRecoveryData.getRecoveryStep())) {
+            notificationResponseBean = setNotificationResponseBean(resendConfirmationManager,
+                    RecoveryScenarios.MOBILE_VERIFICATION_ON_UPDATE.toString(),
+                    RecoverySteps.VERIFY_MOBILE_NUMBER.toString(),
+                    IdentityRecoveryConstants.NOTIFICATION_TYPE_VERIFY_MOBILE_ON_UPDATE, resendCodeRequestDTO);
         }
 
         return notificationResponseBean;


### PR DESCRIPTION
[Mobile Number Verification for an Updated Mobile Number](https://is.docs.wso2.com/en/latest/develop/enable-verification-for-updated-mobile-number/) REST APIs are not supported when invoked by a privileged user. As mentioned in the document, it supports "me" endpoints only.

With this fix, `/api/identity/user/v1.0/resend-code` endpoint support will be added for privileged users.

**Related issue**
- https://github.com/wso2/product-is/issues/13858