### PR TITLE
Add auth attribute handler component

### DIFF
--- a/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.8.13-SNAPSHOT</version>
+        <version>1.8.14-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -47,11 +47,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-        <groupId>org.wso2.carbon.identity.framework</groupId>
-        <artifactId>org.wso2.carbon.identity.testutil</artifactId>
-        <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
@@ -65,16 +60,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -165,7 +150,7 @@
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-<!--                                            <minimum>0.05</minimum>-->
+                                            <minimum>0.35</minimum>
                                         </limit>
                                     </limits>
                                 </rule>
@@ -173,6 +158,14 @@
                         </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <excludes>
+                        <!-- Exclude model classes from code coverage -->
+                        <exclude>**/model/*</exclude>
+                        <!-- Exclude exception classes from code coverage -->
+                        <exclude>**/exception/*</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>com.github.spotbugs</groupId>

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.8.14-SNAPSHOT</version>
+        <version>1.8.16-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.auth.attribute.handler</artifactId>
-    <name>WSO2 Carbon - Identity Authentication Attribute Handler</name>
+    <name>WSO2 Carbon - Identity Auth Attribute Handler</name>
     <packaging>bundle</packaging>
 
     <dependencies>

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.governance</groupId>
+        <artifactId>identity-governance</artifactId>
+        <version>1.8.13-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>org.wso2.carbon.identity.auth.attribute.handler</artifactId>
+    <name>WSO2 Carbon - Identity Authentication Attribute Handler</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi.services</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+        <groupId>org.wso2.carbon.identity.framework</groupId>
+        <artifactId>org.wso2.carbon.identity.testutil</artifactId>
+        <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.2.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>
+                            ${project.artifactId}
+                        </Bundle-SymbolicName>
+                        <Private-Package>
+                            org.wso2.carbon.identity.auth.attribute.handler.internal
+                        </Private-Package>
+                        <Export-Package>
+                            org.wso2.carbon.identity.auth.attribute.handler.*; version="${identity.governance.exp.pkg.version}",
+                            !org.wso2.carbon.identity.auth.attribute.handler.internal
+                        </Export-Package>
+                        <Import-Package>
+                            org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
+                            org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.common.*; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.core.util.*; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.base.*; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",
+                            org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
+                            org.apache.commons.logging.*; version="${commons-logging.osgi.version.range}",
+                            org.wso2.carbon.context; version="${carbon.kernel.package.import.version.range}",
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-prepare-agent-integration</id>
+                        <goals>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report-integration</id>
+                        <goals>
+                            <goal>report-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+<!--                                            <minimum>0.05</minimum>-->
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <configuration>
+                    <threshold>High</threshold>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/AuthAttributeHandler.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/AuthAttributeHandler.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.auth.attribute.handler;
 
 import org.wso2.carbon.identity.auth.attribute.handler.exception.AuthAttributeHandlerException;
 import org.wso2.carbon.identity.auth.attribute.handler.model.AuthAttributeHolder;
+import org.wso2.carbon.identity.auth.attribute.handler.model.ValidationResult;
 
 import java.util.Map;
 
@@ -27,7 +28,7 @@ import java.util.Map;
  * Interface for an Auth Attribute Handler.
  * This interface can be implemented by any
  * component that wants to describe authentication
- * attributes that should be provided be
+ * attributes that should be provided by
  * users when onboarding.
  */
 public interface AuthAttributeHandler {
@@ -77,8 +78,12 @@ public interface AuthAttributeHandler {
      * Used to perform validations on the received attributes.
      *
      * @param attributeMap A map containing the attributes and values.
-     * @return Returns true if validations are successful.
+     * @return Returns a ValidationResult object.
+     * If the validation is successful isValid will be true, along with an
+     * empty validationFailureReasons list. If the validation failed isValid
+     * will be false and will contain a list of validationFailureReasons
+     * pointing to the validation failing auth attributes.
      * @throws AuthAttributeHandlerException authAttributeHandlerException.
      */
-    boolean isValidAttributes(Map<String, String> attributeMap) throws AuthAttributeHandlerException; //validate data
+    ValidationResult validateAttributes(Map<String, String> attributeMap) throws AuthAttributeHandlerException;
 }

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/AuthAttributeHandler.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/AuthAttributeHandler.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.attribute.handler;
+
+import org.wso2.carbon.identity.auth.attribute.handler.exception.AuthAttributeHandlerException;
+import org.wso2.carbon.identity.auth.attribute.handler.model.AuthAttributeHolder;
+
+import java.util.Map;
+
+/**
+ * Interface for an Auth Attribute Handler.
+ * This interface can be implemented by any
+ * component that wants to describe authentication
+ * attributes that should be provided be
+ * users when onboarding.
+ */
+public interface AuthAttributeHandler {
+
+    /**
+     * Provides the identifier of the Auth
+     * Attribute Handler.
+     *
+     * @return Name of the auth attribute handler.
+     * @throws AuthAttributeHandlerException authAttributeHandlerException.
+     */
+    String getName() throws AuthAttributeHandlerException;
+
+    /**
+     * Auth Attribute Handlers can be written independently
+     * or be bound to other components such as Authenticators.
+     * This method returns the binding type of the Auth
+     * Attribute Handler.
+     *
+     * @return Returns an enum of AuthAttributeHandlerBindingType
+     * indicating the binding type.
+     * @throws AuthAttributeHandlerException authAttributeHandlerException.
+     */
+    AuthAttributeHandlerBindingType getBindingType() throws AuthAttributeHandlerException;
+
+    /**
+     * Returns the bound identifier if a binding exists
+     * or returns null in case of no binding.
+     *
+     * @return Bound identifier or null.
+     * @throws AuthAttributeHandlerException authAttributeHandlerException.
+     */
+    String getBoundIdentifier() throws AuthAttributeHandlerException;
+
+    /**
+     * Provides the data of the auth attributes including
+     * the auth attributes that needs to be onboarded
+     * and metadata about the Auth Attribute Handler
+     *
+     * @return Returns a AuthAttributeHolder object
+     * containing auth attribute data.
+     * @throws AuthAttributeHandlerException authAttributeHandlerException.
+     */
+    AuthAttributeHolder getAuthAttributeData() throws AuthAttributeHandlerException;
+
+    /**
+     * Used to perform validations on the received attributes.
+     *
+     * @param attributeMap A map containing the attributes and values.
+     * @return Returns true if validations are successful.
+     * @throws AuthAttributeHandlerException authAttributeHandlerException.
+     */
+    boolean isValidAttributes(Map<String, String> attributeMap) throws AuthAttributeHandlerException; //validate data
+}

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/AuthAttributeHandlerBindingType.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/AuthAttributeHandlerBindingType.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.attribute.handler;
+
+/**
+ * Enum describing the binding types
+ */
+public enum AuthAttributeHandlerBindingType {
+
+    NONE, // Indicates there is no binding.
+    AUTHENTICATOR // Indicates the Auth Attribute Handler is bound to an Authenticator.
+}

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/AuthAttributeHandlerConstants.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/AuthAttributeHandlerConstants.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.attribute.handler;
+
+/**
+ * Class to maintain constants related to the Auth Attribute Handler component.
+ */
+public class AuthAttributeHandlerConstants {
+
+    private AuthAttributeHandlerConstants(){}
+
+    private static final String AUTH_ATTRIBUTE_HANDLER_ERROR_CODE_PREFIX = "AAH";
+
+    /**
+     * Enum containing the error codes and error messages related
+     * to the Auth Attribute Handler component.
+     */
+    public enum ErrorMessages {
+
+        ERROR_CODE_UNEXPECTED_ERROR("65001", "Server encountered an unexpected error."),
+        ERROR_CODE_SERVICE_PROVIDER_NOT_FOUND("60001", "Service provider not found in tenant: %s for identifier: %s"),
+        ERROR_CODE_ATTRIBUTE_NOT_FOUND("60002", "Required attribute not found."),
+        ERROR_CODE_ATTRIBUTE_VALUE_EMPTY("60003", "Provided attribute value is empty.");
+
+        private final String code;
+        private final String message;
+
+        ErrorMessages(String code, String message) {
+
+            this.code = AUTH_ATTRIBUTE_HANDLER_ERROR_CODE_PREFIX + "-" + code;
+            this.message = message;
+        }
+
+        public String getCode() {
+
+            return code;
+        }
+
+        public String getMessage() {
+
+            return message;
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/AuthAttributeHandlerManager.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/AuthAttributeHandlerManager.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.attribute.handler;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.AuthenticationStep;
+import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthenticationConfig;
+import org.wso2.carbon.identity.application.common.model.LocalAuthenticatorConfig;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.auth.attribute.handler.exception.AuthAttributeHandlerClientException;
+import org.wso2.carbon.identity.auth.attribute.handler.exception.AuthAttributeHandlerException;
+import org.wso2.carbon.identity.auth.attribute.handler.internal.AuthAttributeHandlerServiceDataHolder;
+import org.wso2.carbon.identity.auth.attribute.handler.model.AuthAttributeHolder;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Service class responsible for handling Auth Attribute Handlers.
+ * Capabilities provided by the Auth Attribute Handlers are accessed through this class.
+ */
+public class AuthAttributeHandlerManager {
+
+    private static final Log LOG = LogFactory.getLog(AuthAttributeHandlerManager.class);
+    private static final AuthAttributeHandlerManager instance = new AuthAttributeHandlerManager();
+
+    private AuthAttributeHandlerManager() {
+
+    }
+
+    /**
+     * Return the instance of AuthAttributeHandlerManager.
+     *
+     * @return Returns the instance of AuthAttributeHandlerManager.
+     */
+    public static AuthAttributeHandlerManager getInstance() {
+
+        return instance;
+    }
+
+    /**
+     * Get a list of auth attribute holders for a given application id.
+     * The auth attribute holders will be derived based on the configured
+     * authenticators of the application which have bound auth attribute
+     * handlers. The auth attribute holders will contain the metadata of the
+     * auth attribute handler and the required auth attributes.
+     *
+     * @param appId Identifier of the application.
+     * @return A list of Auth Attribute Holders.
+     * @throws AuthAttributeHandlerException authAttributeHandlerException.
+     */
+    public List<AuthAttributeHolder> getAvailableAuthAttributeHolders(String appId) throws
+            AuthAttributeHandlerException {
+
+        String tenantDomain = resolveTenantDomain();
+        List<String> authenticators = getAvailableAuthenticators(appId, tenantDomain);
+        List<AuthAttributeHandler> authAttributeHandlers =
+                AuthAttributeHandlerServiceDataHolder.getInstance().getAuthAttributeHandlers();
+        List<AuthAttributeHolder> selectedAuthAttributeHolders = new ArrayList<>();
+        for (AuthAttributeHandler authAttributeHandler : authAttributeHandlers) {
+            if (authAttributeHandler.getBindingType() == AuthAttributeHandlerBindingType.AUTHENTICATOR
+                    && authenticators.contains(authAttributeHandler.getBoundIdentifier())) {
+                selectedAuthAttributeHolders.add(authAttributeHandler.getAuthAttributeData());
+            }
+        }
+
+        return selectedAuthAttributeHolders;
+    }
+
+    private ApplicationManagementService getApplicationManagementService() {
+
+        return AuthAttributeHandlerServiceDataHolder.getInstance().getApplicationManagementService();
+    }
+
+    private List<String> getAvailableAuthenticators(String appId, String tenantDomain)
+            throws AuthAttributeHandlerException {
+
+        List<String> authenticators = new ArrayList<>();
+        ServiceProvider sp = null;
+        try {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("Attempting to retrieve configures authenticators for appId: %s in " +
+                        "tenantDomain: %s", appId, tenantDomain));
+            }
+            sp = getApplicationManagementService().getApplicationByResourceId(appId, tenantDomain);
+        } catch (IdentityApplicationManagementException e) {
+            throw new AuthAttributeHandlerException(String.format("Error while retrieving application for appId: %s " +
+                    "in tenantDomain: %s", appId, tenantDomain), e);
+        }
+
+        if (sp == null) {
+            throw new AuthAttributeHandlerClientException(String.format("Cannot resolve service provider from " +
+                    "provided appId: %s in tenantDomain: %s", appId, tenantDomain));
+        }
+
+        AuthenticationStep[] authenticationSteps = null;
+
+        LocalAndOutboundAuthenticationConfig localAndOutboundAuthenticationConfig =
+                sp.getLocalAndOutBoundAuthenticationConfig();
+        if (localAndOutboundAuthenticationConfig.getAuthenticationSteps() != null
+                && localAndOutboundAuthenticationConfig.getAuthenticationSteps().length > 0) {
+            authenticationSteps = localAndOutboundAuthenticationConfig.getAuthenticationSteps();
+        }
+
+        if (authenticationSteps != null) {
+            for (AuthenticationStep authenticationStep : authenticationSteps) {
+                LocalAuthenticatorConfig[] configs = authenticationStep.getLocalAuthenticatorConfigs();
+                if (configs != null) {
+                    for (LocalAuthenticatorConfig config : configs) {
+                        if (!authenticators.contains(config.getName())) {
+                            authenticators.add(config.getName());
+                        }
+                    }
+                }
+            }
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Configured authenticators for appId: %s in tenantDomain: %s : %s", appId,
+                    tenantDomain, StringUtils.join(authenticators, ",")));
+        }
+
+        return authenticators;
+    }
+
+    private String resolveTenantDomain() {
+
+        String tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+        if (StringUtils.isBlank(tenantDomain)) {
+            tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Resolved tenant domain: " + tenantDomain);
+        }
+
+        return tenantDomain;
+    }
+}

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/exception/AuthAttributeHandlerClientException.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/exception/AuthAttributeHandlerClientException.java
@@ -25,19 +25,9 @@ public class AuthAttributeHandlerClientException extends AuthAttributeHandlerExc
 
     private static final long serialVersionUID = -3053314671550333970L;
 
