### PR TITLE
Handle default authenticator configuration for auth attribute handler

### DIFF
--- a/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/AuthAttributeHandlerConstants.java
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/src/main/java/org/wso2/carbon/identity/auth/attribute/handler/AuthAttributeHandlerConstants.java
@@ -34,10 +34,9 @@ public class AuthAttributeHandlerConstants {
     public enum ErrorMessages {
 
         ERROR_CODE_UNEXPECTED_ERROR("65001", "Server encountered an unexpected error."),
-        ERROR_CODE_SERVICE_PROVIDER_NOT_FOUND("60001", "Service provider not found in tenant: %s for identifier: %s"),
-        ERROR_CODE_ATTRIBUTE_NOT_FOUND("60002", "Required attribute not found."),
-        ERROR_CODE_ATTRIBUTE_VALUE_EMPTY("60003", "Provided attribute value is empty."),
-        ERROR_CODE_AUTH_ATTRIBUTE_HANDLER_NOT_FOUND("60004",
+        ERROR_CODE_ATTRIBUTE_NOT_FOUND("60001", "Required attribute not found."),
+        ERROR_CODE_ATTRIBUTE_VALUE_EMPTY("60002", "Provided attribute value is empty."),
+        ERROR_CODE_AUTH_ATTRIBUTE_HANDLER_NOT_FOUND("60003",
                 "Unable to find an auth attribute handler for the provided identifier: %s");
 
         private final String code;


### PR DESCRIPTION
Related to: https://github.com/wso2/product-is/issues/15449
Earlier if the application is configured to use default authentication then the authenticators were not available and in turn, the proper auth attribute holders were not returned. With this PR the default authentication case is handled.