### PR TITLE
Pack auth attribute handler as a governance feature

### DIFF
--- a/features/org.wso2.carbon.identity.governance.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.feature/pom.xml
@@ -87,6 +87,12 @@
             <version>${project.version}</version>
             <type>zip</type>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.auth.attribute.handler.server.feature</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+        </dependency>
     </dependencies>
 
     <build>
@@ -135,6 +141,9 @@
                                 </includedFeatureDef>
                                 <includedFeatureDef>
                                     org.wso2.carbon.identity.governance:org.wso2.carbon.identity.piicontroller.server.feature
+                                </includedFeatureDef>
+                                <includedFeatureDef>
+                                    org.wso2.carbon.identity.governance:org.wso2.carbon.identity.auth.attribute.handler.server.feature
                                 </includedFeatureDef>
                             </includedFeatures>
                         </configuration>


### PR DESCRIPTION
This PR packs the auth attribute handler component(https://github.com/wso2-extensions/identity-governance/pull/651) as a governance feature to product-is

Resolves https://github.com/wso2/product-is/issues/15449