### PR TITLE
Fix notification externally manage for ask password flow

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -179,6 +179,11 @@ public class IdentityRecoveryConstants {
     public static final String ADD_USER_EVENT = "ADD_USER";
 
     public static final String CORRELATION_ID_MDC = "Correlation-ID";
+    // Ask Password thread local property name.
+    public static final String AP_CONFIRMATION_CODE_THREAD_LOCAL_PROPERTY = "apConfirmationCodeThreadLocalProperty";
+    // Ask Password thread local initial value.
+    public static final String AP_CONFIRMATION_CODE_THREAD_LOCAL_INITIAL_VALUE =
+            "apConfirmationCodeThreadLocalInitialValue";
 
     private IdentityRecoveryConstants() {
 


### PR DESCRIPTION
### Proposed changes in this pull request
Set the recovery information to data store even when the notifications are managed by the Client app and add the confirmation code to thread local when notifications are managed externally.

- https://github.com/wso2/product-is/issues/14767