### PR TITLE
Update signup logic to support different credential options

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/MeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/MeApiServiceImpl.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.recovery.RecoveryScenarios;
 import org.wso2.carbon.identity.recovery.RecoverySteps;
 import org.wso2.carbon.identity.recovery.bean.NotificationResponseBean;
 import org.wso2.carbon.identity.recovery.confirmation.ResendConfirmationManager;
+import org.wso2.carbon.identity.recovery.exception.SelfRegistrationException;
 import org.wso2.carbon.identity.recovery.model.UserRecoveryData;
 import org.wso2.carbon.identity.recovery.signup.UserSelfRegistrationManager;
 import org.wso2.carbon.identity.user.endpoint.Constants;
@@ -52,6 +53,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_BAD_SELF_REGISTER_REQUEST;
 
 /**
  * Class which contains the implementation of MeApiService.
@@ -89,6 +92,11 @@ public class MeApiServiceImpl extends MeApiService {
 
         String tenantFromContext = (String) IdentityUtil.threadLocalProperties.get().get(Constants.TENANT_NAME_FROM_CONTEXT);
 
+        if (selfUserRegistrationRequestDTO == null) {
+            Utils.handleBadRequest("Invalid data for self-registration.",
+                    ERROR_CODE_BAD_SELF_REGISTER_REQUEST.getCode());
+        }
+
         if (StringUtils.isNotBlank(tenantFromContext)) {
             selfUserRegistrationRequestDTO.getUser().setTenantDomain(tenantFromContext);
         }
@@ -116,6 +124,9 @@ public class MeApiServiceImpl extends MeApiService {
                 Utils.handleBadRequest(e.getMessage(), e.getErrorCode());
             }
         } catch (IdentityRecoveryException e) {
+            if (e instanceof SelfRegistrationException) {
+                Utils.handleSelfRegistrationException((SelfRegistrationException) e , LOG);
+            }
             Utils.handleInternalServerError(Constants.SERVER_ERROR, e.getErrorCode(), LOG, e);
         } catch (Throwable throwable) {
             Utils.handleInternalServerError(Constants.SERVER_ERROR, IdentityRecoveryConstants

--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/MeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/MeApiServiceImpl.java
@@ -123,10 +123,9 @@ public class MeApiServiceImpl extends MeApiService {
             } else {
                 Utils.handleBadRequest(e.getMessage(), e.getErrorCode());
             }
+        } catch (SelfRegistrationException e) {
+                Utils.handleSelfRegistrationException(e , LOG);
         } catch (IdentityRecoveryException e) {
-            if (e instanceof SelfRegistrationException) {
-                Utils.handleSelfRegistrationException((SelfRegistrationException) e , LOG);
-            }
             Utils.handleInternalServerError(Constants.SERVER_ERROR, e.getErrorCode(), LOG, e);
         } catch (Throwable throwable) {
             Utils.handleInternalServerError(Constants.SERVER_ERROR, IdentityRecoveryConstants

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -69,6 +69,10 @@
             <artifactId>org.wso2.carbon.consent.mgt.core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.auth.attribute.handler</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.testutil</artifactId>
             <scope>test</scope>

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -310,12 +310,13 @@ public class IdentityRecoveryConstants {
                 "User specified communication channel does not have any value"),
         ERROR_CODE_BAD_SELF_REGISTER_REQUEST("USR-10003",
                 "Bad Request"),
-        ERROR_CODE_BAD_LITE_REGISTER_REQUEST("USR-10004","Either email or mobile should be submitted."),
+        ERROR_CODE_BAD_LITE_REGISTER_REQUEST("USR-10004", "Either email or mobile should be submitted."),
         ERROR_CODE_UNSUPPORTED_SELF_REGISTER_LITE_REQUEST("USR-10005",
                 "Lite self registration is not supported."),
         ERROR_CODE_INVALID_USER_ATTRIBUTES_FOR_REGISTRATION("USR-10006", "User attributes do not satisfy the " +
                 "requirements of the selected registration option."),
         ERROR_CODE_INVALID_REGISTRATION_OPTION("USR-10007", "Invalid registration option."),
+        ERROR_CODE_MULTIPLE_REGISTRATION_OPTIONS("USR-10008", "Multiple registration options are not supported."),
 
         // USR - User Self Registration - server exceptions.
         ERROR_CODE_UNEXPECTED_ERROR_VALIDATING_ATTRIBUTES("USR-15001", "Unexpected error while validating user " +

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -185,6 +185,9 @@ public class IdentityRecoveryConstants {
     public static final String AP_CONFIRMATION_CODE_THREAD_LOCAL_INITIAL_VALUE =
             "apConfirmationCodeThreadLocalInitialValue";
 
+    // Self sign up properties.
+    public static final String SIGNUP_PROPERTY_REGISTRATION_OPTION = "registrationOption";
+
     private IdentityRecoveryConstants() {
 
     }
@@ -300,7 +303,7 @@ public class IdentityRecoveryConstants {
                 " config store."),
         ERROR_CODE_FAILED_TO_FETCH_RESOURCE_FROM_CONFIG_STORE("55008", "Error occurred while fetching " +
                 "resource from config store."),
-        // USR - User Self Registration.
+        // USR - User Self Registration - client exceptions.
         ERROR_CODE_UNSUPPORTED_PREFERRED_CHANNELS("USR-10001",
                 "User specified communication channel is not supported by the server"),
         ERROR_CODE_PREFERRED_CHANNEL_VALUE_EMPTY("USR-10002",
@@ -310,6 +313,13 @@ public class IdentityRecoveryConstants {
         ERROR_CODE_BAD_LITE_REGISTER_REQUEST("USR-10004","Either email or mobile should be submitted."),
         ERROR_CODE_UNSUPPORTED_SELF_REGISTER_LITE_REQUEST("USR-10005",
                 "Lite self registration is not supported."),
+        ERROR_CODE_INVALID_USER_ATTRIBUTES_FOR_REGISTRATION("USR-10006", "User attributes do not satisfy the " +
+                "requirements of the selected registration option."),
+        ERROR_CODE_INVALID_REGISTRATION_OPTION("USR-10007", "Invalid registration option."),
+
+        // USR - User Self Registration - server exceptions.
+        ERROR_CODE_UNEXPECTED_ERROR_VALIDATING_ATTRIBUTES("USR-15001", "Unexpected error while validating user " +
+                "attributes."),
 
         // UAV - User Account Verification.
         ERROR_CODE_UNSUPPORTED_VERIFICATION_CHANNEL("UAV-10001",

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/exception/SelfRegistrationClientException.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/exception/SelfRegistrationClientException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.recovery.exception;
+
+/**
+ * This class will handle the client exceptions related to the self registration.
+ */
+public class SelfRegistrationClientException extends SelfRegistrationException {
+
+    private static final long serialVersionUID = -3720491701962000088L;
+
+    public SelfRegistrationClientException(String errorCode, String message, String description) {
+
+        super(errorCode, message, description);
+    }
+}

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/exception/SelfRegistrationException.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/exception/SelfRegistrationException.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.recovery.exception;
+
+import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
+
+/**
+ * This class will handle the exceptions related to the self registration.
+ */
+public class SelfRegistrationException extends IdentityRecoveryException {
+
+    private static final long serialVersionUID = -6763234985286131368L;
+    private String description;
+
+    public SelfRegistrationException(String errorCode, String message, String description) {
+
+        super(errorCode, message);
+        this.description = description;
+    }
+
+    public SelfRegistrationException(String errorCode, String message, String description, Throwable cause) {
+
+        super(errorCode, message, cause);
+        this.description = description;
+    }
+
+    public void setDescription(String description) {
+
+        this.description = description;
+    }
+
+    public String getDescription() {
+
+        return description;
+    }
+}

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
@@ -27,6 +27,7 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.consent.mgt.core.ConsentManager;
 import org.wso2.carbon.identity.application.authentication.framework.handler.request.PostAuthenticationHandler;
