### PR TITLE
Improve username recovery flow

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -306,7 +306,8 @@ public class UserAccountRecoveryManager {
             for (String domain : userStoreDomainNames) {
                 List<ExpressionCondition> expressionConditionList = new ArrayList<>();
                 for (String key : claims.keySet()) {
-                    if (StringUtils.isNotEmpty(key) && StringUtils.isNotEmpty(claims.get(key))) {
+                    if (StringUtils.isNotEmpty(key) && StringUtils.isNotEmpty(claims.get(key)) &&
+                            StringUtils.isNotEmpty(claimManager.getAttributeName(domain, key))) {
                         expressionConditionList.add(new ExpressionCondition(ExpressionOperation.EQ.toString(),
                                 claimManager.getAttributeName(domain, key), claims.get(key)));
                     }
@@ -314,7 +315,7 @@ public class UserAccountRecoveryManager {
                 if (!expressionConditionList.isEmpty()) {
                     Condition operationalCondition = expressionConditionList.get(0);
                     if (claims.size() > 1) {
-                        for (int i = 1; i < claims.size(); i++) {
+                        for (int i = 1; i < expressionConditionList.size(); i++) {
                             operationalCondition = new OperationalCondition(OperationalOperation.AND.toString(),
                                     operationalCondition, expressionConditionList.get(i));
                         }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -326,9 +326,10 @@ public class UserAccountRecoveryManager {
             // Return matched user.
             if (!resultedUserList.isEmpty() && resultedUserList.size() == 1) {
                 return resultedUserList.get(0).getDomainQualifiedUsername();
-            } else if (resultedUserList.isEmpty()){
+            } else if (resultedUserList.isEmpty()) {
+                // Return empty when no users found
                 return StringUtils.EMPTY;
-            }else {
+            } else {
                 if (log.isDebugEnabled()) {
                     log.debug("Multiple users matched for given claims set : " +
                             Arrays.toString(resultedUserList.toArray()));

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -578,7 +578,7 @@ public class UserAccountRecoveryManager {
      */
     private String[] getDomainNames(int tenantId) throws IdentityRecoveryServerException {
 
-        ArrayList<String> domainsOfUserStores = new ArrayList<>();
+        List<String> domainsOfUserStores = new ArrayList<>();
         carbonUM = (AbstractUserStoreManager) getUserStoreManager(tenantId);
         UserStoreManager secondaryUserStore = carbonUM.getSecondaryUserStoreManager();
         while (secondaryUserStore != null) {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -605,7 +605,7 @@ public class UserAccountRecoveryManager {
 
     /**
      * Get all the domain names related to user stores.
-     *
+     * @param tenantId   Tenant ID
      * @return A list of all the available domain names for given tenant
      */
     private String[] getDomainNames(int tenantId) throws IdentityRecoveryServerException {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -385,7 +385,6 @@ public class UserAccountRecoveryManager {
                         operationalCondition, expressionConditionList.get(i));
             }
         }
-        operationalCondition.getOperation();
         return operationalCondition;
     }
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -297,8 +297,7 @@ public class UserAccountRecoveryManager {
             String[] userStoreDomainNames = getDomainNames(tenantId);
             AbstractUserStoreManager carbonUM = (AbstractUserStoreManager) getUserStoreManager(tenantId);
             RealmService realmService = IdentityRecoveryServiceDataHolder.getInstance().getRealmService();
-            ClaimManager claimManager = (ClaimManager) realmService.getTenantUserRealm(IdentityTenantUtil.
-                    getTenantId(tenantDomain)).getClaimManager();
+            ClaimManager claimManager = (ClaimManager) realmService.getTenantUserRealm(tenantId).getClaimManager();
             ArrayList<org.wso2.carbon.user.core.common.User> resultedUserList = new ArrayList<>();
 
             for (String domain : userStoreDomainNames) {
@@ -619,8 +618,6 @@ public class UserAccountRecoveryManager {
             secondaryUserStore = secondaryUserStore.getSecondaryUserStoreManager();
             domainsOfUserStores.add(domainName);
         }
-        // Sorting the secondary user stores to maintain an order fo domains so that pagination is consistent.
-        Collections.sort(domainsOfUserStores);
 
         /* Append the primary domain name to the front of the domain list since the first iteration of multiple
            domain filtering should happen for the primary user store. */

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -306,18 +306,14 @@ public class UserAccountRecoveryManager {
             for (String domain : userStoreDomainNames) {
                 List<ExpressionCondition> expressionConditionList =
                         getExpressionConditionList(claims, domain, claimManager);
-
-                if (!expressionConditionList.isEmpty()) {
-                    Condition operationalCondition = getOperationalCondition(expressionConditionList);
-                    /* Get the users list that matches with the condition
-                       limit : 2, offset : 1, sortBy : null, sortOrder : null */
-                    resultedUserList.addAll(carbonUM.getUserListWithID(operationalCondition, domain,
-                            UserCoreConstants.DEFAULT_PROFILE, 2, 1, null, null));
-                }
-                else {
+                if (expressionConditionList.isEmpty()) {
                     continue;
                 }
-
+                Condition operationalCondition = getOperationalCondition(expressionConditionList);
+                /* Get the users list that matches with the condition
+                   limit : 2, offset : 1, sortBy : null, sortOrder : null */
+                resultedUserList.addAll(carbonUM.getUserListWithID(operationalCondition, domain,
+                        UserCoreConstants.DEFAULT_PROFILE, 2, 1, null, null));
                 if (resultedUserList.size() > 1) {
                     if (log.isDebugEnabled()) {
                         log.debug("Multiple users matched for given claims set : " +
@@ -330,10 +326,9 @@ public class UserAccountRecoveryManager {
             // Return empty when no users are found.
             if (resultedUserList.isEmpty()) {
                 return StringUtils.EMPTY;
-            } else {
-                // Return matched user.
-                return resultedUserList.get(0).getDomainQualifiedUsername();
             }
+            // When the code reaches here there only be single user match.
+            return resultedUserList.get(0).getDomainQualifiedUsername();
         } catch (org.wso2.carbon.user.core.UserStoreException e) {
             if (log.isDebugEnabled()) {
                 log.debug("Error while getting users from user store for the given claim set: " +

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -87,8 +87,6 @@ public class UserAccountRecoveryManager {
     private static final boolean PER_USER_FUNCTIONALITY_LOCKING_ENABLED = Utils.isPerUserFunctionalityLockingEnabled();
     private static final String FUNCTIONALITY_PREFIX = "FUNCTIONALITY_";
 
-    AbstractUserStoreManager carbonUM;
-
     /**
      * Constructor.
      */
@@ -297,7 +295,7 @@ public class UserAccountRecoveryManager {
         int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
         try {
             String[] userStoreDomainNames = getDomainNames(tenantId);
-            carbonUM = (AbstractUserStoreManager) getUserStoreManager(tenantId);
+            AbstractUserStoreManager carbonUM = (AbstractUserStoreManager) getUserStoreManager(tenantId);
             RealmService realmService = IdentityRecoveryServiceDataHolder.getInstance().getRealmService();
             ClaimManager claimManager = (ClaimManager) realmService.getTenantUserRealm(IdentityTenantUtil.
                     getTenantId(tenantDomain)).getClaimManager();
@@ -613,7 +611,7 @@ public class UserAccountRecoveryManager {
     private String[] getDomainNames(int tenantId) throws IdentityRecoveryServerException {
 
         List<String> domainsOfUserStores = new ArrayList<>();
-        carbonUM = (AbstractUserStoreManager) getUserStoreManager(tenantId);
+        AbstractUserStoreManager carbonUM = (AbstractUserStoreManager) getUserStoreManager(tenantId);
         UserStoreManager secondaryUserStore = carbonUM.getSecondaryUserStoreManager();
         while (secondaryUserStore != null) {
             String domainName = secondaryUserStore.getRealmConfiguration().

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -323,12 +323,12 @@ public class UserAccountRecoveryManager {
                             UserCoreConstants.DEFAULT_PROFILE, 2, 1, null, null));
                 }
             }
-            // Return matched user.
-            if (!resultedUserList.isEmpty() && resultedUserList.size() == 1) {
-                return resultedUserList.get(0).getDomainQualifiedUsername();
-            } else if (resultedUserList.isEmpty()) {
-                // Return empty when no users found
+            // Return empty when no users are found.
+            if (resultedUserList.isEmpty()) {
                 return StringUtils.EMPTY;
+            } else if (resultedUserList.size() == 1) {
+                // Return matched user.
+                return resultedUserList.get(0).getDomainQualifiedUsername();
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("Multiple users matched for given claims set : " +

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -294,7 +294,7 @@ public class UserAccountRecoveryManager {
         }
         int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
         try {
-            String[] userStoreDomainNames = getDomainNames(tenantId);
+            List<String> userStoreDomainNames = getDomainNames(tenantId);
             AbstractUserStoreManager carbonUM = (AbstractUserStoreManager) getUserStoreManager(tenantId);
             RealmService realmService = IdentityRecoveryServiceDataHolder.getInstance().getRealmService();
             ClaimManager claimManager = (ClaimManager) realmService.getTenantUserRealm(tenantId).getClaimManager();
@@ -607,7 +607,7 @@ public class UserAccountRecoveryManager {
      * @param tenantId   Tenant ID
      * @return A list of all the available domain names for given tenant
      */
-    private String[] getDomainNames(int tenantId) throws IdentityRecoveryServerException {
+    private List<String> getDomainNames(int tenantId) throws IdentityRecoveryServerException {
 
         List<String> domainsOfUserStores = new ArrayList<>();
         AbstractUserStoreManager carbonUM = (AbstractUserStoreManager) getUserStoreManager(tenantId);
@@ -622,7 +622,7 @@ public class UserAccountRecoveryManager {
         /* Append the primary domain name to the front of the domain list since the first iteration of multiple
            domain filtering should happen for the primary user store. */
         domainsOfUserStores.add(0, UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME);
-        return domainsOfUserStores.toArray(new String[0]);
+        return domainsOfUserStores;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -610,6 +610,8 @@ public class UserAccountRecoveryManager {
     private List<String> getDomainNames(int tenantId) throws IdentityRecoveryServerException {
 
         List<String> domainsOfUserStores = new ArrayList<>();
+        // Append the primary domain name to the front of the domain list.
+        domainsOfUserStores.add(UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME);
         AbstractUserStoreManager abstractUserStoreManager = (AbstractUserStoreManager) getUserStoreManager(tenantId);
         UserStoreManager secondaryUserStore = abstractUserStoreManager.getSecondaryUserStoreManager();
         while (secondaryUserStore != null) {
@@ -618,10 +620,6 @@ public class UserAccountRecoveryManager {
             secondaryUserStore = secondaryUserStore.getSecondaryUserStoreManager();
             domainsOfUserStores.add(domainName);
         }
-
-        /* Append the primary domain name to the front of the domain list since the first iteration of multiple
-           domain filtering should happen for the primary user store. */
-        domainsOfUserStores.add(0, UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME);
         return domainsOfUserStores;
     }
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -295,7 +295,7 @@ public class UserAccountRecoveryManager {
         int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
         try {
             List<String> userStoreDomainNames = getDomainNames(tenantId);
-            AbstractUserStoreManager carbonUM = (AbstractUserStoreManager) getUserStoreManager(tenantId);
+            AbstractUserStoreManager abstractUserStoreManager = (AbstractUserStoreManager) getUserStoreManager(tenantId);
             RealmService realmService = IdentityRecoveryServiceDataHolder.getInstance().getRealmService();
             ClaimManager claimManager = (ClaimManager) realmService.getTenantUserRealm(tenantId).getClaimManager();
             ArrayList<org.wso2.carbon.user.core.common.User> resultedUserList = new ArrayList<>();
@@ -309,7 +309,7 @@ public class UserAccountRecoveryManager {
                 Condition operationalCondition = getOperationalCondition(expressionConditionList);
                 /* Get the users list that matches with the condition
                    limit : 2, offset : 1, sortBy : null, sortOrder : null */
-                resultedUserList.addAll(carbonUM.getUserListWithID(operationalCondition, domain,
+                resultedUserList.addAll(abstractUserStoreManager.getUserListWithID(operationalCondition, domain,
                         UserCoreConstants.DEFAULT_PROFILE, 2, 1, null, null));
                 if (resultedUserList.size() > 1) {
                     if (log.isDebugEnabled()) {
@@ -610,8 +610,8 @@ public class UserAccountRecoveryManager {
     private List<String> getDomainNames(int tenantId) throws IdentityRecoveryServerException {
 
         List<String> domainsOfUserStores = new ArrayList<>();
-        AbstractUserStoreManager carbonUM = (AbstractUserStoreManager) getUserStoreManager(tenantId);
-        UserStoreManager secondaryUserStore = carbonUM.getSecondaryUserStoreManager();
+        AbstractUserStoreManager abstractUserStoreManager = (AbstractUserStoreManager) getUserStoreManager(tenantId);
+        UserStoreManager secondaryUserStore = abstractUserStoreManager.getSecondaryUserStoreManager();
         while (secondaryUserStore != null) {
             String domainName = secondaryUserStore.getRealmConfiguration().
                     getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME).toUpperCase();

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -314,7 +314,7 @@ public class UserAccountRecoveryManager {
                 }
                 if (!expressionConditionList.isEmpty()) {
                     Condition operationalCondition = expressionConditionList.get(0);
-                    if (claims.size() > 1) {
+                    if (expressionConditionList.size() > 1) {
                         for (int i = 1; i < expressionConditionList.size(); i++) {
                             operationalCondition = new OperationalCondition(OperationalOperation.AND.toString(),
                                     operationalCondition, expressionConditionList.get(i));

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -328,10 +328,10 @@ public class UserAccountRecoveryManager {
             return resultedUserList.get(0).getDomainQualifiedUsername();
         } catch (org.wso2.carbon.user.core.UserStoreException e) {
             if (log.isDebugEnabled()) {
-                log.debug("Error while getting users from user store for the given claim set: " +
+                log.debug("Error while retrieving users from user store for the given claim set: " +
                         Arrays.toString(claims.keySet().toArray()));
             }
-            throw new IdentityRecoveryException(e.getErrorCode(), e.getMessage(), e);
+            throw new IdentityRecoveryException(e.getErrorCode(), "Error occurred while retrieving users.", e);
         } catch (UserStoreException e) {
             throw new IdentityRecoveryException(e.getMessage(), e);
         }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -351,12 +351,12 @@ public class UserAccountRecoveryManager {
             throws UserStoreException {
 
         List<ExpressionCondition> expressionConditionList = new ArrayList<>();
-        for (String key : claims.keySet()) {
-            String attributeName = claimManager.getAttributeName(domain, key);
-            if (StringUtils.isNotEmpty(key) && StringUtils.isNotEmpty(claims.get(key)) &&
+        for (Map.Entry<String,String> entry : claims.entrySet()) {
+            String attributeName = claimManager.getAttributeName(domain, entry.getKey());
+            if (StringUtils.isNotEmpty(entry.getKey()) && StringUtils.isNotEmpty(entry.getValue()) &&
                     StringUtils.isNotEmpty(attributeName)) {
-                expressionConditionList.add(new ExpressionCondition(ExpressionOperation.EQ.toString(),
-                        attributeName, claims.get(key)));
+                expressionConditionList.add(new ExpressionCondition(ExpressionOperation.EQ.toString(), attributeName,
+                        entry.getValue()));
             }
         }
         return expressionConditionList;

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -326,7 +326,9 @@ public class UserAccountRecoveryManager {
             // Return matched user.
             if (!resultedUserList.isEmpty() && resultedUserList.size() == 1) {
                 return resultedUserList.get(0).getDomainQualifiedUsername();
-            } else {
+            } else if (resultedUserList.isEmpty()){
+                return StringUtils.EMPTY;
+            }else {
                 if (log.isDebugEnabled()) {
                     log.debug("Multiple users matched for given claims set : " +
                             Arrays.toString(resultedUserList.toArray()));

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
@@ -57,7 +57,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
@@ -188,6 +188,7 @@ public class UserAccountRecoveryManagerTest {
         when(userStoreManager
                 .getUserClaimValues(anyString(), ArgumentMatchers.any(String[].class), anyString()))
                 .thenReturn(userClaims);
+        when(userRealm.getUserStoreManager()).thenReturn(abstractUserStoreManager);
         RecoveryChannelInfoDTO recoveryChannelInfoDTO = userAccountRecoveryManager
                 .retrieveUserRecoveryInformation(userClaims, StringUtils.EMPTY, RecoveryScenarios.USERNAME_RECOVERY,
                         null);
@@ -254,6 +255,9 @@ public class UserAccountRecoveryManagerTest {
         mockJDBCRecoveryDataStore();
         mockIdentityEventService();
         mockBuildUser();
+        when(userRealm.getUserStoreManager()).thenReturn(abstractUserStoreManager);
+        when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
+                anyInt(),anyInt(),isNull(), isNull())).thenReturn(getFilteredUSer());
         RecoveryChannelInfoDTO recoveryChannelInfoDTO = userAccountRecoveryManager
                 .retrieveUserRecoveryInformation(userClaims, StringUtils.EMPTY, RecoveryScenarios.USERNAME_RECOVERY,
                         null);
@@ -284,6 +288,8 @@ public class UserAccountRecoveryManagerTest {
                     .thenReturn(IdentityException.error(IdentityRecoveryClientException.class,
                             IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_USER_FOUND.getCode(), ""));
             when(userRealm.getUserStoreManager()).thenReturn(abstractUserStoreManager);
+            when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
+                    anyInt(),anyInt(),isNull(), isNull())).thenReturn(new ArrayList<org.wso2.carbon.user.core.common.User>());
             userAccountRecoveryManager
                     .retrieveUserRecoveryInformation(userClaims, StringUtils.EMPTY, RecoveryScenarios.USERNAME_RECOVERY,
                             null);
@@ -355,6 +361,9 @@ public class UserAccountRecoveryManagerTest {
         mockUserstoreManager();
         when(userStoreManager.getUserList(anyString(), anyString(), isNull()))
                 .thenReturn(new String[]{testUsername1, testUsername2}).thenReturn(new String[]{testUsername3});
+        when(userRealm.getUserStoreManager()).thenReturn(abstractUserStoreManager);
+        when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
+                anyInt(),anyInt(),isNull(), isNull())).thenReturn(new ArrayList<org.wso2.carbon.user.core.common.User>());
         String username = userAccountRecoveryManager
                 .getUsernameByClaims(userClaims, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         assertTrue(username.isEmpty(), "Different Users matched for different claims : ");
@@ -372,10 +381,14 @@ public class UserAccountRecoveryManagerTest {
         String testUsername3 = "sominda3";
 
         mockUserstoreManager();
-        when(userStoreManager.getUserList(anyString(), anyString(), isNull()))
-                .thenReturn(new String[]{testUsername1, testUsername2, testUsername3})
-                .thenReturn(new String[]{testUsername1, testUsername2}).thenReturn(new String[]{testUsername1})
-                .thenReturn(new String[]{testUsername1});
+//        when(userStoreManager.getUserList(anyString(), anyString(), isNull()))
+//                .thenReturn(new String[]{testUsername1, testUsername2, testUsername3})
+//                .thenReturn(new String[]{testUsername1, testUsername2}).thenReturn(new String[]{testUsername1})
+//                .thenReturn(new String[]{testUsername1});
+
+        when(userRealm.getUserStoreManager()).thenReturn(abstractUserStoreManager);
+        when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
+                anyInt(),anyInt(),isNull(), isNull())).thenReturn(getFilteredUSer());
         String username = userAccountRecoveryManager
                 .getUsernameByClaims(userClaims, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         assertEquals(username, testUsername1, "Test get matched users fot given claims : ");
@@ -391,7 +404,7 @@ public class UserAccountRecoveryManagerTest {
         mockGetUserList(new String[]{});
         when(userRealm.getUserStoreManager()).thenReturn(abstractUserStoreManager);
         when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
-                anyInt(),anyInt(),isNull(), isNull())).thenReturn(null);
+                anyInt(),anyInt(),isNull(), isNull())).thenReturn(new ArrayList<org.wso2.carbon.user.core.common.User>());
         String username = userAccountRecoveryManager
                 .getUsernameByClaims(userClaims, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         assertTrue(username.isEmpty(), "No matching users for given set of claims : ");
@@ -518,6 +531,14 @@ public class UserAccountRecoveryManagerTest {
                 .toString(), "testUser1", "testUser1");
         users.add(testUser1);
         users.add(testUser2);
+        return users;
+    }
+
+    private List<org.wso2.carbon.user.core.common.User> getFilteredUSer(){
+        List<org.wso2.carbon.user.core.common.User> users = new ArrayList<org.wso2.carbon.user.core.common.User>();
+        org.wso2.carbon.user.core.common.User testUser1 = new org.wso2.carbon.user.core.common.User(UUID.randomUUID()
+                .toString(), "sominda1", "sominda1");
+        users.add(testUser1);
         return users;
     }
 

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
@@ -189,6 +189,8 @@ public class UserAccountRecoveryManagerTest {
                 .getUserClaimValues(anyString(), ArgumentMatchers.any(String[].class), anyString()))
                 .thenReturn(userClaims);
         when(userRealm.getUserStoreManager()).thenReturn(abstractUserStoreManager);
+        when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
+                anyInt(),anyInt(),isNull(), isNull())).thenReturn(getOneFilteredUser());
         RecoveryChannelInfoDTO recoveryChannelInfoDTO = userAccountRecoveryManager
                 .retrieveUserRecoveryInformation(userClaims, StringUtils.EMPTY, RecoveryScenarios.USERNAME_RECOVERY,
                         null);
@@ -210,7 +212,10 @@ public class UserAccountRecoveryManagerTest {
      */
     private void testGetSelfSignUpUsers() throws Exception {
 
-        when(userStoreManager
+        when(userRealm.getUserStoreManager()).thenReturn(abstractUserStoreManager);
+        when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
+                anyInt(),anyInt(),isNull(), isNull())).thenReturn(getOneFilteredUser());
+        when(abstractUserStoreManager
                 .getUserClaimValues(anyString(), ArgumentMatchers.any(String[].class), isNull()))
                 .thenReturn(userClaims);
         RecoveryChannelInfoDTO recoveryChannelInfoDTO = userAccountRecoveryManager
@@ -257,7 +262,7 @@ public class UserAccountRecoveryManagerTest {
         mockBuildUser();
         when(userRealm.getUserStoreManager()).thenReturn(abstractUserStoreManager);
         when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
-                anyInt(),anyInt(),isNull(), isNull())).thenReturn(getFilteredUSer());
+                anyInt(),anyInt(),isNull(), isNull())).thenReturn(getOneFilteredUser());
         RecoveryChannelInfoDTO recoveryChannelInfoDTO = userAccountRecoveryManager
                 .retrieveUserRecoveryInformation(userClaims, StringUtils.EMPTY, RecoveryScenarios.USERNAME_RECOVERY,
                         null);
@@ -289,7 +294,8 @@ public class UserAccountRecoveryManagerTest {
                             IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_USER_FOUND.getCode(), ""));
             when(userRealm.getUserStoreManager()).thenReturn(abstractUserStoreManager);
             when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
-                    anyInt(),anyInt(),isNull(), isNull())).thenReturn(new ArrayList<org.wso2.carbon.user.core.common.User>());
+                    anyInt(),anyInt(),isNull(), isNull())).
+                    thenReturn(new ArrayList<org.wso2.carbon.user.core.common.User>());
             userAccountRecoveryManager
                     .retrieveUserRecoveryInformation(userClaims, StringUtils.EMPTY, RecoveryScenarios.USERNAME_RECOVERY,
                             null);
@@ -363,7 +369,8 @@ public class UserAccountRecoveryManagerTest {
                 .thenReturn(new String[]{testUsername1, testUsername2}).thenReturn(new String[]{testUsername3});
         when(userRealm.getUserStoreManager()).thenReturn(abstractUserStoreManager);
         when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
-                anyInt(),anyInt(),isNull(), isNull())).thenReturn(new ArrayList<org.wso2.carbon.user.core.common.User>());
+                anyInt(),anyInt(),isNull(), isNull())).thenReturn(
+                        new ArrayList<org.wso2.carbon.user.core.common.User>());
         String username = userAccountRecoveryManager
                 .getUsernameByClaims(userClaims, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         assertTrue(username.isEmpty(), "Different Users matched for different claims : ");
@@ -377,18 +384,11 @@ public class UserAccountRecoveryManagerTest {
     private void testGetMatchedUser() throws Exception {
 
         String testUsername1 = UserProfile.USERNAME.value;
-        String testUsername2 = "sominda2";
-        String testUsername3 = "sominda3";
 
         mockUserstoreManager();
-//        when(userStoreManager.getUserList(anyString(), anyString(), isNull()))
-//                .thenReturn(new String[]{testUsername1, testUsername2, testUsername3})
-//                .thenReturn(new String[]{testUsername1, testUsername2}).thenReturn(new String[]{testUsername1})
-//                .thenReturn(new String[]{testUsername1});
-
         when(userRealm.getUserStoreManager()).thenReturn(abstractUserStoreManager);
         when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
-                anyInt(),anyInt(),isNull(), isNull())).thenReturn(getFilteredUSer());
+                anyInt(),anyInt(),isNull(), isNull())).thenReturn(getOneFilteredUser());
         String username = userAccountRecoveryManager
                 .getUsernameByClaims(userClaims, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         assertEquals(username, testUsername1, "Test get matched users fot given claims : ");
@@ -404,7 +404,8 @@ public class UserAccountRecoveryManagerTest {
         mockGetUserList(new String[]{});
         when(userRealm.getUserStoreManager()).thenReturn(abstractUserStoreManager);
         when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
-                anyInt(),anyInt(),isNull(), isNull())).thenReturn(new ArrayList<org.wso2.carbon.user.core.common.User>());
+                anyInt(),anyInt(),isNull(), isNull())).thenReturn(
+                        new ArrayList<org.wso2.carbon.user.core.common.User>());
         String username = userAccountRecoveryManager
                 .getUsernameByClaims(userClaims, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         assertTrue(username.isEmpty(), "No matching users for given set of claims : ");
@@ -421,7 +422,8 @@ public class UserAccountRecoveryManagerTest {
                     IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_FIELD_FOUND_FOR_USER_RECOVERY.getCode(),
                     IdentityRecoveryConstants.USER_ACCOUNT_RECOVERY))
                     .thenReturn(
-                            IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_FIELD_FOUND_FOR_USER_RECOVERY.getCode());
+                            IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_FIELD_FOUND_FOR_USER_RECOVERY.
+                                    getCode());
             mockedUtils.when(() -> Utils.handleClientException(
                     IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_FIELD_FOUND_FOR_USER_RECOVERY.getCode(),
                     IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NO_FIELD_FOUND_FOR_USER_RECOVERY.getMessage(),
@@ -457,7 +459,7 @@ public class UserAccountRecoveryManagerTest {
                             ""));
             when(userRealm.getUserStoreManager()).thenReturn(abstractUserStoreManager);
             when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
-                    anyInt(),anyInt(),isNull(), isNull())).thenReturn(getFilteredUSers());
+                    anyInt(),anyInt(),isNull(), isNull())).thenReturn(getFilteredUsers());
             String username = userAccountRecoveryManager
                     .getUsernameByClaims(userClaims, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
             assertNull(username, "UserAccountRecoveryManager: Exception should be thrown. Therefore, a "
@@ -523,18 +525,22 @@ public class UserAccountRecoveryManagerTest {
                 .thenReturn(claimMetadataManagementService);
     }
 
-    private List<org.wso2.carbon.user.core.common.User> getFilteredUSers(){
+    private List<org.wso2.carbon.user.core.common.User> getFilteredUsers(){
+
         List<org.wso2.carbon.user.core.common.User> users = new ArrayList<org.wso2.carbon.user.core.common.User>();
         org.wso2.carbon.user.core.common.User testUser1 = new org.wso2.carbon.user.core.common.User(UUID.randomUUID()
-                .toString(), "testUser1", "testUser1");
-        org.wso2.carbon.user.core.common.User testUser2 = new org.wso2.carbon.user.core.common.User(UUID.randomUUID()
-                .toString(), "testUser1", "testUser1");
+                .toString(), "sominda1", "sominda1");
         users.add(testUser1);
+
+        org.wso2.carbon.user.core.common.User testUser2 = new org.wso2.carbon.user.core.common.User(UUID.randomUUID()
+                .toString(), "sominda2", "sominda2");
         users.add(testUser2);
+
         return users;
     }
 
-    private List<org.wso2.carbon.user.core.common.User> getFilteredUSer(){
+    private List<org.wso2.carbon.user.core.common.User> getOneFilteredUser(){
+
         List<org.wso2.carbon.user.core.common.User> users = new ArrayList<org.wso2.carbon.user.core.common.User>();
         org.wso2.carbon.user.core.common.User testUser1 = new org.wso2.carbon.user.core.common.User(UUID.randomUUID()
                 .toString(), "sominda1", "sominda1");

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
@@ -258,6 +258,8 @@ public class UserAccountRecoveryManagerTest {
         mockBuildUser();
         when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
                 anyInt(),anyInt(),isNull(), isNull())).thenReturn(getOneFilteredUser());
+        when(claimManager.getAttributeName(anyString(),anyString())).
+                thenReturn("http://wso2.org/claims/mockedClaim");
         RecoveryChannelInfoDTO recoveryChannelInfoDTO = userAccountRecoveryManager
                 .retrieveUserRecoveryInformation(userClaims, StringUtils.EMPTY, RecoveryScenarios.USERNAME_RECOVERY,
                         null);
@@ -290,8 +292,6 @@ public class UserAccountRecoveryManagerTest {
             when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
                     anyInt(),anyInt(),isNull(), isNull())).
                     thenReturn(new ArrayList<org.wso2.carbon.user.core.common.User>());
-            when(claimManager.getAttributeName(anyString(),anyString())).
-                    thenReturn("http://wso2.org/claims/mockedClaim");
             userAccountRecoveryManager
                     .retrieveUserRecoveryInformation(userClaims, StringUtils.EMPTY, RecoveryScenarios.USERNAME_RECOVERY,
                             null);

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
@@ -290,6 +290,8 @@ public class UserAccountRecoveryManagerTest {
             when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
                     anyInt(),anyInt(),isNull(), isNull())).
                     thenReturn(new ArrayList<org.wso2.carbon.user.core.common.User>());
+            when(claimManager.getAttributeName(anyString(),anyString())).
+                    thenReturn("http://wso2.org/claims/mockedClaim");
             userAccountRecoveryManager
                     .retrieveUserRecoveryInformation(userClaims, StringUtils.EMPTY, RecoveryScenarios.USERNAME_RECOVERY,
                             null);
@@ -424,6 +426,8 @@ public class UserAccountRecoveryManagerTest {
                             IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_MULTIPLE_MATCHING_USERS.getCode(),""));
             when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
                     anyInt(),anyInt(),isNull(), isNull())).thenReturn(getFilteredUsers());
+            when(claimManager.getAttributeName(anyString(),anyString())).
+                    thenReturn("http://wso2.org/claims/mockedClaim");
             String username = userAccountRecoveryManager
                     .getUsernameByClaims(userClaims, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
             assertNull(username, "UserAccountRecoveryManager: Exception should be thrown. Therefore, a "
@@ -476,6 +480,7 @@ public class UserAccountRecoveryManagerTest {
         when(identityRecoveryServiceDataHolder.getClaimMetadataManagementService())
                 .thenReturn(claimMetadataManagementService);
     }
+
     /**
      * Get multiple filtered users
      *

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
@@ -349,31 +349,6 @@ public class UserAccountRecoveryManagerTest {
         testNoMatchingUsers();
         // Test get matched user for given set of claims.
         testGetMatchedUser();
-        // Test no matching users for given set of claims.
-        testNoMatchedUsers();
-    }
-
-    /**
-     * Test get matched user for given claims.
-     *
-     * @throws Exception Error while getting the matched user
-     */
-    private void testNoMatchedUsers() throws Exception {
-
-        String testUsername1 = UserProfile.USERNAME.value;
-        String testUsername2 = "sominda2";
-        String testUsername3 = "sominda3";
-
-        mockUserstoreManager();
-        when(userStoreManager.getUserList(anyString(), anyString(), isNull()))
-                .thenReturn(new String[]{testUsername1, testUsername2}).thenReturn(new String[]{testUsername3});
-        when(userRealm.getUserStoreManager()).thenReturn(abstractUserStoreManager);
-        when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
-                anyInt(),anyInt(),isNull(), isNull())).thenReturn(
-                        new ArrayList<org.wso2.carbon.user.core.common.User>());
-        String username = userAccountRecoveryManager
-                .getUsernameByClaims(userClaims, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
-        assertTrue(username.isEmpty(), "Different Users matched for different claims : ");
     }
 
     /**
@@ -391,7 +366,7 @@ public class UserAccountRecoveryManagerTest {
                 anyInt(),anyInt(),isNull(), isNull())).thenReturn(getOneFilteredUser());
         String username = userAccountRecoveryManager
                 .getUsernameByClaims(userClaims, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
-        assertEquals(username, testUsername1, "Test get matched users fot given claims : ");
+        assertEquals(username, testUsername1, "Test get matched users for given claims : ");
     }
 
     /**
@@ -455,8 +430,7 @@ public class UserAccountRecoveryManagerTest {
             mockedUtils.when(() -> Utils.handleClientException(
                     IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_MULTIPLE_MATCHING_USERS, null))
                     .thenReturn(IdentityException.error(IdentityRecoveryClientException.class,
-                            IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_MULTIPLE_MATCHING_USERS.getCode(),
-                            ""));
+                            IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_MULTIPLE_MATCHING_USERS.getCode(),""));
             when(userRealm.getUserStoreManager()).thenReturn(abstractUserStoreManager);
             when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
                     anyInt(),anyInt(),isNull(), isNull())).thenReturn(getFilteredUsers());
@@ -524,7 +498,11 @@ public class UserAccountRecoveryManagerTest {
         when(identityRecoveryServiceDataHolder.getClaimMetadataManagementService())
                 .thenReturn(claimMetadataManagementService);
     }
-
+    /**
+     * Get multiple filtered users
+     *
+     * @return Users
+     */
     private List<org.wso2.carbon.user.core.common.User> getFilteredUsers(){
 
         List<org.wso2.carbon.user.core.common.User> users = new ArrayList<org.wso2.carbon.user.core.common.User>();
@@ -539,6 +517,11 @@ public class UserAccountRecoveryManagerTest {
         return users;
     }
 
+    /**
+     * Get one filtered user
+     *
+     * @return Users
+     */
     private List<org.wso2.carbon.user.core.common.User> getOneFilteredUser(){
 
         List<org.wso2.carbon.user.core.common.User> users = new ArrayList<org.wso2.carbon.user.core.common.User>();

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
@@ -481,7 +481,7 @@ public class UserAccountRecoveryManagerTest {
      *
      * @return Users
      */
-    private List<org.wso2.carbon.user.core.common.User> getFilteredUsers(){
+    private List<org.wso2.carbon.user.core.common.User> getFilteredUsers() {
 
         List<org.wso2.carbon.user.core.common.User> users = new ArrayList<org.wso2.carbon.user.core.common.User>();
         org.wso2.carbon.user.core.common.User testUser1 = new org.wso2.carbon.user.core.common.User(UUID.randomUUID()
@@ -500,7 +500,7 @@ public class UserAccountRecoveryManagerTest {
      *
      * @return Users
      */
-    private List<org.wso2.carbon.user.core.common.User> getOneFilteredUser(){
+    private List<org.wso2.carbon.user.core.common.User> getOneFilteredUser() {
 
         List<org.wso2.carbon.user.core.common.User> users = new ArrayList<org.wso2.carbon.user.core.common.User>();
         org.wso2.carbon.user.core.common.User testUser1 = new org.wso2.carbon.user.core.common.User(UUID.randomUUID()

--- a/components/org.wso2.carbon.identity.recovery/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.recovery/src/test/resources/testng.xml
@@ -20,12 +20,12 @@
 <suite name="Identity-Governance-Recovery-Connector-Test-Suite">
     <test name="Util-Tests" preserve-order="true" parallel="false">
         <classes>
-<!--            <class name="org.wso2.carbon.identity.recovery.connector.AdminForcedPasswordResetConfigImplTest" />-->
-<!--            <class name="org.wso2.carbon.identity.recovery.connector.RecoveryConfigImplTest" />-->
-<!--            <class name="org.wso2.carbon.identity.recovery.connector.SelfRegistrationConfigImplTest" />-->
-<!--            <class name="org.wso2.carbon.identity.recovery.connector.UserClaimUpdateConfigImplTest" />-->
-<!--            <class name="org.wso2.carbon.identity.recovery.connector.UserEmailVerificationConfigImplTest" />-->
-<!--            <class name="org.wso2.carbon.identity.recovery.signup.UserSelfRegistrationManagerTest"/>-->
+            <class name="org.wso2.carbon.identity.recovery.connector.AdminForcedPasswordResetConfigImplTest" />
+            <class name="org.wso2.carbon.identity.recovery.connector.RecoveryConfigImplTest" />
+            <class name="org.wso2.carbon.identity.recovery.connector.SelfRegistrationConfigImplTest" />
+            <class name="org.wso2.carbon.identity.recovery.connector.UserClaimUpdateConfigImplTest" />
+            <class name="org.wso2.carbon.identity.recovery.connector.UserEmailVerificationConfigImplTest" />
+            <class name="org.wso2.carbon.identity.recovery.signup.UserSelfRegistrationManagerTest"/>
             <class name="org.wso2.carbon.identity.recovery.internal.service.impl.UserAccountRecoveryManagerTest"/>
         </classes>
     </test>

--- a/components/org.wso2.carbon.identity.recovery/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.recovery/src/test/resources/testng.xml
@@ -20,12 +20,12 @@
 <suite name="Identity-Governance-Recovery-Connector-Test-Suite">
     <test name="Util-Tests" preserve-order="true" parallel="false">
         <classes>
-            <class name="org.wso2.carbon.identity.recovery.connector.AdminForcedPasswordResetConfigImplTest" />
-            <class name="org.wso2.carbon.identity.recovery.connector.RecoveryConfigImplTest" />
-            <class name="org.wso2.carbon.identity.recovery.connector.SelfRegistrationConfigImplTest" />
-            <class name="org.wso2.carbon.identity.recovery.connector.UserClaimUpdateConfigImplTest" />
-            <class name="org.wso2.carbon.identity.recovery.connector.UserEmailVerificationConfigImplTest" />
-            <class name="org.wso2.carbon.identity.recovery.signup.UserSelfRegistrationManagerTest"/>
+<!--            <class name="org.wso2.carbon.identity.recovery.connector.AdminForcedPasswordResetConfigImplTest" />-->
+<!--            <class name="org.wso2.carbon.identity.recovery.connector.RecoveryConfigImplTest" />-->
+<!--            <class name="org.wso2.carbon.identity.recovery.connector.SelfRegistrationConfigImplTest" />-->
+<!--            <class name="org.wso2.carbon.identity.recovery.connector.UserClaimUpdateConfigImplTest" />-->
+<!--            <class name="org.wso2.carbon.identity.recovery.connector.UserEmailVerificationConfigImplTest" />-->
+<!--            <class name="org.wso2.carbon.identity.recovery.signup.UserSelfRegistrationManagerTest"/>-->
             <class name="org.wso2.carbon.identity.recovery.internal.service.impl.UserAccountRecoveryManagerTest"/>
         </classes>
     </test>


### PR DESCRIPTION
### Purpose

- Improve the username recovery flow
    - The current behavior checks the user store for each claim and each user store.
    - Improve the get users list method who has the matching claim values
    
### Changes from the PR

- Get all the user store domains for the relevant tenant domain
- Lopping through all the user store domain to get the all users with the given claim values
    - Use ClaimManager to get the mapped attribute from the claimURI and domain
    - Use getUserListWithID method instead of getUserList method.
    - Pass one operational condition to getUserListWithID method instead of searching the user store for claims one by
      one.

### Related issue
Resolves https://github.com/wso2/product-is/issues/14957