### PR TITLE
Remove SHA1 default usage

### DIFF
--- a/components/org.wso2.carbon.identity.password.history/src/main/java/org/wso2/carbon/identity/password/history/store/Impl/DefaultPasswordHistoryDataStore.java
+++ b/components/org.wso2.carbon.identity.password.history/src/main/java/org/wso2/carbon/identity/password/history/store/Impl/DefaultPasswordHistoryDataStore.java
@@ -45,7 +45,7 @@ import java.util.Locale;
  * This interface provides to plug module for preferred persistence store.
  */
 public class DefaultPasswordHistoryDataStore implements PasswordHistoryDataStore {
-    private static final String SHA_1_PRNG = "SHA1PRNG";
+    private static final String RANDOM_ALG_DRBG = "DRBG";
     private static final Log log = LogFactory.getLog(DefaultPasswordHistoryDataStore.class);
     private String digestFunction;
     private int maxHistoryCount;
@@ -228,13 +228,13 @@ public class DefaultPasswordHistoryDataStore implements PasswordHistoryDataStore
     private String generateSaltValue() {
         String saltValue;
         try {
-            SecureRandom secureRandom = SecureRandom.getInstance(SHA_1_PRNG);
+            SecureRandom secureRandom = SecureRandom.getInstance(RANDOM_ALG_DRBG);
             byte[] bytes = new byte[16];
             //secureRandom is automatically seeded by calling nextBytes
             secureRandom.nextBytes(bytes);
             saltValue = Base64.encode(bytes);
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("SHA1PRNG algorithm could not be found.");
+            throw new RuntimeException("DRBG algorithm could not be found.");
         }
         return saltValue;
     }


### PR DESCRIPTION
## Proposed changes in this pull request

The default behavior of our products uses SHA1 which is no longer considered as secure. This PR changes the default usage to SHA256 in the following flows.
- Password salt generation used when saving password history will be done using DRBG algorithm instead of SHA1PRNG.

## Related issues
 
- Issue https://github.com/wso2/product-is/issues/15793

## Related PRs

- PR https://github.com/wso2/carbon-identity-framework/pull/4567
- PR https://github.com/wso2-extensions/identity-outbound-auth-samlsso/pull/162
- PR https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/136
- PR https://github.com/wso2-extensions/identity-metadata-saml2/pull/85
- PR https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2076
- PR https://github.com/wso2/cipher-tool/pull/78
- PR https://github.com/wso2/carbon-kernel/pull/3574
- PR https://github.com/wso2-extensions/identity-user-account-association/pull/47
- PR https://github.com/wso2-enterprise/asgardeo-website/pull/639
- PR https://github.com/wso2-extensions/identity-governance/pull/707
- PR https://github.com/wso2-extensions/identity-inbound-auth-openid/pull/92
- PR https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/173
- PR https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/157

## Documentation

- PR https://github.com/wso2/docs-is/pull/3717