-    public AuthAttributeHandlerClientException(String message) {
-
-        super(message);
-    }
-
     public AuthAttributeHandlerClientException(String errorCode, String message) {
 
         super(errorCode, message);
-    }
-
-    public AuthAttributeHandlerClientException(String message, Throwable cause) {
-
-        super(message, cause);
     }
 
     public AuthAttributeHandlerClientException(String errorCode, String message, Throwable cause) {

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/exception/AuthAttributeHandlerClientException.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/exception/AuthAttributeHandlerClientException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.attribute.handler.exception;
+
+/**
+ * Exception class that represents exceptions thrown from Auth Attribute Handler component due to client errors.
+ */
+public class AuthAttributeHandlerClientException extends AuthAttributeHandlerException {
+
+    private static final long serialVersionUID = -3053314671550333970L;
+
+    public AuthAttributeHandlerClientException(String message) {
+
+        super(message);
+    }
+
+    public AuthAttributeHandlerClientException(String errorCode, String message) {
+
+        super(errorCode, message);
+    }
+
+    public AuthAttributeHandlerClientException(String message, Throwable cause) {
+
+        super(message, cause);
+    }
+
+    public AuthAttributeHandlerClientException(String errorCode, String message, Throwable cause) {
+
+        super(errorCode, message, cause);
+    }
+}

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/exception/AuthAttributeHandlerException.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/exception/AuthAttributeHandlerException.java
@@ -27,19 +27,9 @@ public class AuthAttributeHandlerException extends IdentityException {
 
     private static final long serialVersionUID = -5419168766998504972L;
 
-    public AuthAttributeHandlerException(String message) {
-
-        super(message);
-    }
-
     public AuthAttributeHandlerException(String errorCode, String message) {
 
         super(errorCode, message);
-    }
-
-    public AuthAttributeHandlerException(String message, Throwable cause) {
-
-        super(message, cause);
     }
 
     public AuthAttributeHandlerException(String errorCode, String message, Throwable cause) {

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/exception/AuthAttributeHandlerException.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/exception/AuthAttributeHandlerException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.attribute.handler.exception;
+
+import org.wso2.carbon.identity.base.IdentityException;
+
+/**
+ * Exception class that represents exceptions thrown from Auth Attribute Handler component.
+ */
+public class AuthAttributeHandlerException extends IdentityException {
+
+    private static final long serialVersionUID = -5419168766998504972L;
+
+    public AuthAttributeHandlerException(String message) {
+
+        super(message);
+    }
+
+    public AuthAttributeHandlerException(String errorCode, String message) {
+
+        super(errorCode, message);
+    }
+
+    public AuthAttributeHandlerException(String message, Throwable cause) {
+
+        super(message, cause);
+    }
+
+    public AuthAttributeHandlerException(String errorCode, String message, Throwable cause) {
+
+        super(errorCode, message, cause);
+    }
+}

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/internal/AuthAttributeHandlerServiceComponent.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/internal/AuthAttributeHandlerServiceComponent.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.attribute.handler.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.auth.attribute.handler.AuthAttributeHandler;
+import org.wso2.carbon.identity.auth.attribute.handler.AuthAttributeHandlerManager;
+
+/**
+ * This class contains the OSGI components of the Auth Attribute Handler.
+ */
+@Component(
+        name = "org.wso2.carbon.identity.auth.attribute.handler.internal.AuthAttributeHandlerServiceComponent",
+        immediate = true)
+public class AuthAttributeHandlerServiceComponent {
+
+    private static final Log log = LogFactory.getLog(AuthAttributeHandlerServiceComponent.class);
+
+    @Activate
+    protected void activate(ComponentContext context) {
+
+        try {
+            BundleContext bundleContext = context.getBundleContext();
+            bundleContext.registerService(AuthAttributeHandlerManager.class.getName(),
+                    AuthAttributeHandlerManager.getInstance(), null);
+        } catch (Exception e) {
+            log.error("Error while activating auth attribute handler service component.", e);
+        }
+    }
+
+    @Reference(
+            name = "AuthAttributeHandler",
+            service = AuthAttributeHandler.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetAuthAttributeHandlers")
+    protected void setAuthAttributeHandlers(AuthAttributeHandler authAttributeHandler) {
+
+        AuthAttributeHandlerServiceDataHolder.getInstance().getAuthAttributeHandlers().add(authAttributeHandler);
+    }
+
+    protected void unsetAuthAttributeHandlers(AuthAttributeHandler authAttributeHandler) {
+
+        AuthAttributeHandlerServiceDataHolder.getInstance().getAuthAttributeHandlers().remove(authAttributeHandler);
+    }
+
+    @Reference(
+            name = "ApplicationManagementService",
+            service = ApplicationManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetApplicationManagementService")
+    protected void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        AuthAttributeHandlerServiceDataHolder.getInstance()
+                .setApplicationManagementService(applicationManagementService);
+    }
+
+    protected void unsetApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        AuthAttributeHandlerServiceDataHolder.getInstance().setApplicationManagementService(null);
+    }
+}

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/internal/AuthAttributeHandlerServiceDataHolder.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/internal/AuthAttributeHandlerServiceDataHolder.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.attribute.handler.internal;
+
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.auth.attribute.handler.AuthAttributeHandler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class holds OSGI services required by the Auth Attribute Handler component.
+ */
+public class AuthAttributeHandlerServiceDataHolder {
+
+    private static final AuthAttributeHandlerServiceDataHolder instance = new AuthAttributeHandlerServiceDataHolder();
+
+    private final List<AuthAttributeHandler> authAttributeHandlers = new ArrayList<>();
+    private ApplicationManagementService applicationManagementService;
+
+    public static AuthAttributeHandlerServiceDataHolder getInstance() {
+
+        return instance;
+    }
+
+    public List<AuthAttributeHandler> getAuthAttributeHandlers() {
+
+        return authAttributeHandlers;
+    }
+
+    public ApplicationManagementService getApplicationManagementService() {
+
+        return this.applicationManagementService;
+    }
+
+    public void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        this.applicationManagementService = applicationManagementService;
+    }
+}

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/model/AuthAttribute.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/model/AuthAttribute.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.attribute.handler.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Model class that represent an auth attribute.
+ */
+public class AuthAttribute {
+
+    private String attribute;
+    private boolean isClaim;
+    // Used to indicate if the attribute should be handled as a sensitive attribute.
+    private boolean isConfidential;
+    // Used to indicate the type of the application which can be in processing or UI representation.
+    private AuthAttributeType type;
+    private Map<String, String> properties = new HashMap<>();
+
+    public AuthAttribute() {
+
+    }
+
+    public AuthAttribute(String attribute, boolean isClaim, boolean isConfidential,
+                         AuthAttributeType type) {
+
+        this.attribute = attribute;
+        this.isClaim = isClaim;
+        this.isConfidential = isConfidential;
+        this.type = type;
+    }
+
+    public String getAttribute() {
+
+        return attribute;
+    }
+
+    public void setAttribute(String attribute) {
+
+        this.attribute = attribute;
+    }
+
+    public boolean isClaim() {
+
+        return isClaim;
+    }
+
+    public void setIsClaim(boolean claim) {
+
+        isClaim = claim;
+    }
+
+    public boolean isConfidential() {
+
+        return isConfidential;
+    }
+
+    public void setIsConfidential(boolean credential) {
+
+        isConfidential = credential;
+    }
+
+    public AuthAttributeType getType() {
+
+        return type;
+    }
+
+    public void setType(AuthAttributeType type) {
+
+        this.type = type;
+    }
+
+    public Map<String, String> getProperties() {
+
+        return properties;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+
+        this.properties = properties;
+    }
+}

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/model/AuthAttributeHolder.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/model/AuthAttributeHolder.java
@@ -33,7 +33,7 @@ public class AuthAttributeHolder {
 
     private String handlerName;
     private AuthAttributeHandlerBindingType handlerBinding;
-    private String handlerBindingIdentifier;
+    private String handlerBoundIdentifier;
     private List<AuthAttribute> authAttributes = new ArrayList<>();
     private Map<String, String> properties = new HashMap<>();
 
@@ -42,11 +42,11 @@ public class AuthAttributeHolder {
     }
 
     public AuthAttributeHolder(String handlerName, AuthAttributeHandlerBindingType handlerBinding,
-                               String handlerBindingIdentifier, List<AuthAttribute> authAttributes) {
+                               String handlerBoundIdentifier, List<AuthAttribute> authAttributes) {
 
         this.handlerName = handlerName;
         this.handlerBinding = handlerBinding;
-        this.handlerBindingIdentifier = handlerBindingIdentifier;
+        this.handlerBoundIdentifier = handlerBoundIdentifier;
         this.authAttributes = authAttributes;
     }
 
@@ -70,14 +70,14 @@ public class AuthAttributeHolder {
         this.handlerBinding = handlerBinding;
     }
 
-    public String getHandlerBindingIdentifier() {
+    public String getHandlerBoundIdentifier() {
 
-        return handlerBindingIdentifier;
+        return handlerBoundIdentifier;
     }
 
-    public void setHandlerBindingIdentifier(String handlerBindingIdentifier) {
+    public void setHandlerBoundIdentifier(String handlerBoundIdentifier) {
 
-        this.handlerBindingIdentifier = handlerBindingIdentifier;
+        this.handlerBoundIdentifier = handlerBoundIdentifier;
     }
 
     public List<AuthAttribute> getAuthAttributes() {

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/model/AuthAttributeHolder.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/model/AuthAttributeHolder.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.attribute.handler.model;
+
+import org.wso2.carbon.identity.auth.attribute.handler.AuthAttributeHandlerBindingType;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Model class used to represent an auth attribute handler
+ * and contained the auth attributes.
+ */
+public class AuthAttributeHolder {
+
+    private String handlerName;
+    private AuthAttributeHandlerBindingType handlerBinding;
+    private String handlerBindingIdentifier;
+    private List<AuthAttribute> authAttributes = new ArrayList<>();
+    private Map<String, String> properties = new HashMap<>();
+
+    public AuthAttributeHolder() {
+
+    }
+
+    public AuthAttributeHolder(String handlerName, AuthAttributeHandlerBindingType handlerBinding,
+                               String handlerBindingIdentifier, List<AuthAttribute> authAttributes) {
+
+        this.handlerName = handlerName;
+        this.handlerBinding = handlerBinding;
+        this.handlerBindingIdentifier = handlerBindingIdentifier;
+        this.authAttributes = authAttributes;
+    }
+
+    public String getHandlerName() {
+
+        return handlerName;
+    }
+
+    public void setHandlerName(String handlerName) {
+
+        this.handlerName = handlerName;
+    }
+
+    public AuthAttributeHandlerBindingType getHandlerBinding() {
+
+        return handlerBinding;
+    }
+
+    public void setHandlerBinding(AuthAttributeHandlerBindingType handlerBinding) {
+
+        this.handlerBinding = handlerBinding;
+    }
+
+    public String getHandlerBindingIdentifier() {
+
+        return handlerBindingIdentifier;
+    }
+
+    public void setHandlerBindingIdentifier(String handlerBindingIdentifier) {
+
+        this.handlerBindingIdentifier = handlerBindingIdentifier;
+    }
+
+    public List<AuthAttribute> getAuthAttributes() {
+
+        return authAttributes;
+    }
+
+    public void setAuthAttributes(List<AuthAttribute> authAttributes) {
+
+        this.authAttributes = authAttributes;
+    }
+
+    public Map<String, String> getProperties() {
+
+        return properties;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+
+        this.properties = properties;
+    }
+}

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/model/AuthAttributeType.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/model/AuthAttributeType.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.attribute.handler.model;
+
+/**
+ * Enum used to represent the possible types of auth attributes.
+ */
+public enum AuthAttributeType {
+
+    STRING,
+    INT
+}

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/model/ValidationFailureReason.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/model/ValidationFailureReason.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.attribute.handler.model;
+
+/**
+ * Model class that represent a validation failure reason.
+ */
+public class ValidationFailureReason {
+
+    private String authAttribute;
+    private String errorCode;
+    private String reason;
+
+    public ValidationFailureReason() {
+
+    }
+
+    public ValidationFailureReason(String authAttribute, String errorCode, String reason) {
+
+        this.authAttribute = authAttribute;
+        this.errorCode = errorCode;
+        this.reason = reason;
+    }
+
+    public String getAuthAttribute() {
+
+        return authAttribute;
+    }
+
+    public void setAuthAttribute(String authAttribute) {
+
+        this.authAttribute = authAttribute;
+    }
+
+    public String getErrorCode() {
+
+        return errorCode;
+    }
+
+    public void setErrorCode(String errorCode) {
+
+        this.errorCode = errorCode;
+    }
+
+    public String getReason() {
+
+        return reason;
+    }
+
+    public void setReason(String reason) {
+
+        this.reason = reason;
+    }
+}

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/model/ValidationResult.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/model/ValidationResult.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.attribute.handler.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Model class that represent a validation result.
+ */
+public class ValidationResult {
+
+    private boolean isValid;
+    private List<ValidationFailureReason> validationFailureReasons = new ArrayList<>();
+
+    public ValidationResult() {
+
+    }
+
+    public ValidationResult(boolean isValid) {
+
+        this.isValid = isValid;
+    }
+
+    public ValidationResult(boolean isValid, List<ValidationFailureReason> validationFailureReasons) {
+
+        this.isValid = isValid;
+        this.validationFailureReasons = validationFailureReasons;
+    }
+
+    public boolean isValid() {
+
+        return isValid;
+    }
+
+    public void setValid(boolean valid) {
+
+        isValid = valid;
+    }
+
+    public List<ValidationFailureReason> getValidationFailureReasons() {
+
+        return validationFailureReasons;
+    }
+
+    public void setValidationFailureReasons(List<ValidationFailureReason> validationFailureReasons) {
+
+        this.validationFailureReasons = validationFailureReasons;
+    }
+}

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/test/java/org/wso2/carbon/identity/auth/attribute/handler/AuthAttributeHandlerManagerTest.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/test/java/org/wso2/carbon/identity/auth/attribute/handler/AuthAttributeHandlerManagerTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.attribute.handler;
+
+import org.apache.commons.lang.StringUtils;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.common.model.AuthenticationStep;
+import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthenticationConfig;
+import org.wso2.carbon.identity.application.common.model.LocalAuthenticatorConfig;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.auth.attribute.handler.exception.AuthAttributeHandlerException;
+import org.wso2.carbon.identity.auth.attribute.handler.internal.AuthAttributeHandlerServiceDataHolder;
+import org.wso2.carbon.identity.auth.attribute.handler.model.AuthAttributeHolder;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit test for AuthAttributeHandlerManager.
+ */
+public class AuthAttributeHandlerManagerTest {
+
+    private AuthAttributeHandlerManager authAttributeHandlerManager = AuthAttributeHandlerManager.getInstance();
+    private static final String APP_ID = "0181313d-5c84-4ec4-a931-b73085408eff";
+    private static final String AUTHENTICATOR_BASICAUTH = "BasicAuthenticator";
+    private static final String AUTHENTICATOR_MAGICLINK = "MagicLinkAuthenticator";
+    private static final String AUTHENTICATOR_FIDO = "FIDOAuthenticator";
+    private static final String AUTHENTICATOR_TOTP = "TOTPAuthenticator";
+    private static final String AUTHENTICATOR_SMSOTP = "SMSOTPAuthenticator";
+    private static final String[] EXPECTED_HANDLERS = new String[]{AUTHENTICATOR_BASICAUTH, AUTHENTICATOR_MAGICLINK,
+            AUTHENTICATOR_FIDO};
+
+    @Mock
+    ApplicationManagementService applicationManagementService;
+
+    @Mock
+    AuthAttributeHandlerServiceDataHolder authAttributeHandlerServiceDataHolder;
+
+    private MockedStatic<AuthAttributeHandlerServiceDataHolder> mockedAuthAttributeHandlerServiceDataHolder;
+
+    @BeforeTest
+    private void setup() {
+
+        MockitoAnnotations.openMocks(this);
+        mockedAuthAttributeHandlerServiceDataHolder = Mockito.mockStatic(AuthAttributeHandlerServiceDataHolder.class);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        mockedAuthAttributeHandlerServiceDataHolder.close();
+    }
+
+    @Test
+    public void testGetAvailableAuthAttributeHolders() {
+
+        try {
+            initiateMocks();
+            List<AuthAttributeHolder> authAttributeHolders =
+                    authAttributeHandlerManager.getAvailableAuthAttributeHolders(APP_ID);
+
+            Assert.assertEquals(authAttributeHolders.size(), EXPECTED_HANDLERS.length, "Expected 3 auth attribute " +
+                    "holders but there is " + authAttributeHolders.size());
+            String[] authAttributeHandlers = getAuthAttributeHandlers(authAttributeHolders);
+            Assert.assertEqualsNoOrder(authAttributeHandlers, EXPECTED_HANDLERS,
+                    String.format("Expected auth attribute handlers: %s actual auth attribute handlers: %s",
+                            StringUtils.join(EXPECTED_HANDLERS, ","),
+                            StringUtils.join(authAttributeHandlers, ",")));
+
+        } catch (Exception e) {
+            Assert.fail("Test threw an unexpected exception.", e);
+        }
+    }
+
+    private String[] getAuthAttributeHandlers(List<AuthAttributeHolder> authAttributeHolderList) {
+
+        List<String> authAttributeHandlers = new ArrayList<>();
+        for (AuthAttributeHolder authAttributeHolder :
+                authAttributeHolderList) {
+            authAttributeHandlers.add(authAttributeHolder.getHandlerName());
+        }
+
+        return authAttributeHandlers.toArray(new String[0]);
+    }
+
+    private void initiateMocks() throws Exception {
+
+        mockedAuthAttributeHandlerServiceDataHolder.when(AuthAttributeHandlerServiceDataHolder::getInstance)
+                .thenReturn(authAttributeHandlerServiceDataHolder);
+        when(authAttributeHandlerServiceDataHolder.getApplicationManagementService())
+                .thenReturn(applicationManagementService);
+        when(applicationManagementService.getApplicationByResourceId(anyString(), anyString()))
+                .thenReturn(getServiceProvider());
+        when(authAttributeHandlerServiceDataHolder.getAuthAttributeHandlers())
+                .thenReturn(getAuthAttributeHandlers());
+        IdentityUtil.threadLocalProperties.get().put("TenantNameFromContext", "carbon.super");
+    }
+
+    private ServiceProvider getServiceProvider() {
+
+        ServiceProvider sp = new ServiceProvider();
+        List<AuthenticationStep> authenticationSteps = new ArrayList<>();
+        authenticationSteps.add(getAuthenticationStep(new String[]{AUTHENTICATOR_BASICAUTH, AUTHENTICATOR_MAGICLINK}));
+        authenticationSteps.add(getAuthenticationStep(new String[]{AUTHENTICATOR_FIDO, AUTHENTICATOR_SMSOTP}));
+
+        LocalAndOutboundAuthenticationConfig localAndOutboundAuthenticationConfig =
+                new LocalAndOutboundAuthenticationConfig();
+        localAndOutboundAuthenticationConfig.setAuthenticationSteps(
+                authenticationSteps.toArray(new AuthenticationStep[0]));
+
+        sp.setLocalAndOutBoundAuthenticationConfig(localAndOutboundAuthenticationConfig);
+
+        return sp;
+    }
+
+    private LocalAuthenticatorConfig getLocalAuthenticatorConfig(String name) {
+
+        LocalAuthenticatorConfig localAuthenticatorConfig = new LocalAuthenticatorConfig();
+        localAuthenticatorConfig.setName(name);
+
+        return localAuthenticatorConfig;
+    }
+
+    private AuthenticationStep getAuthenticationStep(String[] authenticators) {
+
+        List<LocalAuthenticatorConfig> localAuthenticatorConfigs = new ArrayList<>();
+        for (String authenticator : authenticators) {
+            localAuthenticatorConfigs.add(getLocalAuthenticatorConfig(authenticator));
+        }
+
+        AuthenticationStep authenticationStep = new AuthenticationStep();
+        authenticationStep.setLocalAuthenticatorConfigs(
+                localAuthenticatorConfigs.toArray(new LocalAuthenticatorConfig[0]));
+        return authenticationStep;
+    }
+
+    private List<AuthAttributeHandler> getAuthAttributeHandlers() {
+
+        List<AuthAttributeHandler> authAttributeHandlers = new ArrayList<>();
+        authAttributeHandlers.add(new BasicAuthAttributeHandler());
+        authAttributeHandlers.add(new MagicLinkAttributeHandler());
+        authAttributeHandlers.add(new FIDOAttributeHandler());
+        authAttributeHandlers.add(new TOTPAttributeHandler());
+
+        return authAttributeHandlers;
+    }
+
+    private AuthAttributeHolder getAuthAttributeHolder(String name) {
+
+        AuthAttributeHolder authAttributeHolder = new AuthAttributeHolder();
+        authAttributeHolder.setHandlerName(name);
+        authAttributeHolder.setHandlerBinding(AuthAttributeHandlerBindingType.AUTHENTICATOR);
+        authAttributeHolder.setHandlerBoundIdentifier(name);
+
+        return authAttributeHolder;
+    }
+
+    class BasicAuthAttributeHandler extends MockAbstractAuthAttributeHandler {
+
+        @Override
+        public AuthAttributeHolder getAuthAttributeData() throws AuthAttributeHandlerException {
+
+            return getAuthAttributeHolder(AUTHENTICATOR_BASICAUTH);
+        }
+
+        @Override
+        public String getBoundIdentifier() throws AuthAttributeHandlerException {
+
+            return AUTHENTICATOR_BASICAUTH;
+        }
+    }
+
+    class MagicLinkAttributeHandler extends MockAbstractAuthAttributeHandler {
+
+        @Override
+        public AuthAttributeHolder getAuthAttributeData() throws AuthAttributeHandlerException {
+
+            return getAuthAttributeHolder(AUTHENTICATOR_MAGICLINK);
+        }
+
+        @Override
+        public String getBoundIdentifier() throws AuthAttributeHandlerException {
+
+            return AUTHENTICATOR_MAGICLINK;
+        }
+    }
+
+    class FIDOAttributeHandler extends MockAbstractAuthAttributeHandler {
+
+        @Override
+        public AuthAttributeHolder getAuthAttributeData() throws AuthAttributeHandlerException {
+
+            return getAuthAttributeHolder(AUTHENTICATOR_FIDO);
+        }
+
+        @Override
+        public String getBoundIdentifier() throws AuthAttributeHandlerException {
+
+            return AUTHENTICATOR_FIDO;
+        }
+    }
+
+    class TOTPAttributeHandler extends MockAbstractAuthAttributeHandler {
+
+        @Override
+        public AuthAttributeHolder getAuthAttributeData() throws AuthAttributeHandlerException {
+
+            return getAuthAttributeHolder(AUTHENTICATOR_TOTP);
+        }
+
+        @Override
+        public String getBoundIdentifier() throws AuthAttributeHandlerException {
+
+            return AUTHENTICATOR_TOTP;
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/test/java/org/wso2/carbon/identity/auth/attribute/handler/MockAbstractAuthAttributeHandler.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/test/java/org/wso2/carbon/identity/auth/attribute/handler/MockAbstractAuthAttributeHandler.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.auth.attribute.handler;
 
 import org.wso2.carbon.identity.auth.attribute.handler.exception.AuthAttributeHandlerException;
 import org.wso2.carbon.identity.auth.attribute.handler.model.AuthAttributeHolder;
+import org.wso2.carbon.identity.auth.attribute.handler.model.ValidationResult;
 
 import java.util.Map;
 
@@ -53,8 +54,8 @@ public abstract class MockAbstractAuthAttributeHandler implements AuthAttributeH
     }
 
     @Override
-    public boolean isValidAttributes(Map<String, String> attributeMap) throws AuthAttributeHandlerException {
+    public ValidationResult validateAttributes(Map<String, String> attributeMap) throws AuthAttributeHandlerException {
 
-        return false;
+        return null;
     }
 }

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/test/java/org/wso2/carbon/identity/auth/attribute/handler/MockAbstractAuthAttributeHandler.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/test/java/org/wso2/carbon/identity/auth/attribute/handler/MockAbstractAuthAttributeHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.attribute.handler;
+
+import org.wso2.carbon.identity.auth.attribute.handler.exception.AuthAttributeHandlerException;
+import org.wso2.carbon.identity.auth.attribute.handler.model.AuthAttributeHolder;
+
+import java.util.Map;
+
+/**
+ * A mock class added as an abstract class that can be used in the unit test.
+ */
+public abstract class MockAbstractAuthAttributeHandler implements AuthAttributeHandler {
+
+    @Override
+    public String getName() throws AuthAttributeHandlerException {
+
+        return null;
+    }
+
+    @Override
+    public AuthAttributeHandlerBindingType getBindingType() throws AuthAttributeHandlerException {
+
+        return AuthAttributeHandlerBindingType.AUTHENTICATOR;
+    }
+
+    @Override
+    public String getBoundIdentifier() throws AuthAttributeHandlerException {
+
+        return null;
+    }
+
+    @Override
+    public AuthAttributeHolder getAuthAttributeData() throws AuthAttributeHandlerException {
+
+        return null;
+    }
+
+    @Override
+    public boolean isValidAttributes(Map<String, String> attributeMap) throws AuthAttributeHandlerException {
+
+        return false;
+    }
+}

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/test/resources/testng.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Auth-Attribute-Handler-Test-Suite">
+    <test name="Util-Tests" preserve-order="true" parallel="false">
+        <classes>
+           <class name="org.wso2.carbon.identity.auth.attribute.handler.AuthAttributeHandlerManagerTest" />
+        </classes>
+    </test>
+</suite>

--- a/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.8.14-SNAPSHOT</version>
+        <version>1.8.16-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.8.13-SNAPSHOT</version>
+        <version>1.8.14-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.governance</groupId>
+        <artifactId>identity-governance</artifactId>
+        <relativePath>../../pom.xml</relativePath>
+        <version>1.8.13-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.auth.attribute.handler.server.feature</artifactId>
+    <packaging>pom</packaging>
+    <name>WSO2 Carbon - Identity Auth Attribute Handler Server Feature</name>
+    <url>http://wso2.org</url>
+    <description>This feature contains the bundle required for auth attribute handler functionality</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.auth.attribute.handler</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>carbon-p2-plugin</artifactId>
+                <version>${carbon.p2.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>p2-feature-generation</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>p2-feature-gen</goal>
+                        </goals>
+                        <configuration>
+                            <id>org.wso2.carbon.identity.auth.attribute.handler.server</id>
+                            <propertiesFile>../../etc/feature.properties</propertiesFile>
+                            <adviceFile>
+                                <properties>
+                                    <propertyDef>org.wso2.carbon.p2.category.type:server</propertyDef>
+                                </properties>
+                            </adviceFile>
+                            <bundles>
+                                <bundleDef>org.wso2.carbon.identity.governance:org.wso2.carbon.identity.auth.attribute.handler</bundleDef>
+                            </bundles>
+                            <importFeatures>
+                            </importFeatures>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <module>components/org.wso2.carbon.identity.api.user.governance</module>
         <module>components/org.wso2.carbon.identity.tenant.resource.manager</module>
         <module>components/org.wso2.carbon.identity.multi.attribute.login</module>
+        <module>components/org.wso2.carbon.identity.auth.attribute.handler</module>
 
         <module>service-stubs/identity</module>
 
@@ -74,6 +75,7 @@
         <module>features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature</module>
         <module>features/org.wso2.carbon.identity.tenant.resource.manager.feature</module>
         <module>features/org.wso2.carbon.identity.multi.attribute.login.service.server.feature</module>
+        <module>features/org.wso2.carbon.identity.auth.attribute.handler.server.feature</module>
     </modules>
 
     <dependencyManagement>
@@ -288,6 +290,11 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.commons</groupId>
                 <artifactId>org.wso2.carbon.tenant.common</artifactId>
                 <version>${carbon.commons.version}</version>
@@ -352,6 +359,11 @@
             <dependency>
                 <groupId>org.wso2.carbon.identity.governance</groupId>
                 <artifactId>org.wso2.carbon.identity.user.rename.core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.governance</groupId>
+                <artifactId>org.wso2.carbon.identity.auth.attribute.handler</artifactId>
                 <version>${project.version}</version>
             </dependency>
 


### PR DESCRIPTION
This PR improves the internals to support different credential types for users when onboarding

IS provides multiple login options for applications. Users can log in with different credential options configured for their locally managed account (ex: password, magic link, fido) in Asgardeo or login with existing identities (ex: social login) trusted by the application.
However, when it comes to user onboarding, the registration options for a user are only a subset of the login options. Especially, when creating an account in the organization, users only have the opportunity to proceed with a password as the credential.

This PR introduces a new component(Auth Attribute Handler Manager) and an interface(Auth Attribute Handler) which will be used to create new components that will contain authentication-related attributes which will allow user onboarding flows to determine what attributes should be requested from the user to support an authentication mechanism. With this PR the required attributes for authentication will be derived based on the authenticators that are configured for the application.

The following is a high-level view of the components
<img width="750" alt="Screenshot 2023-01-20 at 13 14 12" src="https://user-images.githubusercontent.com/11583571/213650877-895a0ac6-53c7-45d3-8600-425c1f5a7449.png">

The following sequence diagram shows how the auth attribute handler manager interacts with other components
![Auth Attribute Handler Manager interaction (2)](https://user-images.githubusercontent.com/11583571/213651015-c4525130-0040-4de6-a003-af02198d158c.png)

Related to https://github.com/wso2/product-is/issues/15449


