### PR TITLE
Update multi tenancy and commons versions in governance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -641,11 +641,11 @@
         <carbon.consent.mgt.version>2.2.4</carbon.consent.mgt.version>
         <carbon.consent.mgt.version.range>[2.2.4, 3.0.0)</carbon.consent.mgt.version.range>
 
-        <carbon.multitenancy.version>4.7.11</carbon.multitenancy.version>
+        <carbon.multitenancy.version>4.11.0</carbon.multitenancy.version>
         <carbon.multitenancy.imp.pkg.version.range>[4.7.4, 5.0.0)</carbon.multitenancy.imp.pkg.version.range>
 
         <!--Carbon commons version-->
-        <carbon.commons.version>4.7.18</carbon.commons.version>
+        <carbon.commons.version>4.7.50</carbon.commons.version>
         <carbon.commons.imp.pkg.version>[4.7.2, 5.0.0)</carbon.commons.imp.pkg.version>
 
         <!--Maven Plugin Version-->


### PR DESCRIPTION
### Proposed changes in this pull request
- Updating the multitenancy version and the carbon.commons version to the latest
- Multitenancy latest version is 4.11.0[1]
- Carbon commons latest 4.7.x version is 4.7.50[2]

[1] https://github.com/wso2/carbon-multitenancy/tree/v4.11.0
[2] https://github.com/wso2/carbon-commons/tree/v4.7.50