### PR TITLE
Introducing a DAO layer to store last login time of the users

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -189,6 +189,11 @@ public class IdentityRecoveryConstants {
     // Self sign up properties.
     public static final String SIGNUP_PROPERTY_REGISTRATION_OPTION = "registrationOption";
 
+    // IdentityUserMetadataMgtHandler constants.
+    public static final String TENANT_ASSOCIATION_MANAGER = "tenant-association-manager";
+    public static final String STORE_IDENTITY_CLAIMS = "StoreIdentityClaims";
+    public static final String ASGARDEO_USER_DOMAIN_NAME = "ASGARDEO-USER";
+
     private IdentityRecoveryConstants() {
 
     }
@@ -664,6 +669,21 @@ public class IdentityRecoveryConstants {
         public static final String LOAD_RECOVERY_DATA_OF_USER_BY_STEP_CASE_INSENSITIVE = "SELECT "
                 + "* FROM IDN_RECOVERY_DATA WHERE LOWER(USER_NAME)=LOWER(?) AND SCENARIO = ? AND USER_DOMAIN = ? " +
                 "AND TENANT_ID = ? AND STEP = ?";
+
+        public static final String UPDATE_USER_METADATA = "UPDATE IDN_IDENTITY_USER_DATA SET DATA_VALUE = ? WHERE " +
+                "TENANT_ID = ? AND USER_NAME = ? AND DATA_KEY = ?";
+
+        public static final String INSERT_USER_METADATA = "INSERT INTO IDN_IDENTITY_USER_DATA (TENANT_ID, USER_NAME, " +
+                "DATA_KEY, DATA_VALUE) VALUES (?, ?, ?, ?)";
+
+        public static final String LOAD_USER_METADATA = "SELECT * FROM IDN_IDENTITY_USER_DATA WHERE TENANT_ID = ? AND " +
+                "USER_NAME = ? AND DATA_KEY = ?";
+
+        public static final String LOAD_USER_METADATA_FROM_USER_STORE_SQL_KEY = "GetUserPropertyForProfileSQL";
+
+        public static final String INSERT_USER_METADATA_TO_USER_STORE_SQL_KEY = "AddUserPropertySQL";
+
+        public static final String UPDATE_USER_METADATA_TO_USER_STORE_SQL_KEY = "UpdateUserPropertySQL";
     }
 
     public static class Questions {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dao/IdentityUserMetadataMgtDAO.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dao/IdentityUserMetadataMgtDAO.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.recovery.dao;
+
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.governance.model.UserIdentityClaim;
+import org.wso2.carbon.user.core.UserStoreManager;
+
+/**
+ * This interface is used to access the data storage to retrieve and store identity user metadata.
+ */
+public interface IdentityUserMetadataMgtDAO {
+
+    /**
+     * Update user metadata.
+     *
+     * @param userStoreManager          UserStore manager.
+     * @param username                  Username.
+     * @param claimURI                  Claim URI.
+     * @param value                     Value of the claim.
+     * @param eventName                 Event name.
+     * @throws IdentityEventException   Identity Event Exception.
+     */
+    void updateUserMetadata(UserStoreManager userStoreManager, String username,
+                            String claimURI, String value, String eventName) throws IdentityEventException;
+
+    /**
+     * Retrieve user metadata from cache memory.
+     *
+     * @param userStoreManager  User store manager.
+     * @param username          User name.
+     * @return                  User metadata from cache.
+     */
+    UserIdentityClaim loadUserMetadataFromCache(UserStoreManager userStoreManager, String username);
+
+    /**
+     * Retrieve user metadata from cache memory.
+     *
+     * @param userStoreManager  User store manager.
+     * @param userIdentityDTO   User identity data object.
+     *
+     */
+    void storeUserMetadataToCache(UserStoreManager userStoreManager, UserIdentityClaim userIdentityDTO);
+}

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dao/impl/IdentityUserMetadataMgtDAOImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dao/impl/IdentityUserMetadataMgtDAOImpl.java
@@ -87,46 +87,45 @@ public class IdentityUserMetadataMgtDAOImpl implements IdentityUserMetadataMgtDA
     public UserIdentityClaim loadUserMetadataFromCache(UserStoreManager userStoreManager, String userName) {
 
         try {
-            if (userName != null) {
-                userName = UserCoreUtil.removeDomainFromName(userName);
-                if (!IdentityUtil.isUserStoreCaseSensitive(userStoreManager)) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Case insensitive user store found. Changing username from : " + userName +
-                                " to : " + userName.toLowerCase(Locale.ENGLISH));
-                    }
-                    userName = userName.toLowerCase(Locale.ENGLISH);
-                } else if (!IdentityUtil.isUseCaseSensitiveUsernameForCacheKeys(userStoreManager)) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Case insensitive username for cache key is used. Changing username from : "
-                                + userName + " to : " + userName.toLowerCase(Locale.ENGLISH));
-                    }
-                    userName = userName.toLowerCase(Locale.ENGLISH);
+            userName = UserCoreUtil.removeDomainFromName(userName);
+            String lowerCaseUserName = userName.toLowerCase(Locale.ENGLISH);
+            if (!IdentityUtil.isUserStoreCaseSensitive(userStoreManager)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Case insensitive user store found. Changing username from : " + userName +
+                            " to : " + lowerCaseUserName);
                 }
