### PR TITLE
Add User Store Validation during Self-registration

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImpl.java
@@ -55,6 +55,9 @@ public class ValidateUsernameApiServiceImpl extends ValidateUsernameApiService {
 
         String username = user.getUsername();
         if (StringUtils.isEmpty(username)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Username validation failed as the username is empty.");
+            }
             ErrorDTO errorDTO = new ErrorDTO();
             errorDTO.setRef(Utils.getCorrelation());
             errorDTO.setMessage("Username cannot be empty.");
@@ -81,7 +84,12 @@ public class ValidateUsernameApiServiceImpl extends ValidateUsernameApiService {
 
             String userStoreDomain = IdentityUtil.extractDomainFromName(username);
             if (StringUtils.isNotEmpty(realm) && !userStoreDomain.equals(realm)) {
+                // When the userstore domain is not prepended to the username or if the prepended userstore domain is
+                // different from the realm property, the domain from the realm will be added to the username.
                 username = realm + IdentityManagementEndpointConstants.USER_STORE_DOMAIN_SEPARATOR + username;
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(String.format("Username after adding the userstore domain: %s", username));
+                }
             }
 
             UserSelfRegistrationManager userSelfRegistrationManager = Utils

--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImpl.java
@@ -53,7 +53,8 @@ public class ValidateUsernameApiServiceImpl extends ValidateUsernameApiService {
     @Override
     public Response validateUsernamePost(UsernameValidationRequestDTO user) {
 
-        if (StringUtils.isEmpty(user.getUsername())) {
+        String username = user.getUsername();
+        if (StringUtils.isEmpty(username)) {
             ErrorDTO errorDTO = new ErrorDTO();
             errorDTO.setRef(Utils.getCorrelation());
             errorDTO.setMessage("Username cannot be empty.");
@@ -61,7 +62,8 @@ public class ValidateUsernameApiServiceImpl extends ValidateUsernameApiService {
         }
 
         try {
-            String tenantDomain = MultitenantUtils.getTenantDomain(user.getUsername());
+            String tenantDomain = MultitenantUtils.getTenantDomain(username);
+            String realm = null;
             List<PropertyDTO> propertyDTOList = user.getProperties();
             boolean skipSelfSignUpEnabledCheck = false;
 
@@ -71,13 +73,21 @@ public class ValidateUsernameApiServiceImpl extends ValidateUsernameApiService {
                         skipSelfSignUpEnabledCheck = Boolean.parseBoolean(propertyDTO.getValue());
                     } else if (IdentityManagementEndpointConstants.TENANT_DOMAIN.equals(propertyDTO.getKey())) {
                         tenantDomain = propertyDTO.getValue();
+                    } else if (IdentityManagementEndpointConstants.REALM.equals(propertyDTO.getKey())) {
+                        realm = propertyDTO.getValue();
                     }
                 }
             }
+
+            String userStoreDomain = IdentityUtil.extractDomainFromName(username);
+            if (StringUtils.isNotEmpty(realm) && !userStoreDomain.equals(realm)) {
+                username = realm + IdentityManagementEndpointConstants.USER_STORE_DOMAIN_SEPARATOR + username;
+            }
+
             UserSelfRegistrationManager userSelfRegistrationManager = Utils
                     .getUserSelfRegistrationManager();
             if (LOG.isDebugEnabled()) {
-                LOG.debug(String.format("Validating username for user %s", user.getUsername()));
+                LOG.debug(String.format("Validating username for user %s", username));
             }
             UsernameValidateInfoResponseDTO responseDTO = new UsernameValidateInfoResponseDTO();
             ErrorDTO errorDTO = new ErrorDTO();
@@ -94,22 +104,29 @@ public class ValidateUsernameApiServiceImpl extends ValidateUsernameApiService {
                 errorDTO.setCode(SelfRegistrationStatusCodes.ERROR_CODE_SELF_REGISTRATION_DISABLED);
                 errorDTO.setRef(Utils.getCorrelation());
                 return Response.status(Response.Status.BAD_REQUEST).entity(errorDTO).build();
-            } else if (userSelfRegistrationManager.isUsernameAlreadyTaken(user.getUsername(), tenantDomain)) {
+            } else if (userSelfRegistrationManager.isUsernameAlreadyTaken(username, tenantDomain)) {
                 logDebug(String.format("username : %s is an already taken. Hence returning code %s: ",
-                        user.getUsername(), SelfRegistrationStatusCodes.ERROR_CODE_USER_ALREADY_EXISTS));
+                        username, SelfRegistrationStatusCodes.ERROR_CODE_USER_ALREADY_EXISTS));
                 errorDTO.setCode(SelfRegistrationStatusCodes.ERROR_CODE_USER_ALREADY_EXISTS);
                 errorDTO.setRef(Utils.getCorrelation());
                 return Response.status(Response.Status.BAD_REQUEST).entity(errorDTO).build();
-            } else if (!userSelfRegistrationManager.isMatchUserNameRegex(tenantDomain, user.getUsername())) {
+            } else if (!userSelfRegistrationManager.isMatchUserNameRegex(tenantDomain, username)) {
                 logDebug(String.format("%s is an invalid user name. Hence returning code %s: ",
-                        user.getUsername(), SelfRegistrationStatusCodes.CODE_USER_NAME_INVALID));
+                        username, SelfRegistrationStatusCodes.CODE_USER_NAME_INVALID));
                 errorDTO.setCode(SelfRegistrationStatusCodes.CODE_USER_NAME_INVALID);
                 errorDTO.setMessage(getRegexViolationErrorMsg(user, tenantDomain));
                 errorDTO.setRef(Utils.getCorrelation());
                 return Response.status(Response.Status.BAD_REQUEST).entity(errorDTO).build();
+            } else if (StringUtils.isNotEmpty(realm) && !userSelfRegistrationManager.
+                    isValidUserStoreDomain(realm, tenantDomain)) {
+                logDebug(String.format("%s is an invalid user store domain. Hence returning code %s: ", realm,
+                        SelfRegistrationStatusCodes.ERROR_CODE_INVALID_USERSTORE));
+                errorDTO.setCode(SelfRegistrationStatusCodes.ERROR_CODE_INVALID_USERSTORE);
+                errorDTO.setRef(Utils.getCorrelation());
+                return Response.status(Response.Status.BAD_REQUEST).entity(errorDTO).build();
             } else {
                 logDebug(String.format("username : %s is available for self registration. Hence returning code %s: ",
-                        user.getUsername(), SelfRegistrationStatusCodes.CODE_USER_NAME_AVAILABLE));
+                        username, SelfRegistrationStatusCodes.CODE_USER_NAME_AVAILABLE));
                 responseDTO.setStatusCode(Integer.parseInt(SelfRegistrationStatusCodes.CODE_USER_NAME_AVAILABLE));
                 return Response.ok().entity(responseDTO).build();
             }
