### PR TITLE
Third-party dependency upgrade

### DIFF
--- a/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
@@ -73,6 +73,10 @@
             <artifactId>swagger-jaxrs</artifactId>
             <exclusions>
                 <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
@@ -113,6 +117,10 @@
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -73,6 +73,10 @@
             <artifactId>swagger-jaxrs</artifactId>
             <exclusions>
                 <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
@@ -112,6 +116,10 @@
             <groupId>org.json.wso2</groupId>
             <artifactId>json</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,11 @@
                 <version>${spring-web.version}</version>
             </dependency>
             <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>${javax.validation-api}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-jaxrs</artifactId>
                 <version>${swagger-jaxrs.version}</version>
@@ -660,6 +665,7 @@
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
         <junit.version>4.13.1</junit.version>
         <maven.war.plugin.version>3.3.2</maven.war.plugin.version>
+        <javax.validation-api>2.0.1.Final</javax.validation-api>
 
         <!-- Unit test versions -->
         <testng.version>6.9.10</testng.version>


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/1017

Related PR - https://github.com/wso2-extensions/identity-governance/pull/630
validation-api has been updated from 1.1.0.Final to 2.0.1.Final from this PR

The following components will be updated from this PR

- ./repository/deployment/server/webapps/api#identity#user#v1.0/WEB-INF/lib/validation-api-1.1.0.Final.jar
- ./repository/deployment/server/webapps/api#identity#recovery#v0.9/WEB-INF/lib/validation-api-1.1.0.Final.jar