-
-                String domainName = userStoreManager.getRealmConfiguration().
-                        getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
-
-                IdentityDataStoreCacheKey key = new IdentityDataStoreCacheKey(domainName, userName);
-                int tenantId = userStoreManager.getTenantId();
-                UserIdentityClaim userIdentityDTO = identityDataStoreCache.getValueFromCache(key, tenantId);
-
-                if (userIdentityDTO != null && log.isDebugEnabled()) {
-                    StringBuilder data = new StringBuilder("{");
-                    if (userIdentityDTO.getUserIdentityDataMap() != null) {
-                        for (Map.Entry<String, String> entry : userIdentityDTO.getUserIdentityDataMap().entrySet()) {
-                            data.append("[").append(entry.getKey()).append(" = ").append(entry.getValue())
-                                    .append("], ");
-                        }
-                    }
-                    if (data.indexOf(",") >= 0) {
-                        data.deleteCharAt(data.lastIndexOf(","));
-                    }
-                    data.append("}");
-                    log.debug("Loaded UserIdentityClaimsDO from cache for user :" + userName + " with claims: " + data);
-
+                userName = lowerCaseUserName;
+            } else if (!IdentityUtil.isUseCaseSensitiveUsernameForCacheKeys(userStoreManager)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Case insensitive username for cache key is used. Changing username from : "
+                            + userName + " to : " + lowerCaseUserName);
                 }
-                return userIdentityDTO;
+                userName = lowerCaseUserName;
             }
+
+            String domainName = userStoreManager.getRealmConfiguration().
+                    getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
+
+            IdentityDataStoreCacheKey key = new IdentityDataStoreCacheKey(domainName, userName);
+            int tenantId = userStoreManager.getTenantId();
+            UserIdentityClaim userIdentityDTO = identityDataStoreCache.getValueFromCache(key, tenantId);
+
+            if (userIdentityDTO != null && log.isDebugEnabled()) {
+                StringBuilder data = new StringBuilder("{");
+                if (userIdentityDTO.getUserIdentityDataMap() != null) {
+                    for (Map.Entry<String, String> entry : userIdentityDTO.getUserIdentityDataMap().entrySet()) {
+                        data.append("[").append(entry.getKey()).append(" = ").append(entry.getValue())
+                                .append("], ");
+                    }
+                }
+                if (data.indexOf(",") >= 0) {
+                    data.deleteCharAt(data.lastIndexOf(","));
+                }
+                data.append("}");
+                log.debug("Loaded UserIdentityClaimsDO from cache for user :" + userName + " with claims: " + data);
+
+            }
+            return userIdentityDTO;
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
             log.error("Error while obtaining tenant ID from user store manager");
         }
