### PR TITLE
Add Redirect URL and redirect Error page to the configured retry endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/filter/CaptchaFilter.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/filter/CaptchaFilter.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.captcha.filter;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.captcha.connector.CaptchaConnector;
 import org.wso2.carbon.identity.captcha.connector.CaptchaPostValidationResponse;
 import org.wso2.carbon.identity.captcha.connector.CaptchaPreValidationResponse;
@@ -109,19 +110,21 @@ public class CaptchaFilter implements Filter {
             HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
             HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
 
+            String redirectURL = FrameworkUtils.getContextData(httpRequest).getRedirectURL();
+
             if (captchaPreValidationResponse.isCaptchaValidationRequired()) {
                 try {
                     boolean validCaptcha = selectedCaptchaConnector.verifyCaptcha(servletRequest, servletResponse);
                     if (!validCaptcha) {
                         log.warn("Captcha validation failed for the user.");
-                        httpResponse.sendRedirect(CaptchaUtil.getOnFailRedirectUrl(httpRequest.getHeader("referer"),
+                        httpResponse.sendRedirect(CaptchaUtil.getOnFailRedirectUrl(redirectURL,
                                 captchaPreValidationResponse.getOnCaptchaFailRedirectUrls(),
                                 captchaPreValidationResponse.getCaptchaAttributes()));
                         return;
                     }
                 } catch (CaptchaClientException e) {
                     log.warn("Captcha validation failed for the user. Cause : " + e.getMessage());
-                    httpResponse.sendRedirect(CaptchaUtil.getOnFailRedirectUrl(httpRequest.getHeader("referer"),
+                    httpResponse.sendRedirect(CaptchaUtil.getOnFailRedirectUrl(redirectURL,
                             captchaPreValidationResponse.getOnCaptchaFailRedirectUrls(),
                             captchaPreValidationResponse.getCaptchaAttributes()));
                     return;

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaUtil.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaUtil.java
@@ -37,6 +37,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
+import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
@@ -158,26 +159,23 @@ public class CaptchaUtil {
         }
     }
 
-    public static String getOnFailRedirectUrl(String referrerUrl, List<String> onFailRedirectUrls,
+    public static String getOnFailRedirectUrl(String redirectURL, List<String> onFailRedirectUrls,
                                               Map<String, String> attributes) {
 
-        if (StringUtils.isBlank(referrerUrl) || onFailRedirectUrls.isEmpty()) {
+        if (StringUtils.isBlank(redirectURL) || onFailRedirectUrls.isEmpty()) {
             return getErrorPage("Human Verification Failed.", "Something went wrong. Please try again.");
         }
 
         URIBuilder uriBuilder;
         try {
-            uriBuilder = new URIBuilder(referrerUrl);
+            uriBuilder = new URIBuilder(redirectURL);
         } catch (URISyntaxException e) {
             return getErrorPage("Human Verification Failed.", "Something went wrong. Please try again.");
         }
 
         for (String url : onFailRedirectUrls) {
             if (!StringUtils.isBlank(url) && url.equalsIgnoreCase(uriBuilder.getPath())) {
-                for (NameValuePair pair : uriBuilder.getQueryParams()) {
-                    attributes.put(pair.getName(), pair.getValue());
-                }
-                return getUpdatedUrl(url, attributes);
+                return getUpdatedUrl(redirectURL, attributes);
             }
         }
 
@@ -187,7 +185,7 @@ public class CaptchaUtil {
     public static String getErrorPage(String status, String statusMsg) {
 
         try {
-            URIBuilder uriBuilder = new URIBuilder(CaptchaConstants.ERROR_PAGE);
+            URIBuilder uriBuilder = new URIBuilder(ConfigurationFacade.getInstance().getAuthenticationEndpointRetryURL());
             uriBuilder.addParameter("status", status);
             uriBuilder.addParameter("statusMsg", statusMsg);
             return uriBuilder.build().toString();
@@ -195,7 +193,7 @@ public class CaptchaUtil {
             if (log.isDebugEnabled()) {
                 log.debug("Error occurred while building URL.", e);
             }
-            return CaptchaConstants.ERROR_PAGE;
+            return ConfigurationFacade.getInstance().getAuthenticationEndpointRetryURL();
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -639,7 +639,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.90</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.98</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.20.211, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Purpose

1. Depending on Referrer URL to capture the headers is considered inappropriate and the Redirect URL parameter is introduced in `AuthenticationContext`. 
2. The behaviour of redirecting to the custom retry endpoint is considered inappropriate and redirected to the configured retry endpoint obtained from `ConfigurationFacade`.

### Dependent PR

- https://github.com/wso2/carbon-identity-framework/pull/4427

### Related Issue
- https://github.com/wso2/product-is/issues/15320
