### PR TITLE
Fix resend code not sent upon disabling manage notifications internally for self registration

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
@@ -419,7 +419,7 @@ public class ResendConfirmationManager {
         // Resolve the tenant domain and the userstore domain name of the user.
         resolveUserAttributes(user);
 
-        boolean notificationInternallyManage = isNotificationInternallyManage(user);
+        boolean notificationInternallyManage = isNotificationInternallyManage(user, recoveryScenario);
 
         NotificationResponseBean notificationResponseBean = new NotificationResponseBean(user);
         UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
@@ -573,6 +573,31 @@ public class ResendConfirmationManager {
         return Boolean.parseBoolean(Utils.getSignUpConfigs
                 (IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
                         user.getTenantDomain()));
+    }
+
+    private boolean isNotificationInternallyManage(User user, String recoveryScenario)
+            throws IdentityRecoveryServerException {
+
+        if (RecoveryScenarios.ASK_PASSWORD.toString().equals(recoveryScenario)) {
+            return Boolean.parseBoolean(Utils.getSignUpConfigs
+                    (IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_INTERNALLY_MANAGE,
+                            user.getTenantDomain()));
+        } else if (RecoveryScenarios.NOTIFICATION_BASED_PW_RECOVERY.toString().equals(recoveryScenario)) {
+            return Boolean.parseBoolean(Utils.getSignUpConfigs
+                    (IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE,
+                            user.getTenantDomain()));
+        } else if (RecoveryScenarios.SELF_SIGN_UP.toString().equals(recoveryScenario)) {
+            return Boolean.parseBoolean(Utils.getSignUpConfigs
+                    (IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
+                            user.getTenantDomain()));
+        } else if (RecoveryScenarios.LITE_SIGN_UP.toString().equals(recoveryScenario)) {
+            return Boolean.parseBoolean(Utils.getSignUpConfigs
+                    (IdentityRecoveryConstants.ConnectorConfig.LITE_SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
+                            user.getTenantDomain()));
+        } else {
+            // To maintain the backward compatibility for the non-configurable flows.
+            return isNotificationInternallyManage(user);
+        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
@@ -586,8 +586,6 @@ public class ResendConfirmationManager {
             return Boolean.parseBoolean(Utils.getSignUpConfigs
                     (IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE,
                             user.getTenantDomain()));
-        } else if (RecoveryScenarios.SELF_SIGN_UP.toString().equals(recoveryScenario)) {
-            return isNotificationInternallyManage(user);
         } else if (RecoveryScenarios.LITE_SIGN_UP.toString().equals(recoveryScenario)) {
             return Boolean.parseBoolean(Utils.getSignUpConfigs
                     (IdentityRecoveryConstants.ConnectorConfig.LITE_SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
@@ -587,13 +587,17 @@ public class ResendConfirmationManager {
                     (IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_INTERNALLY_MANAGE,
                             user.getTenantDomain()));
         } else if (RecoveryScenarios.SELF_SIGN_UP.toString().equals(recoveryScenario)) {
-            return Boolean.parseBoolean(Utils.getSignUpConfigs
-                    (IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
-                            user.getTenantDomain()));
+            return isNotificationInternallyManage(user);
         } else if (RecoveryScenarios.LITE_SIGN_UP.toString().equals(recoveryScenario)) {
             return Boolean.parseBoolean(Utils.getSignUpConfigs
                     (IdentityRecoveryConstants.ConnectorConfig.LITE_SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
                             user.getTenantDomain()));
+        } else if (RecoveryScenarios.EMAIL_VERIFICATION_ON_UPDATE.toString().equals(recoveryScenario)) {
+            // We manage the notifications internally for EMAIL_VERIFICATION_ON_UPDATE.
+            return true;
+        } else if (RecoveryScenarios.MOBILE_VERIFICATION_ON_UPDATE.toString().equals(recoveryScenario)) {
+            // We manage the notifications internally for MOBILE_VERIFICATION_ON_UPDATE.
+            return true;
         } else {
             // To maintain the backward compatibility for the non-configurable flows.
             return isNotificationInternallyManage(user);


### PR DESCRIPTION
### Purpose
- upon disabling internally managed notifications in self registration under Resident IDP, resend-code for other scenarios also disabling. This PR is to fix this issue.

### Related Issues
- https://github.com/wso2/product-is/issues/14710