@@ -118,7 +135,7 @@ public class ValidateUsernameApiServiceImpl extends ValidateUsernameApiService {
             errorDTO.setRef(Utils.getCorrelation());
             errorDTO.setMessage("Error while checking user existence");
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Error while checking username validity for user " + user.getUsername(), e);
+                LOG.debug("Error while checking username validity for user " + username, e);
             }
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(errorDTO).build();
         }

--- a/components/org.wso2.carbon.identity.api.user.governance/src/test/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/test/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImplTest.java
@@ -27,6 +27,7 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.mgt.constants.SelfRegistrationStatusCodes;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.signup.UserSelfRegistrationManager;
@@ -46,6 +47,7 @@ import javax.ws.rs.core.Response;
 public class ValidateUsernameApiServiceImplTest {
 
     private MockedStatic<Utils> mockedUtils;
+    private MockedStatic<IdentityUtil> mockedIdentityUtil;
 
     @InjectMocks
     private ValidateUsernameApiServiceImpl validateUsernameApiService;
@@ -96,6 +98,8 @@ public class ValidateUsernameApiServiceImplTest {
         MockitoAnnotations.openMocks(this);
         mockedUtils = Mockito.mockStatic(Utils.class);
         mockedUtils.when(Utils::getUserSelfRegistrationManager).thenReturn(userSelfRegistrationManager);
+        mockedIdentityUtil = Mockito.mockStatic(IdentityUtil.class);
+        mockedIdentityUtil.when(IdentityUtil::getPrimaryDomainName).thenReturn("PRIMARY");
         Mockito.doReturn(true).when(userSelfRegistrationManager)
                 .isValidTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         Mockito.doReturn(false).when(userSelfRegistrationManager)
@@ -108,5 +112,6 @@ public class ValidateUsernameApiServiceImplTest {
     public void tearDown() {
 
         mockedUtils.close();
+        mockedIdentityUtil.close();
     }
 }

--- a/components/org.wso2.carbon.identity.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.governance/pom.xml
@@ -114,6 +114,7 @@
                     </suiteXmlFiles>
                     <classpathDependencyExcludes>
                         <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                     </classpathDependencyExcludes>
                 </configuration>
             </plugin>

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -69,6 +69,11 @@
             <artifactId>org.wso2.carbon.consent.mgt.core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.testutil</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -1215,6 +1215,30 @@ public class UserSelfRegistrationManager {
     }
 
     /**
+     * Checks whether the given userstore domain of a username is valid / exists or not.
+     *
+     * @param userStoreDomain Tenant domain.
+     * @return True if the userstore domain of the user is valid / available, else false.
+     */
+    public boolean isValidUserStoreDomain(String userStoreDomain, String tenantDomain) throws IdentityRecoveryException {
+
+        boolean isValidUserStore;
+        try {
+            UserStoreManager userStoreManager = getUserRealm(tenantDomain).getUserStoreManager().
+                    getSecondaryUserStoreManager(userStoreDomain);
+            isValidUserStore = userStoreManager != null;
+
+        } catch (CarbonException | UserStoreException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error while getting secondary userstore manager for domain " + userStoreDomain);
+            }
+            // In a case of a non existing tenant.
+            throw new IdentityRecoveryException("Error while retrieving user realm for tenant : " + tenantDomain, e);
+        }
+        return isValidUserStore;
+    }
+
+    /**
      * Returns whether a given username is already taken by a user or not.
      *
      * @param username Username.

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -1217,7 +1217,7 @@ public class UserSelfRegistrationManager {
     /**
      * Checks whether the given userstore domain of a username is valid / exists or not.
      *
-     * @param userStoreDomain Tenant domain.
+     * @param userStoreDomain Userstore domain of the user.
      * @return True if the userstore domain of the user is valid / available, else false.
      */
     public boolean isValidUserStoreDomain(String userStoreDomain, String tenantDomain) throws IdentityRecoveryException {

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
@@ -128,6 +128,7 @@
                     </systemPropertyVariables>
                     <classpathDependencyExcludes>
                         <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                     </classpathDependencyExcludes>
                 </configuration>
             </plugin>

--- a/components/org.wso2.carbon.identity.user.rename.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.rename.core/pom.xml
@@ -139,6 +139,7 @@
                     </systemPropertyVariables>
                     <classpathDependencyExcludes>
                         <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                     </classpathDependencyExcludes>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -627,7 +627,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.21.1-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.21.3</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.20.211, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -422,7 +422,7 @@
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.testutil</artifactId>
                 <scope>test</scope>
-                <version>${carbon.identity.framework.version}</version>
+                <version>${carbon.identity.testutil.version}</version>
             </dependency>
 
             <dependency>
@@ -627,7 +627,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.20.444-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.21.1-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.20.211, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 
@@ -668,6 +668,7 @@
         <powermock.version>1.6.4</powermock.version>
         <mokito.version>1.6.6</mokito.version>
         <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
+        <carbon.identity.testutil.version>5.20.211</carbon.identity.testutil.version>
 
         <h2database.version>2.1.210</h2database.version>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>

--- a/pom.xml
+++ b/pom.xml
@@ -668,6 +668,7 @@
         <powermock.version>1.6.4</powermock.version>
         <mokito.version>1.6.6</mokito.version>
         <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
+        <!--Maintaining testutil version separately as it is removed from higher framework versions-->
         <carbon.identity.testutil.version>5.20.211</carbon.identity.testutil.version>
 
         <h2database.version>2.1.210</h2database.version>

--- a/pom.xml
+++ b/pom.xml
@@ -620,14 +620,14 @@
         <identity.data.publisher.authentication.version>5.3.0</identity.data.publisher.authentication.version>
 
         <!--Carbon Kernel Version-->
-        <carbon.kernel.version>4.7.0-m11</carbon.kernel.version>
+        <carbon.kernel.version>4.7.0-beta</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.1</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.20.211</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.444-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.20.211, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
Related Issue: https://github.com/wso2/product-is/issues/13797

This PR adds a validation to check whether the userstore entered in the username is valid or not. 

The userstore of the current user will be received in the realm property of the user object passed into the `validateUsernamePost` method.

NOTE:
- Need to bump the identity-framework version when https://github.com/wso2/carbon-identity-framework/pull/4096 is merged.
- `org.wso2.org.ops4j.pax.logging` needed to be excluded from tests to resolve logging related test failures that occur after bumping the identity-framework to the latest version.
- Since `org.wso2.carbon.identity.testutil` is removed from the 5.21.x framework version, `testutil` version is not upgraded with the framework version and will be kept the same.
