### PR TITLE
Do not show error page if email is not configured in password recovery flow

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -516,7 +516,7 @@ public class IdentityRecoveryConstants {
                 "SelfRegistration.EnableAccountLockForVerifiedPreferredChannel";
         public static final String NOTIFICATION_INTERNALLY_MANAGE = "Recovery.Notification.InternallyManage";
         public static final String NOTIFY_USER_EXISTENCE = "Recovery.NotifyUserExistence";
-        public static final String NOTIFY_EMAIL_NOT_FOUND = "Recovery.NotifyEmailNotFound";
+        public static final String NOTIFY_RECOVERY_EMAIL_EXISTENCE = "Recovery.NotifyRecoveryEmailExistence";
         public static final String NOTIFY_USER_ACCOUNT_STATUS = "Recovery.NotifyUserAccountStatus";
         public static final String NOTIFICATION_SEND_RECOVERY_NOTIFICATION_SUCCESS = "Recovery.NotifySuccess";
         public static final String NOTIFICATION_SEND_RECOVERY_SECURITY_START = "Recovery.Question.Password.NotifyStart";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -205,6 +205,7 @@ public class IdentityRecoveryConstants {
         ERROR_CODE_RECOVERY_NOTIFICATION_FAILURE("18015", "Error sending recovery notification"),
         ERROR_CODE_INVALID_TENANT("18016", "Invalid tenant '%s'."),
         ERROR_CODE_CHALLENGE_QUESTION_NOT_FOUND("18017", "No challenge question found. %s"),
+        ERROR_CODE_EMAIL_NOT_FOUND("18018", "Sending email address is not found for the user %s."),
         ERROR_CODE_INVALID_CREDENTIALS("17002", "Invalid Credentials"),
         ERROR_CODE_LOCKED_ACCOUNT("17003", "User account is locked - '%s'."),
         ERROR_CODE_DISABLED_ACCOUNT("17004", "user account is disabled '%s'."),
@@ -515,6 +516,7 @@ public class IdentityRecoveryConstants {
                 "SelfRegistration.EnableAccountLockForVerifiedPreferredChannel";
         public static final String NOTIFICATION_INTERNALLY_MANAGE = "Recovery.Notification.InternallyManage";
         public static final String NOTIFY_USER_EXISTENCE = "Recovery.NotifyUserExistence";
+        public static final String NOTIFY_EMAIL_NOT_FOUND = "Recovery.NotifyEmailNotFound";
         public static final String NOTIFY_USER_ACCOUNT_STATUS = "Recovery.NotifyUserAccountStatus";
         public static final String NOTIFICATION_SEND_RECOVERY_NOTIFICATION_SUCCESS = "Recovery.NotifySuccess";
         public static final String NOTIFICATION_SEND_RECOVERY_SECURITY_START = "Recovery.Question.Password.NotifyStart";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -138,11 +138,11 @@ public class NotificationPasswordRecoveryManager {
                 return new NotificationResponseBean(user);
             } else if (isExistingUser(user) && StringUtils.isEmpty(getEmail(user))) {
 
-            /* If the email is not found for the user, Check for NOTIFY_EMAIL_NOT_FOUND property. If the property is not
-            enabled, notify with an empty NotificationResponseBean.*/
-                boolean notifyEmailNotFound = Boolean.parseBoolean(
-                        IdentityUtil.getProperty(IdentityRecoveryConstants.ConnectorConfig.NOTIFY_EMAIL_NOT_FOUND));
-                if (notifyEmailNotFound) {
+            /* If the email is not found for the user, Check for NOTIFY_RECOVERY_EMAIL_EXISTENCE property.
+            If the property is not enabled, notify with an empty NotificationResponseBean.*/
+                boolean notifyRecoveryEmailExistence = Boolean.parseBoolean(
+                        IdentityUtil.getProperty(IdentityRecoveryConstants.ConnectorConfig.NOTIFY_RECOVERY_EMAIL_EXISTENCE));
+                if (notifyRecoveryEmailExistence) {
                     throw Utils.handleClientException(
                             IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_EMAIL_NOT_FOUND, user.getUserName());
                 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -56,8 +56,10 @@ import org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.util.Utils;
 import org.wso2.carbon.registry.core.Resource;
+import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 
 import java.io.UnsupportedEncodingException;
@@ -67,6 +69,7 @@ import java.util.Map;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AUDIT_FAILED;
 import static org.wso2.carbon.registry.core.RegistryConstants.PATH_SEPARATOR;
+import static org.wso2.carbon.user.core.UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME;
 
 /**
  * Manager class which can be used to recover passwords using a notification.
@@ -131,6 +134,17 @@ public class NotificationPasswordRecoveryManager {
                 if (notifyUserExistence) {
                     throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_USER,
                             user.getUserName());
+                }
+                return new NotificationResponseBean(user);
+            } else if (isExistingUser(user) && StringUtils.isEmpty(getEmail(user))) {
+
+            /* If the email is not found for the user, Check for NOTIFY_EMAIL_NOT_FOUND property. If the property is not
+            enabled, notify with an empty NotificationResponseBean.*/
+                boolean notifyEmailNotFound = Boolean.parseBoolean(
+                        IdentityUtil.getProperty(IdentityRecoveryConstants.ConnectorConfig.NOTIFY_EMAIL_NOT_FOUND));
+                if (notifyEmailNotFound) {
+                    throw Utils.handleClientException(
+                            IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_EMAIL_NOT_FOUND, user.getUserName());
                 }
                 return new NotificationResponseBean(user);
             }
@@ -959,5 +973,36 @@ public class NotificationPasswordRecoveryManager {
         Resource templateType = resourceMgtService.getIdentityResource(path, tenantDomain);
         return templateType != null;
     }
-}
 
+    /**
+     * Retrieve email address of the user.
+     *
+     * @param user      User the email need to be retrieved.
+     * @return email address of the user.
+     * @throws IdentityRecoveryServerException
+     */
+    private String getEmail(User user) throws IdentityRecoveryServerException {
+
+        String userStoreDomain = user.getUserStoreDomain();
+        RealmService realmService = IdentityRecoveryServiceDataHolder.getInstance().getRealmService();
+        try {
+            UserRealm userRealm = realmService.getTenantUserRealm(IdentityTenantUtil.getTenantId(user.getTenantDomain()));
+            UserStoreManager userStoreManager = userRealm.getUserStoreManager();
+
+            if (userStoreManager == null) {
+                throw new IdentityRecoveryServerException(String.format("userStoreManager is null for user: " +
+                        "%s in tenant domain : %s", user.getUserName(), user.getTenantDomain()));
+            }
+            if (StringUtils.isNotBlank(userStoreDomain) && !PRIMARY_DEFAULT_DOMAIN_NAME.equals(userStoreDomain)) {
+                userStoreManager = ((AbstractUserStoreManager) userStoreManager).getSecondaryUserStoreManager(userStoreDomain);
+            }
+
+            return userStoreManager.getUserClaimValue(user.getUserName(), IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM, null);
+
+        } catch (UserStoreException e) {
+            String error = String.format("Error occurred while retrieving existing email address for user: " +
+                    "%s in tenant domain : %s", user.getUserName(), user.getTenantDomain());
+            throw new IdentityRecoveryServerException(error, e);
+        }
+    }
+}


### PR DESCRIPTION
Currently if user does not have a email attribute configured for a user, We show an error page in saying email attribute is not configured for the user in the password recovery flow user.
We need to improve the flow to show the success msg even the email attribute is not configured for the user

Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/4552