### PR TITLE
Update user roles claim in recovery constants

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -115,7 +115,7 @@ public class IdentityRecoveryConstants {
     public static final String TENANT_ADMIN_ASK_PASSWORD_CLAIM =
             "http://wso2.org/claims/identity/tenantAdminAskPassword";
     public static final String OTP_PASSWORD_CLAIM = "http://wso2.org/claims/oneTimePassword";
-    public static final String USER_ROLES_CLAIM = "http://wso2.org/claims/role";
+    public static final String USER_ROLES_CLAIM = "http://wso2.org/claims/roles";
     public static final String EMAIL_ADDRESS_CLAIM = "http://wso2.org/claims/emailaddress";
     public static final String MOBILE_NUMBER_CLAIM = "http://wso2.org/claims/mobile";
     public static final String DEFAULT_CHALLENGE_QUESTION_SEPARATOR = "!";


### PR DESCRIPTION
With the task [1], `http://wso2.org/claims/roles` claim has been introduced which contains internal roles, and made `http://wso2.org/claims/role` claim a legacy claim. Hence, this PR update the user roles claim value from `http://wso2.org/claims/role` to `http://wso2.org/claims/roles`.

[1] https://github.com/wso2/product-is/issues/11327