### PR TITLE
Validating recovery steps during introspection call for self signup flow

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -838,6 +838,10 @@ public class UserSelfRegistrationManager {
 
         // Validate context tenant domain name with user tenant domain.
         validateContextTenantDomainWithUserTenantDomain(user);
+
+        // Validate the recovery step to confirm self sign up, to verify email account or to verify mobile number.
+        validateRecoverySteps(recoveryData, user);
+
         return recoveryData;
     }
 


### PR DESCRIPTION
With this PR, recovery steps validation will be added to the introspection API call method for the self signup flow. 

The validation has been already added to the validation API call for the self signup flow.
Related PR: https://github.com/wso2-extensions/identity-governance/pull/591