### PR TITLE
Decide identity data store/retrive location based on userstore property `StoreIdentityClaims`

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
@@ -62,6 +62,7 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
     private boolean isHybridDataStoreEnable = false;
     private static final String INVALID_OPERATION = "InvalidOperation";
     private static final String USER_IDENTITY_CLAIMS = "UserIdentityClaims";
+    private static final String STORE_IDENTITY_CLAIMS = "StoreIdentityClaims";
 
     public IdentityStoreEventListener() throws IllegalAccessException, InstantiationException, ClassNotFoundException {
 
@@ -126,7 +127,8 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
 
             Map.Entry<String, String> claim = it.next();
             if (claim.getKey().contains(UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI_PREFIX)
-                    && !(identityDataStore instanceof UserStoreBasedIdentityDataStore)) {
+                    && !(identityDataStore instanceof UserStoreBasedIdentityDataStore || Boolean.parseBoolean
+                    (userStoreManager.getRealmConfiguration().getUserStoreProperty(STORE_IDENTITY_CLAIMS)))) {
                 // add the identity claim to temp map
                 userDataMap.put(claim.getKey(), claim.getValue());
                 // we remove the identity claims to prevent it from getting stored in user store
@@ -239,7 +241,8 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
         }
 
         // No need to separately handle if identity `data store is user store based
-        if (identityDataStore instanceof UserStoreBasedIdentityDataStore) {
+        if (identityDataStore instanceof UserStoreBasedIdentityDataStore || Boolean.parseBoolean
+                (storeManager.getRealmConfiguration().getUserStoreProperty(STORE_IDENTITY_CLAIMS))) {
             return true;
         }
 
@@ -382,7 +385,8 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
         }
 
         // No need to separately handle if identity data store is user store based.
-        if (identityDataStore instanceof UserStoreBasedIdentityDataStore) {
+        if (identityDataStore instanceof UserStoreBasedIdentityDataStore || Boolean.parseBoolean
+                (userStoreManager.getRealmConfiguration().getUserStoreProperty(STORE_IDENTITY_CLAIMS))) {
             return true;
         }
 
@@ -506,7 +510,8 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
         }
 
         // No need to separately handle if identity data store is user store based.
-        if (identityDataStore instanceof UserStoreBasedIdentityDataStore) {
+        if (identityDataStore instanceof UserStoreBasedIdentityDataStore || Boolean.parseBoolean
+                (userStoreManager.getRealmConfiguration().getUserStoreProperty(STORE_IDENTITY_CLAIMS))) {
             return true;
         }
 
@@ -601,7 +606,8 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
                                              Map<String, String> claims) throws UserStoreException {
 
         // No need to separately handle if data identityDataStore is user store based
-        if (identityDataStore instanceof UserStoreBasedIdentityDataStore) {
+        if (identityDataStore instanceof UserStoreBasedIdentityDataStore || Boolean.parseBoolean
+                (userStoreManager.getRealmConfiguration().getUserStoreProperty(STORE_IDENTITY_CLAIMS))) {
             return true;
         }
 
@@ -660,8 +666,12 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
             log.debug("Method doPostGetUsersClaimValues getting executed in the IdentityStoreEventListener.");
         }
 
+        // Pulling the UserStoreManager using the realm service as it is not passed to the listener.
+        UserStoreManager userStoreManager = getUserStoreManager();
+
         // No need to separately handle if identity data store is user store based.
-        if (identityDataStore instanceof UserStoreBasedIdentityDataStore) {
+        if (identityDataStore instanceof UserStoreBasedIdentityDataStore || Boolean.parseBoolean
+                (userStoreManager.getRealmConfiguration().getUserStoreProperty(STORE_IDENTITY_CLAIMS))) {
             return true;
         }
 
@@ -678,9 +688,6 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
         if (!containsIdentityClaims) {
             return true;
         }
-
-        // Pulling the UserStoreManager using the realm service as it is not passed to the listener.
-        UserStoreManager userStoreManager = getUserStoreManager();
 
         for (UserClaimSearchEntry userClaimSearchEntry : userClaimSearchEntries) {
 

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
@@ -128,7 +128,7 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
             Map.Entry<String, String> claim = it.next();
             if (claim.getKey().contains(UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI_PREFIX)
                     && !(identityDataStore instanceof UserStoreBasedIdentityDataStore ||
-                    isStoreIdentityClaimsInUserStore(userStoreManager))) {
+                    isStoreIdentityClaimsInUserStoreEnabled(userStoreManager))) {
                 // add the identity claim to temp map
                 userDataMap.put(claim.getKey(), claim.getValue());
                 // we remove the identity claims to prevent it from getting stored in user store
@@ -242,7 +242,7 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
 
         // No need to separately handle if identity `data store is user store based
         if (identityDataStore instanceof UserStoreBasedIdentityDataStore ||
-                isStoreIdentityClaimsInUserStore(storeManager)) {
+                isStoreIdentityClaimsInUserStoreEnabled(storeManager)) {
             return true;
         }
 
@@ -386,7 +386,7 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
 
         // No need to separately handle if identity data store is user store based.
         if (identityDataStore instanceof UserStoreBasedIdentityDataStore ||
-                isStoreIdentityClaimsInUserStore(userStoreManager)) {
+                isStoreIdentityClaimsInUserStoreEnabled(userStoreManager)) {
             return true;
         }
 
@@ -511,7 +511,7 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
 
         // No need to separately handle if identity data store is user store based.
         if (identityDataStore instanceof UserStoreBasedIdentityDataStore ||
-                isStoreIdentityClaimsInUserStore(userStoreManager)) {
+                isStoreIdentityClaimsInUserStoreEnabled(userStoreManager)) {
             return true;
         }
 
@@ -607,7 +607,7 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
 
         // No need to separately handle if data identityDataStore is user store based
         if (identityDataStore instanceof UserStoreBasedIdentityDataStore ||
-                isStoreIdentityClaimsInUserStore(userStoreManager)) {
+                isStoreIdentityClaimsInUserStoreEnabled(userStoreManager)) {
             return true;
         }
 
@@ -671,7 +671,7 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
 
         // No need to separately handle if identity data store is user store based.
         if (identityDataStore instanceof UserStoreBasedIdentityDataStore ||
-                isStoreIdentityClaimsInUserStore(userStoreManager)) {
+                isStoreIdentityClaimsInUserStoreEnabled(userStoreManager)) {
             return true;
         }
 
@@ -751,7 +751,7 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
      * @param userStoreManager User Store manager.
      * @return Weather identity claims are stored in user store or not.
      */
-    private boolean isStoreIdentityClaimsInUserStore (UserStoreManager userStoreManager) {
+    private boolean isStoreIdentityClaimsInUserStoreEnabled(UserStoreManager userStoreManager) {
 
         return Boolean.parseBoolean(userStoreManager.getRealmConfiguration().
                 getUserStoreProperty(STORE_IDENTITY_CLAIMS));

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
@@ -62,7 +62,7 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
     private boolean isHybridDataStoreEnable = false;
     private static final String INVALID_OPERATION = "InvalidOperation";
     private static final String USER_IDENTITY_CLAIMS = "UserIdentityClaims";
-    private static final String STORE_IDENTITY_CLAIMS = "StoreIdentityClaims";
+    public static final String STORE_IDENTITY_CLAIMS = "StoreIdentityClaims";
 
     public IdentityStoreEventListener() throws IllegalAccessException, InstantiationException, ClassNotFoundException {
 
@@ -127,8 +127,8 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
 
             Map.Entry<String, String> claim = it.next();
             if (claim.getKey().contains(UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI_PREFIX)
-                    && !(identityDataStore instanceof UserStoreBasedIdentityDataStore || Boolean.parseBoolean
-                    (userStoreManager.getRealmConfiguration().getUserStoreProperty(STORE_IDENTITY_CLAIMS)))) {
+                    && !(identityDataStore instanceof UserStoreBasedIdentityDataStore ||
+                    isStoreIdentityClaimsInUserStore(userStoreManager))) {
                 // add the identity claim to temp map
                 userDataMap.put(claim.getKey(), claim.getValue());
                 // we remove the identity claims to prevent it from getting stored in user store
@@ -241,8 +241,8 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
         }
 
         // No need to separately handle if identity `data store is user store based
-        if (identityDataStore instanceof UserStoreBasedIdentityDataStore || Boolean.parseBoolean
-                (storeManager.getRealmConfiguration().getUserStoreProperty(STORE_IDENTITY_CLAIMS))) {
+        if (identityDataStore instanceof UserStoreBasedIdentityDataStore ||
+                isStoreIdentityClaimsInUserStore(storeManager)) {
             return true;
         }
 
@@ -385,8 +385,8 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
         }
 
         // No need to separately handle if identity data store is user store based.
-        if (identityDataStore instanceof UserStoreBasedIdentityDataStore || Boolean.parseBoolean
-                (userStoreManager.getRealmConfiguration().getUserStoreProperty(STORE_IDENTITY_CLAIMS))) {
+        if (identityDataStore instanceof UserStoreBasedIdentityDataStore ||
+                isStoreIdentityClaimsInUserStore(userStoreManager)) {
             return true;
         }
 
@@ -510,8 +510,8 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
         }
 
         // No need to separately handle if identity data store is user store based.
-        if (identityDataStore instanceof UserStoreBasedIdentityDataStore || Boolean.parseBoolean
-                (userStoreManager.getRealmConfiguration().getUserStoreProperty(STORE_IDENTITY_CLAIMS))) {
+        if (identityDataStore instanceof UserStoreBasedIdentityDataStore ||
+                isStoreIdentityClaimsInUserStore(userStoreManager)) {
             return true;
         }
 
@@ -606,8 +606,8 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
                                              Map<String, String> claims) throws UserStoreException {
 
         // No need to separately handle if data identityDataStore is user store based
-        if (identityDataStore instanceof UserStoreBasedIdentityDataStore || Boolean.parseBoolean
-                (userStoreManager.getRealmConfiguration().getUserStoreProperty(STORE_IDENTITY_CLAIMS))) {
+        if (identityDataStore instanceof UserStoreBasedIdentityDataStore ||
+                isStoreIdentityClaimsInUserStore(userStoreManager)) {
             return true;
         }
 
@@ -670,8 +670,8 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
         UserStoreManager userStoreManager = getUserStoreManager();
 
         // No need to separately handle if identity data store is user store based.
-        if (identityDataStore instanceof UserStoreBasedIdentityDataStore || Boolean.parseBoolean
-                (userStoreManager.getRealmConfiguration().getUserStoreProperty(STORE_IDENTITY_CLAIMS))) {
+        if (identityDataStore instanceof UserStoreBasedIdentityDataStore ||
+                isStoreIdentityClaimsInUserStore(userStoreManager)) {
             return true;
         }
 
@@ -742,5 +742,18 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
             throw new UserStoreException("Error occurred while retrieving user realm.", e);
         }
         return userRealm.getUserStoreManager();
+    }
+
+    /**
+     * Check weather the given user store has enabled the property "StoreIdentityClaims" to store identity claims
+     * in the user store.
+     *
+     * @param userStoreManager User Store manager.
+     * @return Weather identity claims are stored in user store or not.
+     */
+    private boolean isStoreIdentityClaimsInUserStore (UserStoreManager userStoreManager) {
+
+        return Boolean.parseBoolean(userStoreManager.getRealmConfiguration().
+                getUserStoreProperty(STORE_IDENTITY_CLAIMS));
     }
 }

--- a/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListenerTest.java
+++ b/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListenerTest.java
@@ -54,6 +54,7 @@ public class IdentityStoreEventListenerTest {
     private static final String USER_OPERATION_EVENT_LISTENER_TYPE = "org.wso2.carbon.user.core.listener" +
             ".UserOperationEventListener";
     private static final String DATA_STORE_PROPERTY_NAME = "Data.Store";
+    private static final String STORE_IDENTITY_CLAIMS = "StoreIdentityClaims";
     private static final int TENANT_ID = 1234;
 
     @Mock
@@ -121,6 +122,8 @@ public class IdentityStoreEventListenerTest {
                                  Map<String, String> claims,
                                  String prof) throws Exception {
         userStoreManager = mock(UserStoreManager.class);
+        Mockito.when(userStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
+        Mockito.when(realmConfiguration.getUserStoreProperty(STORE_IDENTITY_CLAIMS)).thenReturn(String.valueOf(false));
         Mockito.when(userStoreManager.getTenantId()).thenReturn(1001);
         assertTrue(identityStoreEventListener.doPreAddUser(userName, pwd, roleList, claims, prof, userStoreManager));
     }
@@ -132,6 +135,8 @@ public class IdentityStoreEventListenerTest {
                                   Map<String, String> claims,
                                   String prof) throws Exception {
         TestUtils.startTenantFlow("carbon.super");
+        Mockito.when(userStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
+        Mockito.when(realmConfiguration.getUserStoreProperty(STORE_IDENTITY_CLAIMS)).thenReturn(String.valueOf(false));
         assertTrue(identityStoreEventListener.doPostAddUser(userName, pwd, roleList, claims, prof, userStoreManager));
     }
 
@@ -143,6 +148,8 @@ public class IdentityStoreEventListenerTest {
                                             String prof) throws Exception {
         userStoreManager = mock(UserStoreManager.class);
         realmConfiguration = mock(RealmConfiguration.class);
+        Mockito.when(userStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
+        Mockito.when(realmConfiguration.getUserStoreProperty(STORE_IDENTITY_CLAIMS)).thenReturn(String.valueOf(false));
         userIdentityDataStore = mock(UserIdentityDataStore.class);
         UserIdentityClaim userIdentityClaim = null;
 
@@ -197,6 +204,8 @@ public class IdentityStoreEventListenerTest {
                                              Map<String, String> claims,
                                              String prof) throws Exception {
         realmConfiguration = mock(RealmConfiguration.class);
+        Mockito.when(userStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
+        Mockito.when(realmConfiguration.getUserStoreProperty(STORE_IDENTITY_CLAIMS)).thenReturn(String.valueOf(false));
         userIdentityDataStore = mock(UserIdentityDataStore.class);
 
         Field fieldIdentityStore = IdentityStoreEventListener.class


### PR DESCRIPTION
### Proposed changes in this pull request

Improve IdentityStoreEventListner to decide identity data store/retrieve location based on userstore property `StoreIdentityClaims`.

If userstore property `StoreIdentityClaims` was set to true, identity claims of the users of that particular userstore will be savved in the userstore.(in UM_USER_ATTRIBUTE table). Otherwise identity claims are stored in the identity database(default behaviour)


#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