+import org.wso2.carbon.identity.auth.attribute.handler.AuthAttributeHandlerManager;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.consent.mgt.services.ConsentUtilityService;
@@ -444,5 +445,23 @@ public class IdentityRecoveryServiceComponent {
     protected void unsetMultiAttributeLoginService(MultiAttributeLoginService multiAttributeLoginService) {
 
         dataHolder.getInstance().setMultiAttributeLoginService(null);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.identity.auth.attribute.handler.internal.AuthAttributeHandlerServiceComponent",
+            service = AuthAttributeHandlerManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetAuthAttributeHandlerManager")
+    protected void setAuthAttributeHandlerManager(AuthAttributeHandlerManager authAttributeHandlerManager) {
+
+        log.debug("Auth Attribute Handler Manager service is set in recovery component.");
+        dataHolder.setAuthAttributeHandlerManager(authAttributeHandlerManager);
+    }
+
+    protected void unsetAuthAttributeHandlerManager(AuthAttributeHandlerManager authAttributeHandlerManager) {
+
+        log.debug("Auth Attribute Handler Manager service is unset in recovery component.");
+        dataHolder.setAuthAttributeHandlerManager(null);
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceDataHolder.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceDataHolder.java
@@ -17,6 +17,7 @@
 package org.wso2.carbon.identity.recovery.internal;
 
 import org.wso2.carbon.consent.mgt.core.ConsentManager;
+import org.wso2.carbon.identity.auth.attribute.handler.AuthAttributeHandlerManager;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.consent.mgt.services.ConsentUtilityService;
@@ -48,6 +49,7 @@ public class IdentityRecoveryServiceDataHolder {
     private UserFunctionalityManager userFunctionalityManagerService;
     private OTPGenerator otpGenerator;
     private MultiAttributeLoginService multiAttributeLoginService;
+    private AuthAttributeHandlerManager authAttributeHandlerManager;
     public static IdentityRecoveryServiceDataHolder getInstance() {
 
         return instance;
@@ -269,4 +271,25 @@ public class IdentityRecoveryServiceDataHolder {
 
         this.otpGenerator = otpGenerator;
     }
+
+    /**
+     * Get the AuthAttributeHandlerManager object held at the data holder.
+     *
+     * @return AuthAttributeHandlerManager object.
+     */
+    public AuthAttributeHandlerManager getAuthAttributeHandlerManager() {
+
+        return authAttributeHandlerManager;
+    }
+
+    /**
+     * Set the AuthAttributeHandlerManager.
+     *
+     * @param authAttributeHandlerManager AuthAttributeHandlerManager object.
+     */
+    public void setAuthAttributeHandlerManager(AuthAttributeHandlerManager authAttributeHandlerManager) {
+
+        this.authAttributeHandlerManager = authAttributeHandlerManager;
+    }
+
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -122,6 +122,8 @@ public class UserSelfRegistrationManager {
     private static UserSelfRegistrationManager instance = new UserSelfRegistrationManager();
     private static final String PURPOSE_GROUP_SELF_REGISTER = "SELF-SIGNUP";
     private static final String PURPOSE_GROUP_TYPE_SYSTEM = "SYSTEM";
+    private static final String AUTH_ATTRIBUTE_USERNAME = "username";
+    private static final String AUTH_ATTRIBUTE_PASSWORD = "password";
 
     private UserSelfRegistrationManager() {
 
@@ -1952,8 +1954,8 @@ public class UserSelfRegistrationManager {
             throws SelfRegistrationException {
 
         Map<String, String> userAttributes = new HashMap<>();
-        userAttributes.put("username", user.getUserName());
-        userAttributes.put("password", password);
+        userAttributes.put(AUTH_ATTRIBUTE_USERNAME, user.getUserName());
+        userAttributes.put(AUTH_ATTRIBUTE_PASSWORD, password);
 
         if (ArrayUtils.isNotEmpty(claims)) {
             for (Claim claim : claims) {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1376,8 +1376,8 @@ public class Utils {
 
         if (validationResult == null) {
             throw new SelfRegistrationClientException(
-                    ERROR_CODE_UNEXPECTED_ERROR_VALIDATING_ATTRIBUTES.getMessage(),
                     ERROR_CODE_UNEXPECTED_ERROR_VALIDATING_ATTRIBUTES.getCode(),
+                    ERROR_CODE_UNEXPECTED_ERROR_VALIDATING_ATTRIBUTES.getMessage(),
                     "The attribute verification result is undefined.");
         }
         String errorDescription = "The mandatory attributes of the selected registration option are missing or empty " +
@@ -1386,8 +1386,8 @@ public class Utils {
             errorDescription = convertFailureReasonsToString(validationResult.getValidationFailureReasons());
         }
         throw new SelfRegistrationClientException(
-                ERROR_CODE_INVALID_USER_ATTRIBUTES_FOR_REGISTRATION.getMessage(),
                 ERROR_CODE_INVALID_USER_ATTRIBUTES_FOR_REGISTRATION.getCode(),
+                ERROR_CODE_INVALID_USER_ATTRIBUTES_FOR_REGISTRATION.getMessage(),
                 errorDescription);
     }
 
@@ -1403,13 +1403,13 @@ public class Utils {
         if (e instanceof AuthAttributeHandlerClientException
                 && ERROR_CODE_AUTH_ATTRIBUTE_HANDLER_NOT_FOUND.getCode().equals(e.getErrorCode())) {
             throw new SelfRegistrationClientException(
-                    ERROR_CODE_INVALID_REGISTRATION_OPTION.getMessage(),
                     ERROR_CODE_INVALID_REGISTRATION_OPTION.getCode(),
+                    ERROR_CODE_INVALID_REGISTRATION_OPTION.getMessage(),
                     e.getMessage());
         }
         throw new SelfRegistrationException(
-                ERROR_CODE_UNEXPECTED_ERROR_VALIDATING_ATTRIBUTES.getMessage(),
                 ERROR_CODE_UNEXPECTED_ERROR_VALIDATING_ATTRIBUTES.getCode(),
+                ERROR_CODE_UNEXPECTED_ERROR_VALIDATING_ATTRIBUTES.getMessage(),
                 e.getMessage(),
                 e);
     }


### PR DESCRIPTION
Related to https://github.com/wso2/product-is/issues/15573

**Proposed changes of the PR**
This PR updates the [signup API of wso2 identity server](https://is.docs.wso2.com/en/latest/apis/use-the-self-sign-up-rest-apis/) to support user registration using different credential options in addition to the Username and Password. The PR also updates the signup logic to verify the user attributes coming in the signup request against the registration option that is selected.

**Approach**
In the signup request, the selected registration option must be sent as a property with the key `registrationOption`.
The options that we support at the moment are, `BasicAuthAuthAttributeHandler` and `MagicLinkAuthAttributeHandler`. These names are based on the authenticators we have.

*Sample Request*
```
{
    "user": {
        "username": "kim",
        "realm": "PRIMARY",
        "password" : "Kim@123",
        "claims": [
            {
                "uri": "http://wso2.org/claims/givenname",
                "value": "kim"
            },
            {
                "uri": "http://wso2.org/claims/emailaddress",
                "value": "kim.anderson@gmail.com"
            }
        ]
    },
    "properties": [
        {
            "key": "callback",
            "value": "https://localhost:9443/myaccount/login"
        },
        {
            "key" : "registrationOption",
            "value": "BasicAuthAuthAttributeHandle"
        }
    ]
}
```

