### PR TITLE
Modify the listener to read identity data only from the identity data store based on config

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
@@ -59,7 +59,7 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
     private static final String DATA_STORE_PROPERTY_NAME = "Data.Store";
     private static final String ENABLE_HYBRID_DATA_STORE_PROPERTY_NAME = "EnableHybridDataStore";
     private UserIdentityDataStore identityDataStore;
-    private boolean isHybridDataStoreEnable = true;
+    private boolean isHybridDataStoreEnable = false;
     private static final String INVALID_OPERATION = "InvalidOperation";
     private static final String USER_IDENTITY_CLAIMS = "UserIdentityClaims";
 


### PR DESCRIPTION
### Purpose
Based on the configuration, this improvement will allow users to configure the identity data store to read data only from the configured data store.

### Related PRs

- https://github.com/wso2/carbon-identity-framework/pull/4243
