### PR TITLE
Redirect users to success flow when password does not exist for the local user account.

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
@@ -85,8 +85,7 @@ public class RecoverPasswordApiServiceImpl extends RecoverPasswordApiService {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Client Error while sending recovery notification ", e);
             }
-            if (StringUtils.equals(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FEDERATED_USER.getCode(),
-                    e.getErrorCode())) {
+            if (IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FEDERATED_USER.getCode().equals(e.getErrorCode())) {
                 return Response.accepted().build();
             }
             RecoveryUtil.handleBadRequest(e.getMessage(), e.getErrorCode());

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
@@ -86,8 +86,7 @@ public class RecoverPasswordApiServiceImpl extends RecoverPasswordApiService {
                 LOG.debug("Client Error while sending recovery notification ", e);
             }
             if (StringUtils.equals(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FEDERATED_USER.getCode(),
-                    e.getErrorCode()) && StringUtils.equals(String.format(IdentityRecoveryConstants.ErrorMessages
-                    .ERROR_CODE_FEDERATED_USER.getMessage(), user.getUsername()), e.getMessage())) {
+                    e.getErrorCode())) {
                 return Response.accepted().build();
             }
             RecoveryUtil.handleBadRequest(e.getMessage(), e.getErrorCode());

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
@@ -85,6 +85,11 @@ public class RecoverPasswordApiServiceImpl extends RecoverPasswordApiService {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Client Error while sending recovery notification ", e);
             }
+            if (StringUtils.equals(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_FEDERATED_USER.getCode(),
+                    e.getErrorCode()) && StringUtils.equals(String.format(IdentityRecoveryConstants.ErrorMessages
+                    .ERROR_CODE_FEDERATED_USER.getMessage(), user.getUsername()), e.getMessage())) {
+                return Response.accepted().build();
+            }
             RecoveryUtil.handleBadRequest(e.getMessage(), e.getErrorCode());
         } catch (IdentityRecoveryException e) {
             if (e.getCause() != null && StringUtils.equals(Constants.ERROR_MESSAGE_EMAIL_NOT_FOUND,

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -200,7 +200,7 @@ public class IdentityRecoveryConstants {
         ERROR_CODE_INVALID_CODE("18001", "Invalid Code '%s'."),
         ERROR_CODE_EXPIRED_CODE("18002", "Expired Code '%s'."),
         ERROR_CODE_INVALID_USER("18003", "Invalid User '%s'."),
-        ERROR_CODE_FEDERATED_USER("18004", "User %s doesn't have a password for local account."),
+        ERROR_CODE_FEDERATED_USER("18006", "User %s doesn't have a password for local account."),
         ERROR_CODE_UNEXPECTED("18013", "Unexpected error"),
         ERROR_CODE_RECOVERY_NOTIFICATION_FAILURE("18015", "Error sending recovery notification"),
         ERROR_CODE_INVALID_TENANT("18016", "Invalid tenant '%s'."),


### PR DESCRIPTION
**Purpose**:

This PR resolved https://github.com/wso2-enterprise/asgardeo-product/issues/14306

**Solution**:

When a user with social sign up tries to recover the password, password recovery flow redirects user to an error page with message "User user@gmail.com doesn't have a password for local account." This fix handles that exception in the password recovery flow and redirects user to the success page which is improved in the https://github.com/wso2-enterprise/asgardeo-product/issues/14442 