@@ -139,18 +138,19 @@ public class IdentityUserMetadataMgtDAOImpl implements IdentityUserMetadataMgtDA
         try {
             if (userIdentityDTO != null && userIdentityDTO.getUserName() != null) {
                 String userName = UserCoreUtil.removeDomainFromName(userIdentityDTO.getUserName());
+                String lowerCaseUserName = userName.toLowerCase(Locale.ENGLISH);
                 if (!IdentityUtil.isUserStoreCaseSensitive(userStoreManager)) {
                     if (log.isDebugEnabled()) {
                         log.debug("Case insensitive user store found. Changing username from : " + userName +
-                                " to : " + userName.toLowerCase(Locale.ENGLISH));
+                                " to : " + lowerCaseUserName);
                     }
-                    userName = userName.toLowerCase(Locale.ENGLISH);
+                    userName = lowerCaseUserName;
                 } else if (!IdentityUtil.isUseCaseSensitiveUsernameForCacheKeys(userStoreManager)) {
                     if (log.isDebugEnabled()) {
                         log.debug("Case insensitive username for cache key is used. Changing username from : "
-                                + userName + " to : " + userName.toLowerCase(Locale.ENGLISH));
+                                + userName + " to : " + lowerCaseUserName);
                     }
-                    userName = userName.toLowerCase(Locale.ENGLISH);
+                    userName = lowerCaseUserName;
                 }
 
                 if (log.isDebugEnabled()) {
@@ -206,11 +206,11 @@ public class IdentityUserMetadataMgtDAOImpl implements IdentityUserMetadataMgtDA
         try (Connection connection = getDBConnection(userStoreManager.getRealmConfiguration())) {
             try {
                 if (isMetadataExistsInUserStore(connection, userStoreManager, tenantId, username, claimAttributeName)) {
-                    // update claim in user store
+                    // Update claim in user store.
                     executionResult = updateExistingMetadataInUserStore(connection, userStoreManager, tenantId,
                             username, claimAttributeName, value);
                 } else {
-                    // add claim to user store
+                    // Add claim to user store.
                     executionResult = insertMetadataInUserStore(connection, userStoreManager, tenantId, username,
                             claimAttributeName, value);
                 }
@@ -232,12 +232,12 @@ public class IdentityUserMetadataMgtDAOImpl implements IdentityUserMetadataMgtDA
     /**
      * Store user metadata in the identity store.
      *
-     * @param username                  Username
-     * @param tenantId                  Tenant ID
-     * @param claimURI                  Claim URI
-     * @param value                     Claim attribute value
-     * @param eventName                 Event name
-     * @throws IdentityEventException   Identity event exception
+     * @param username                  Username.
+     * @param tenantId                  Tenant ID.
+     * @param claimURI                  Claim URI.
+     * @param value                     Claim attribute value.
+     * @param eventName                 Event name.
+     * @throws IdentityEventException   Identity event exception.
      */
     private void storeMetadataToIdentityStore(String username, String tenantId, String claimURI, String value,
                                               String eventName) throws IdentityEventException {
@@ -359,9 +359,8 @@ public class IdentityUserMetadataMgtDAOImpl implements IdentityUserMetadataMgtDA
         String sqlStmt = userStoreManager.getRealmConfiguration().getUserStoreProperty(sqlStatementKey);
         if (StringUtils.isNotBlank(sqlStmt)) {
             return sqlStmt;
-        } else {
-            throw new IdentityEventException("SQL statement is not configured in the user store configuration.");
         }
+        throw new IdentityEventException("SQL statement is not configured in the user store configuration.");
     }
 
     /**
@@ -465,7 +464,7 @@ public class IdentityUserMetadataMgtDAOImpl implements IdentityUserMetadataMgtDA
                 dbConnection = DatabaseUtil.getDBConnection(dataSource);
             }
 
-            //if primary user store, DB connection can be same as realm data source.
+            // If primary user store, DB connection can be same as realm data source.
             if (dbConnection == null && realmConfiguration.isPrimary()) {
                 dbConnection = IdentityDatabaseUtil.getUserDBConnection(false);
             } else if (dbConnection == null) {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dao/impl/IdentityUserMetadataMgtDAOImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dao/impl/IdentityUserMetadataMgtDAOImpl.java
@@ -1,0 +1,508 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.recovery.dao.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.governance.internal.cache.IdentityDataStoreCache;
+import org.wso2.carbon.identity.governance.internal.cache.IdentityDataStoreCacheKey;
+import org.wso2.carbon.identity.governance.model.UserIdentityClaim;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
+import org.wso2.carbon.identity.recovery.dao.IdentityUserMetadataMgtDAO;
+import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
+import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.claim.ClaimManager;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.util.DatabaseUtil;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Locale;
+import java.util.Map;
+import javax.sql.DataSource;
+
+/**
+ * Implementation class for IdentityUserMetadataMgtDAO.
+ */
+public class IdentityUserMetadataMgtDAOImpl implements IdentityUserMetadataMgtDAO {
+
+    private static final Log log = LogFactory.getLog(IdentityUserMetadataMgtDAOImpl.class);
+
+    private final IdentityDataStoreCache identityDataStoreCache = IdentityDataStoreCache.getInstance();
+
+    @Override
+    public void updateUserMetadata(UserStoreManager userStoreManager, String username,
+                                   String claimURI, String value, String eventName) throws IdentityEventException {
+
+        if (username.contains(IdentityRecoveryConstants.TENANT_ASSOCIATION_MANAGER)) {
+            return;
+        }
+
+        String tenantId;
+        try {
+            tenantId = String.valueOf(userStoreManager.getTenantId());
+        } catch (UserStoreException e) {
+            throw new IdentityEventException(
+                    String.format("Error occurred while retrieving the tenantId of the user related to %s event.",
+                            eventName), e);
+        }
+
+        String userStoreDomain = UserCoreUtil.extractDomainFromName(username);
+        if (StringUtils.isNotBlank(userStoreDomain) && IdentityRecoveryConstants.ASGARDEO_USER_DOMAIN_NAME
+                .equalsIgnoreCase(userStoreDomain) && isStoreIdentityClaimsInUserStoreEnabled(userStoreManager)) {
+            username = UserCoreUtil.removeDomainFromName(username);
+            storeMetadataToUserStore(userStoreManager, username, tenantId, claimURI, value, eventName);
+            return;
+        }
+
+        storeMetadataToIdentityStore(username, tenantId, claimURI, value, eventName);
+    }
+
+    @Override
+    public UserIdentityClaim loadUserMetadataFromCache(UserStoreManager userStoreManager, String userName) {
+
+        try {
+            if (userName != null) {
+                userName = UserCoreUtil.removeDomainFromName(userName);
+                if (!IdentityUtil.isUserStoreCaseSensitive(userStoreManager)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Case insensitive user store found. Changing username from : " + userName +
+                                " to : " + userName.toLowerCase(Locale.ENGLISH));
+                    }
+                    userName = userName.toLowerCase(Locale.ENGLISH);
+                } else if (!IdentityUtil.isUseCaseSensitiveUsernameForCacheKeys(userStoreManager)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Case insensitive username for cache key is used. Changing username from : "
+                                + userName + " to : " + userName.toLowerCase(Locale.ENGLISH));
+                    }
+                    userName = userName.toLowerCase(Locale.ENGLISH);
+                }
+
+                String domainName = userStoreManager.getRealmConfiguration().
+                        getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
+
+                IdentityDataStoreCacheKey key = new IdentityDataStoreCacheKey(domainName, userName);
+                int tenantId = userStoreManager.getTenantId();
+                UserIdentityClaim userIdentityDTO = identityDataStoreCache.getValueFromCache(key, tenantId);
+
+                if (userIdentityDTO != null && log.isDebugEnabled()) {
+                    StringBuilder data = new StringBuilder("{");
+                    if (userIdentityDTO.getUserIdentityDataMap() != null) {
+                        for (Map.Entry<String, String> entry : userIdentityDTO.getUserIdentityDataMap().entrySet()) {
+                            data.append("[").append(entry.getKey()).append(" = ").append(entry.getValue())
+                                    .append("], ");
+                        }
+                    }
+                    if (data.indexOf(",") >= 0) {
+                        data.deleteCharAt(data.lastIndexOf(","));
+                    }
+                    data.append("}");
+                    log.debug("Loaded UserIdentityClaimsDO from cache for user :" + userName + " with claims: " + data);
+
+                }
+                return userIdentityDTO;
+            }
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            log.error("Error while obtaining tenant ID from user store manager");
+        }
+        return null;
+    }
+
+    @Override
+    public void storeUserMetadataToCache(UserStoreManager userStoreManager, UserIdentityClaim userIdentityDTO) {
+
+        try {
+            if (userIdentityDTO != null && userIdentityDTO.getUserName() != null) {
+                String userName = UserCoreUtil.removeDomainFromName(userIdentityDTO.getUserName());
+                if (!IdentityUtil.isUserStoreCaseSensitive(userStoreManager)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Case insensitive user store found. Changing username from : " + userName +
+                                " to : " + userName.toLowerCase(Locale.ENGLISH));
+                    }
+                    userName = userName.toLowerCase(Locale.ENGLISH);
+                } else if (!IdentityUtil.isUseCaseSensitiveUsernameForCacheKeys(userStoreManager)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Case insensitive username for cache key is used. Changing username from : "
+                                + userName + " to : " + userName.toLowerCase(Locale.ENGLISH));
+                    }
+                    userName = userName.toLowerCase(Locale.ENGLISH);
+                }
+
+                if (log.isDebugEnabled()) {
+                    StringBuilder data = new StringBuilder("{");
+                    if (userIdentityDTO.getUserIdentityDataMap() != null) {
+                        for (Map.Entry<String, String> entry : userIdentityDTO.getUserIdentityDataMap().entrySet()) {
+                            data.append("[").append(entry.getKey()).append(" = ")
+                                    .append(entry.getValue()).append("], ");
+                        }
+                    }
+                    if (data.indexOf(",") >= 0) {
+                        data.deleteCharAt(data.lastIndexOf(","));
+                    }
+                    data.append("}");
+                    log.debug("Storing UserIdentityClaimsDO to cache for user: " + userName + " with claims: " + data);
+                }
+
+                String domainName = userStoreManager.getRealmConfiguration().
+                        getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
+
+                IdentityDataStoreCacheKey key = new IdentityDataStoreCacheKey(domainName, userName);
+                int tenantId = userStoreManager.getTenantId();
+                UserIdentityClaim cachedUserIdentityDTO = identityDataStoreCache.getValueFromCache(key, tenantId);
+                if (cachedUserIdentityDTO != null) {
+                    cachedUserIdentityDTO.getUserIdentityDataMap().putAll(userIdentityDTO.getUserIdentityDataMap());
+                    identityDataStoreCache.addToCache(key, cachedUserIdentityDTO, tenantId);
+                } else {
+                    identityDataStoreCache.addToCache(key, userIdentityDTO, tenantId);
+                }
+            }
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            log.error("Error while obtaining tenant ID from user store manager", e);
+        }
+    }
+
+    /**
+     * Store user metadata in the user store.
+     *
+     * @param userStoreManager          User store manager
+     * @param username                  Username
+     * @param tenantId                  Tenant ID
+     * @param claimURI                  Claim URI
+     * @param value                     Claim attribute value
+     * @param eventName                 Event name
+     * @throws IdentityEventException   Identity event exception
+     */
+    private void storeMetadataToUserStore(UserStoreManager userStoreManager, String username, String tenantId,
+                                          String claimURI, String value, String eventName)
+            throws IdentityEventException {
+
+        String claimAttributeName = retrieveAttributeName(userStoreManager, tenantId, claimURI);
+        boolean executionResult;
+        try (Connection connection = getDBConnection(userStoreManager.getRealmConfiguration())) {
+            try {
+                if (isMetadataExistsInUserStore(connection, userStoreManager, tenantId, username, claimAttributeName)) {
+                    // update claim in user store
+                    executionResult = updateExistingMetadataInUserStore(connection, userStoreManager, tenantId,
+                            username, claimAttributeName, value);
+                } else {
+                    // add claim to user store
+                    executionResult = insertMetadataInUserStore(connection, userStoreManager, tenantId, username,
+                            claimAttributeName, value);
+                }
+            } catch (SQLException e) {
+                DatabaseUtil.rollBack(connection);
+                throw new IdentityEventException(String.format("Error while updating the user metadata in user store " +
+                        "related to %s event.", eventName), e);
+            }
+            connection.commit();
+        } catch (SQLException e) {
+            throw new IdentityEventException("Error while implementing database connection with user store.");
+        }
+
+        if (log.isDebugEnabled() && executionResult) {
+            log.debug(String.format("Successfully updated the user metadata related to %s event.", eventName));
+        }
+    }
+
+    /**
+     * Store user metadata in the identity store.
+     *
+     * @param username                  Username
+     * @param tenantId                  Tenant ID
+     * @param claimURI                  Claim URI
+     * @param value                     Claim attribute value
+     * @param eventName                 Event name
+     * @throws IdentityEventException   Identity event exception
+     */
+    private void storeMetadataToIdentityStore(String username, String tenantId, String claimURI, String value,
+                                              String eventName) throws IdentityEventException {
+
+        boolean executionResult;
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)) {
+            try {
+                if (isMetadataExists(connection, tenantId, username, claimURI)) {
+                    executionResult = updateExistingMetadata(connection, value, tenantId, username, claimURI);
+                } else {
+                    executionResult = insertNewMetadata(connection, value, tenantId, username, claimURI);
+                }
+            } catch (SQLException e) {
+                DatabaseUtil.rollBack(connection);
+                throw new IdentityEventException(String.format("Error while updating the user metadata in identity " +
+                        "store related to %s event.", eventName), e);
+            }
+            connection.commit();
+        } catch (SQLException e) {
+            throw new IdentityEventException(
+                    String.format("Error occurred while updating user metadata related to %s event.", eventName), e);
+        }
+
+        if (log.isDebugEnabled() && executionResult) {
+            log.debug(String.format("Successfully updated the user metadata related to %s event.", eventName));
+        }
+    }
+
+    /**
+     * Check the existence of the user metadata.
+     *
+     * @param tenantId      Tenant Id.
+     * @param username      Username.
+     * @param claimURI      Claim URI.
+     * @return              boolean value of the existence.
+     * @throws SQLException SQL Exception.
+     */
+    private boolean isMetadataExists(Connection connection, String tenantId, String username, String claimURI)
+            throws SQLException {
+
+        String sqlStmt = IdentityRecoveryConstants.SQLQueries.LOAD_USER_METADATA;
+        PreparedStatement prepStmt = connection.prepareStatement(sqlStmt);
+        prepStmt.setString(1, tenantId);
+        prepStmt.setString(2, username);
+        prepStmt.setString(3, claimURI);
+        return prepStmt.executeQuery().next();
+    }
+
+    /**
+     * Update existing user metadata.
+     *
+     * @param value         Value of the claim.
+     * @param tenantId      Tenant Id.
+     * @param username      Username.
+     * @param claimURI      Claim URI.
+     * @return              boolean value of the execution.
+     * @throws SQLException SQL Exception.
+     */
+    private boolean updateExistingMetadata(Connection connection, String value, String tenantId, String username,
+                                           String claimURI) throws SQLException {
+
+        String sqlStmt = IdentityRecoveryConstants.SQLQueries.UPDATE_USER_METADATA;
+        PreparedStatement prepStmt = connection.prepareStatement(sqlStmt);
+        prepStmt.setString(1, value);
+        prepStmt.setString(2, tenantId);
+        prepStmt.setString(3, username);
+        prepStmt.setString(4, claimURI);
+        int result = prepStmt.executeUpdate();
+        return result > 0;
+    }
+
+    /**
+     * Insert new user metadata.
+     *
+     * @param value         Value of the claim.
+     * @param tenantId      Tenant Id.
+     * @param username      Username.
+     * @param claimURI      Claim URI.
+     * @return              boolean value of the execution.
+     * @throws SQLException SQL Exception.
+     */
+    private boolean insertNewMetadata(Connection connection, String value, String tenantId, String username,
+                                      String claimURI) throws SQLException {
+
+        String sqlStmt = IdentityRecoveryConstants.SQLQueries.INSERT_USER_METADATA;
+        PreparedStatement prepStmt = connection.prepareStatement(sqlStmt);
+        prepStmt.setString(1, tenantId);
+        prepStmt.setString(2, username);
+        prepStmt.setString(3, claimURI);
+        prepStmt.setString(4, value);
+        int result = prepStmt.executeUpdate();
+        return result > 0;
+    }
+
+    /**
+     * Check weather the given user store has enabled the property "StoreIdentityClaims" to store identity claims
+     * in the user store.
+     *
+     * @param userStoreManager  User Store manager.
+     * @return                  Whether identity claims are stored in user store or not.
+     */
+    private boolean isStoreIdentityClaimsInUserStoreEnabled(UserStoreManager userStoreManager) {
+
+        return Boolean.parseBoolean(userStoreManager.getRealmConfiguration().
+                getUserStoreProperty(IdentityRecoveryConstants.STORE_IDENTITY_CLAIMS));
+    }
+
+    /**
+     * Fetch relevant SQL statement from user store configuration.
+     *
+     * @param userStoreManager          User Store manager.
+     * @param sqlStatementKey           Property name of the SQL statement.
+     * @return                          SQL statement string.
+     * @throws IdentityEventException   Error while fetching the SQL statement.
+     */
+    private String fetchSQLStatementFromUserStoreConfig(UserStoreManager userStoreManager, String sqlStatementKey)
+            throws IdentityEventException {
+
+        String sqlStmt = userStoreManager.getRealmConfiguration().getUserStoreProperty(sqlStatementKey);
+        if (StringUtils.isNotBlank(sqlStmt)) {
+            return sqlStmt;
+        } else {
+            throw new IdentityEventException("SQL statement is not configured in the user store configuration.");
+        }
+    }
+
+    /**
+     * Check the existence of the user metadata in user store.
+     *
+     * @param userStoreManager      UserStoreManager.
+     * @param tenantId              Tenant Id.
+     * @param username              Username.
+     * @param claimAttributeName    Claim attribute name.
+     * @return                      boolean value of the existence.
+     * @throws SQLException         SQL Exception.
+     */
+    private boolean isMetadataExistsInUserStore(Connection connection, UserStoreManager userStoreManager,
+                                                String tenantId, String username, String claimAttributeName)
+            throws IdentityEventException, SQLException {
+
+        String sqlStmt = fetchSQLStatementFromUserStoreConfig(userStoreManager,
+                IdentityRecoveryConstants.SQLQueries.LOAD_USER_METADATA_FROM_USER_STORE_SQL_KEY);
+
+        PreparedStatement prepStmt = connection.prepareStatement(sqlStmt);
+        prepStmt.setString(1, username);
+        prepStmt.setString(2, claimAttributeName);
+        prepStmt.setString(3, UserCoreConstants.DEFAULT_PROFILE);
+        prepStmt.setString(4, tenantId);
+        prepStmt.setString(5, tenantId);
+        return prepStmt.executeQuery().next();
+    }
+
+    /**
+     * Update existing user metadata in user store.
+     *
+     * @param userStoreManager      UserStoreManager.
+     * @param tenantId              Tenant Id.
+     * @param username              Username.
+     * @param claimAttributeName    Claim attribute name.
+     * @param value                 Value of the claim.
+     * @return                      boolean value of the execution.
+     * @throws SQLException         SQL Exception.
+     */
+    private boolean updateExistingMetadataInUserStore(Connection connection, UserStoreManager userStoreManager,
+                                                      String tenantId, String username, String claimAttributeName,
+                                                      String value) throws SQLException, IdentityEventException {
+
+        String sqlStmt = fetchSQLStatementFromUserStoreConfig(userStoreManager,
+                IdentityRecoveryConstants.SQLQueries.UPDATE_USER_METADATA_TO_USER_STORE_SQL_KEY);
+
+        PreparedStatement prepStmt = connection.prepareStatement(sqlStmt);
+        prepStmt.setString(1, value);
+        prepStmt.setString(2, username);
+        prepStmt.setString(3, tenantId);
+        prepStmt.setString(4, claimAttributeName);
+        prepStmt.setString(5, UserCoreConstants.DEFAULT_PROFILE);
+        prepStmt.setString(6, tenantId);
+        int result = prepStmt.executeUpdate();
+        return result > 0;
+    }
+
+    /**
+     * Insert new user metadata in user store.
+     *
+     * @param userStoreManager      UserStoreManager.
+     * @param tenantId              Tenant Id.
+     * @param username              Username.
+     * @param claimAttributeName    Claim attribute name.
+     * @param value                 Value of the claim.
+     * @return                      boolean value of the execution.
+     * @throws SQLException         SQL Exception.
+     */
+    private boolean insertMetadataInUserStore(Connection connection, UserStoreManager userStoreManager, String tenantId,
+                                              String username, String claimAttributeName, String value)
+            throws SQLException, IdentityEventException {
+
+        String sqlStmt = fetchSQLStatementFromUserStoreConfig(userStoreManager,
+                IdentityRecoveryConstants.SQLQueries.INSERT_USER_METADATA_TO_USER_STORE_SQL_KEY);
+
+        PreparedStatement prepStmt = connection.prepareStatement(sqlStmt);
+        prepStmt.setString(1, username);
+        prepStmt.setString(2, tenantId);
+        prepStmt.setString(3, claimAttributeName);
+        prepStmt.setString(4, value);
+        prepStmt.setString(5, UserCoreConstants.DEFAULT_PROFILE);
+        prepStmt.setString(6, tenantId);
+        int result = prepStmt.executeUpdate();
+        return result > 0;
+    }
+
+    /**
+     * Get database connection.
+     *
+     * @param realmConfiguration        Realm configuration.
+     * @return                          Database connection.
+     * @throws IdentityEventException   Identity event exception.
+     */
+    private Connection getDBConnection(RealmConfiguration realmConfiguration) throws IdentityEventException {
+
+        Connection dbConnection = null;
+        DataSource dataSource = DatabaseUtil.createUserStoreDataSource(realmConfiguration);
+
+        try {
+            if (dataSource != null) {
+                dbConnection = DatabaseUtil.getDBConnection(dataSource);
+            }
+
+            //if primary user store, DB connection can be same as realm data source.
+            if (dbConnection == null && realmConfiguration.isPrimary()) {
+                dbConnection = IdentityDatabaseUtil.getUserDBConnection(false);
+            } else if (dbConnection == null) {
+                throw new org.wso2.carbon.user.api.UserStoreException("Could not create a database connection to " +
+                        realmConfiguration.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME));
+            }
+            dbConnection.setAutoCommit(false);
+            dbConnection.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+            return dbConnection;
+        } catch (SQLException | org.wso2.carbon.user.api.UserStoreException e) {
+            throw new IdentityEventException("Error occurred while getting DB connection", e);
+        }
+    }
+
+    /**
+     * Get the claim attribute name.
+     *
+     * @param userStoreManager          User store manager.
+     * @param tenantId                  Tenant Id.
+     * @param claimURI                  Claim URI.
+     * @return                          Claim attribute name.
+     * @throws IdentityEventException   Identity event exception.
+     */
+    private String retrieveAttributeName(UserStoreManager userStoreManager, String tenantId,
+                                         String claimURI) throws IdentityEventException {
+
+        ClaimManager claimManager;
+        String claimAttributeName;
+        RealmService realmService = IdentityRecoveryServiceDataHolder.getInstance().getRealmService();
+        try {
+            claimManager = (ClaimManager) realmService.getTenantUserRealm(Integer.parseInt(tenantId)).getClaimManager();
+            String userStoreDomain = userStoreManager.getRealmConfiguration().
+                    getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
+            claimAttributeName = claimManager.getAttributeName(userStoreDomain, claimURI);
+            return claimAttributeName;
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            throw new IdentityEventException("Error while retrieving claimAttributeName using claim manager.", e);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dao/impl/IdentityUserMetadataMgtDAOImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/dao/impl/IdentityUserMetadataMgtDAOImpl.java
@@ -59,10 +59,6 @@ public class IdentityUserMetadataMgtDAOImpl implements IdentityUserMetadataMgtDA
     public void updateUserMetadata(UserStoreManager userStoreManager, String username,
                                    String claimURI, String value, String eventName) throws IdentityEventException {
 
-        if (username.contains(IdentityRecoveryConstants.TENANT_ASSOCIATION_MANAGER)) {
-            return;
-        }
-
         String tenantId;
         try {
             tenantId = String.valueOf(userStoreManager.getTenantId());

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/IdentityUserMetadataMgtHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/IdentityUserMetadataMgtHandler.java
@@ -90,10 +90,10 @@ public class IdentityUserMetadataMgtHandler extends AbstractEventHandler {
                 if (username.contains(IdentityRecoveryConstants.TENANT_ASSOCIATION_MANAGER)) {
                     return;
                 }
-                // update data in db
+                // Update data in db.
                 identityUserMetadataMgtDAO.updateUserMetadata(userStoreManager, username,
                         IdentityMgtConstants.LAST_LOGIN_TIME, lastLoginTime, POST_AUTHENTICATION);
-                //update cache
+                // Update cache.
                 updateUserIdentityCache(userStoreManager, username, IdentityMgtConstants.LAST_LOGIN_TIME, lastLoginTime);
                 return;
             }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/IdentityUserMetadataMgtHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/IdentityUserMetadataMgtHandler.java
@@ -69,7 +69,8 @@ public class IdentityUserMetadataMgtHandler extends AbstractEventHandler {
             }
             return;
         }
-        if (IdentityEventConstants.Event.POST_AUTHENTICATION.equals(event.getEventName())) {
+        if (IdentityEventConstants.Event.POST_AUTHENTICATION.equals(event.getEventName()) ||
+                IdentityEventConstants.Event.POST_AUTH_STORE_LAST_LOGIN.equals(event.getEventName())) {
             handlePostAuthenticate(eventProperties, userStoreManager, enableDao);
         } else if (IdentityEventConstants.Event.POST_UPDATE_CREDENTIAL.equals(event.getEventName()) ||
                 IdentityEventConstants.Event.POST_UPDATE_CREDENTIAL_BY_ADMIN.equals(event.getEventName())) {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/IdentityUserMetadataMgtHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/IdentityUserMetadataMgtHandler.java
@@ -50,7 +50,17 @@ public class IdentityUserMetadataMgtHandler extends AbstractEventHandler {
     private static final String ENABLE_IDENTITY_USER_METADATA_MGT_HANDLER = "identityUserMetadataMgtHandler.enable";
     private static final String USE_DAO_FOR_USER_METADATA_UPDATE = "identityUserMetadataMgtHandler.enableDAO";
 
-    private final IdentityUserMetadataMgtDAO identityUserMetadataMgtDAO = new IdentityUserMetadataMgtDAOImpl();
+    private IdentityUserMetadataMgtDAO identityUserMetadataMgtDAO;
+
+    /**
+     * Constructor of the handler.
+     *
+     * @param identityUserMetadataMgtDAO DAO for identity user metadata management.
+     */
+    public IdentityUserMetadataMgtHandler(IdentityUserMetadataMgtDAO identityUserMetadataMgtDAO) {
+
+        this.identityUserMetadataMgtDAO = identityUserMetadataMgtDAO;
+    }
 
     @Override
     public void handleEvent(Event event) throws IdentityEventException {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
@@ -53,6 +53,8 @@ import org.wso2.carbon.identity.recovery.connector.UserClaimUpdateConfigImpl;
 import org.wso2.carbon.identity.recovery.connector.RecoveryConfigImpl;
 import org.wso2.carbon.identity.recovery.connector.SelfRegistrationConfigImpl;
 import org.wso2.carbon.identity.recovery.connector.UserEmailVerificationConfigImpl;
+import org.wso2.carbon.identity.recovery.dao.IdentityUserMetadataMgtDAO;
+import org.wso2.carbon.identity.recovery.dao.impl.IdentityUserMetadataMgtDAOImpl;
 import org.wso2.carbon.identity.recovery.handler.AccountConfirmationValidationHandler;
 import org.wso2.carbon.identity.recovery.handler.AdminForcedPasswordResetHandler;
 import org.wso2.carbon.identity.recovery.handler.ChallengeAnswerValidationHandler;
@@ -119,8 +121,9 @@ public class IdentityRecoveryServiceComponent {
                     , null);
             bundleContext.registerService(AbstractEventHandler.class.getName(),
                     new TenantRegistrationVerificationHandler(), null);
-            bundleContext.registerService(AbstractEventHandler.class.getName(), new IdentityUserMetadataMgtHandler(),
-                    null);
+            IdentityUserMetadataMgtDAO identityUserMetadataMgtDAO = new IdentityUserMetadataMgtDAOImpl();
+            bundleContext.registerService(AbstractEventHandler.class.getName(),
+                    new IdentityUserMetadataMgtHandler(identityUserMetadataMgtDAO), null);
             bundleContext.registerService(IdentityConnectorConfig.class.getName(), new RecoveryConfigImpl(), null);
             bundleContext.registerService(IdentityConnectorConfig.class.getName(), new SelfRegistrationConfigImpl(),
                     null);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1436,4 +1436,13 @@ public class Utils {
         stringBuilder.deleteCharAt(stringBuilder.length() - 1);
         return stringBuilder.toString();
     }
+
+    public static String buildUserNameWithDomain(org.wso2.carbon.user.core.UserStoreManager userStoreManager,
+                                                 Map<String, Object> eventProperties) {
+
+        String username = (String) eventProperties.get(IdentityEventConstants.EventProperty.USER_NAME);
+        String userStoreDomain = userStoreManager.getRealmConfiguration().
+                getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
+        return UserCoreUtil.addDomainToName(username, userStoreDomain);
+    }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1438,9 +1438,12 @@ public class Utils {
     }
 
     public static String buildUserNameWithDomain(org.wso2.carbon.user.core.UserStoreManager userStoreManager,
-                                                 Map<String, Object> eventProperties) {
+                                                 Map<String, Object> eventProperties) throws IdentityEventException {
 
         String username = (String) eventProperties.get(IdentityEventConstants.EventProperty.USER_NAME);
+        if (StringUtils.isBlank(username)) {
+            throw new IdentityEventException("Username is not found in the event properties.");
+        }
         String userStoreDomain = userStoreManager.getRealmConfiguration().
                 getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
         return UserCoreUtil.addDomainToName(username, userStoreDomain);


### PR DESCRIPTION
### Proposed changes in this pull request

- Instead of using `userStoreManager.setUserClaimValues()` method to store the last login time of the user, a DAO layer is written to execute the relevant SQL statements to store it. This will avoid invoking unnecessary listeners in the UserStoreManager's method.

### When should this PR be merged

A new event has been introduced related to the implementation. This PR should be merged after merging the below given PR and bumping the framework version in identity-governance 
- https://github.com/wso2/carbon-identity-framework/pull/4612

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
