### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -589,7 +589,7 @@
     <properties>
         <!--Carbon Identity Governance Version-->
         <identity.governance.exp.pkg.version>${project.version}</identity.governance.exp.pkg.version>
-        <identity.governance.imp.pkg.version.range>[1.3.0, 2.0.0)</identity.governance.imp.pkg.version.range>
+        <identity.governance.imp.pkg.version.range>[2.0.0, 3.0.0)</identity.governance.imp.pkg.version.range>
 
         <equinox.javax.servlet.version>3.0.0.v201112011016</equinox.javax.servlet.version>
 
@@ -634,20 +634,20 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.21.7</carbon.identity.framework.version>
-        <carbon.identity.framework.imp.pkg.version.range>[5.20.211, 6.0.0)
+        <carbon.identity.framework.version>6.0.0</carbon.identity.framework.version>
+        <carbon.identity.framework.imp.pkg.version.range>[6.0.0, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 
         <!--Carbon Identity Extension Versions-->
-        <carbon.identity.account.lock.handler.version>1.1.12</carbon.identity.account.lock.handler.version>
-        <carbon.identity.account.lock.handler.imp.pkg.version.range>[1.1.12, 2.0.0)
+        <carbon.identity.account.lock.handler.version>2.0.0</carbon.identity.account.lock.handler.version>
+        <carbon.identity.account.lock.handler.imp.pkg.version.range>[2.0.0, 3.0.0)
         </carbon.identity.account.lock.handler.imp.pkg.version.range>
 
-        <carbon.consent.mgt.version>2.2.4</carbon.consent.mgt.version>
-        <carbon.consent.mgt.version.range>[2.2.4, 3.0.0)</carbon.consent.mgt.version.range>
+        <carbon.consent.mgt.version>3.0.0</carbon.consent.mgt.version>
+        <carbon.consent.mgt.version.range>[3.0.0, 4.0.0)</carbon.consent.mgt.version.range>
 
-        <carbon.multitenancy.version>4.11.0</carbon.multitenancy.version>
-        <carbon.multitenancy.imp.pkg.version.range>[4.7.4, 5.0.0)</carbon.multitenancy.imp.pkg.version.range>
+        <carbon.multitenancy.version>5.0.0</carbon.multitenancy.version>
+        <carbon.multitenancy.imp.pkg.version.range>[5.0.0, 6.0.0)</carbon.multitenancy.imp.pkg.version.range>
 
         <!--Carbon commons version-->
         <carbon.commons.version>4.7.50</carbon.commons.version>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16