### PR TITLE
Add Generic Recaptcha Validation Support for Local Authenticators

### DIFF
--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/GenericAuthenticatorReCaptchaConnector.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/GenericAuthenticatorReCaptchaConnector.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.org).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.captcha.connector.recaptcha;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.captcha.connector.CaptchaPostValidationResponse;
+import org.wso2.carbon.identity.captcha.connector.CaptchaPreValidationResponse;
+import org.wso2.carbon.identity.captcha.exception.CaptchaException;
+import org.wso2.carbon.identity.captcha.util.CaptchaConstants;
+import org.wso2.carbon.identity.captcha.util.CaptchaUtil;
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+/**
+ * This class handles the generic ReCaptcha validation for local authenticators.
+ */
+public class GenericAuthenticatorReCaptchaConnector extends AbstractReCaptchaConnector {
+
+    private static final String IDF = "IdentifierExecutor";
+
+    @Override
+    public void init(IdentityGovernanceService identityGovernanceService) {
+
+    }
+
+    @Override
+    public int getPriority() {
+
+        // Giving the lowest priority for the generic captcha connector, as any custom captcha connector
+        // should have a higher priority than this.
+        return 2;
+    }
+
+    @Override
+    public boolean canHandle(ServletRequest servletRequest, ServletResponse servletResponse)
+            throws CaptchaException {
+
+        String sessionDataKey = servletRequest.getParameter(FrameworkUtils.SESSION_DATA_KEY);
+        if (StringUtils.isBlank(sessionDataKey)) {
+            return false;
+        }
+        AuthenticationContext context = FrameworkUtils.getAuthenticationContextFromCache(sessionDataKey);
+
+        return context != null && context.getCurrentAuthenticator() != null &&
+                CaptchaUtil.isGenericRecaptchaEnabledAuthenticator(context.getCurrentAuthenticator());
+    }
+
+    @Override
+    public CaptchaPreValidationResponse preValidate(ServletRequest servletRequest, ServletResponse servletResponse) {
+
+        CaptchaPreValidationResponse preValidationResponse = new CaptchaPreValidationResponse();
+
+        Map<String, String> params = new HashMap<>();
+        params.put(CaptchaConstants.RE_CAPTCHA, CaptchaConstants.TRUE);
+        params.put(CaptchaConstants.AUTH_FAILURE, CaptchaConstants.TRUE);
+        params.put(CaptchaConstants.AUTH_FAILURE_MSG, CaptchaConstants.RECAPTCHA_FAIL_MSG_KEY);
+        preValidationResponse.setCaptchaAttributes(params);
+        preValidationResponse.setCaptchaValidationRequired(true);
+
+        String sessionDataKey = servletRequest.getParameter(FrameworkUtils.SESSION_DATA_KEY);
+        if (StringUtils.isNotBlank(sessionDataKey)) {
+            AuthenticationContext context = FrameworkUtils.getAuthenticationContextFromCache(sessionDataKey);
+            if (context != null) {
+                String authenticator = context.getCurrentAuthenticator();
+                // Currently, we are only adding the failed login URLs for the identifier first authenticator.
+                // This could be done for any other authenticators as well, when extending the connector's support
+                // for other authenticators.
+                if (StringUtils.isNotBlank(authenticator) && authenticator.equals(IDF)) {
+                    preValidationResponse.setOnCaptchaFailRedirectUrls(CaptchaUtil.getOnFailedLoginUrls());
+                }
+            }
+        }
+
+        return preValidationResponse;
+    }
+
+    @Override
+    public CaptchaPostValidationResponse postValidate(ServletRequest servletRequest, ServletResponse servletResponse)
+            throws CaptchaException {
+
+        // No post validation required.
+        return null;
+    }
+}

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/SSOLoginReCaptchaConfig.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/SSOLoginReCaptchaConfig.java
@@ -38,16 +38,14 @@ import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 
+import static org.wso2.carbon.identity.captcha.util.CaptchaConstants.AUTH_FAILURE;
 import static org.wso2.carbon.identity.captcha.util.CaptchaConstants.ConnectorConfig.SSO_LOGIN_RECAPTCHA_ENABLED;
 import static org.wso2.carbon.identity.captcha.util.CaptchaConstants.ConnectorConfig.SSO_LOGIN_RECAPTCHA_ENABLE_ALWAYS;
 import static org.wso2.carbon.identity.captcha.util.CaptchaConstants.ConnectorConfig.SSO_LOGIN_RECAPTCHA_MAX_ATTEMPTS;
@@ -64,7 +62,6 @@ public class SSOLoginReCaptchaConfig extends AbstractReCaptchaConnector implemen
     private static final String CONNECTOR_IDENTIFIER_ATTRIBUTE = "username,password";
     private static final String RECAPTCHA_VERIFICATION_CLAIM = "http://wso2.org/claims/identity/failedLoginAttempts";
     private static final String SECURED_DESTINATIONS = "/commonauth,/samlsso,/oauth2";
-    private static final String ON_FAIL_REDIRECT_URL = "/authenticationendpoint/login.do";
 
     private IdentityGovernanceService identityGovernanceService;
 
@@ -127,10 +124,10 @@ public class SSOLoginReCaptchaConfig extends AbstractReCaptchaConnector implemen
                 connectorConfigs.length != 0 && (Boolean.valueOf(connectorConfigs[0].getValue())))) {
 
             Map<String, String> params = new HashMap<>();
-            params.put("authFailure", "true");
-            params.put("authFailureMsg", "recaptcha.fail.message");
+            params.put(AUTH_FAILURE, CaptchaConstants.TRUE);
+            params.put(CaptchaConstants.AUTH_FAILURE_MSG, CaptchaConstants.RECAPTCHA_FAIL_MSG_KEY);
             preValidationResponse.setCaptchaAttributes(params);
-            preValidationResponse.setOnCaptchaFailRedirectUrls(getFailedUrlList());
+            preValidationResponse.setOnCaptchaFailRedirectUrls(CaptchaUtil.getOnFailedLoginUrls());
             preValidationResponse.setCaptchaValidationRequired(true);
 
         } else if (CaptchaUtil.isMaximumFailedLoginAttemptsReached(MultitenantUtils.getTenantAwareUsername(username),
@@ -138,11 +135,11 @@ public class SSOLoginReCaptchaConfig extends AbstractReCaptchaConnector implemen
             preValidationResponse.setCaptchaValidationRequired(true);
             preValidationResponse.setMaxFailedLimitReached(true);
 
-            preValidationResponse.setOnCaptchaFailRedirectUrls(getFailedUrlList());
+            preValidationResponse.setOnCaptchaFailRedirectUrls(CaptchaUtil.getOnFailedLoginUrls());
             Map<String, String> params = new HashMap<>();
-            params.put("reCaptcha", "true");
-            params.put("authFailure", "true");
-            params.put("authFailureMsg", "recaptcha.fail.message");
+            params.put(CaptchaConstants.RE_CAPTCHA, CaptchaConstants.TRUE);
+            params.put(CaptchaConstants.AUTH_FAILURE, CaptchaConstants.TRUE);
+            params.put(CaptchaConstants.AUTH_FAILURE_MSG, CaptchaConstants.RECAPTCHA_FAIL_MSG_KEY);
             preValidationResponse.setCaptchaAttributes(params);
         }
         // Post validate all requests
@@ -162,7 +159,7 @@ public class SSOLoginReCaptchaConfig extends AbstractReCaptchaConnector implemen
             validationResponse.setSuccessfulAttempt(false);
             validationResponse.setEnableCaptchaResponsePath(true);
             Map<String, String> params = new HashMap<>();
-            params.put("reCaptcha", "true");
+            params.put(CaptchaConstants.RE_CAPTCHA, CaptchaConstants.TRUE);
             validationResponse.setCaptchaAttributes(params);
             return validationResponse;
         }
@@ -282,25 +279,6 @@ public class SSOLoginReCaptchaConfig extends AbstractReCaptchaConnector implemen
             throws IdentityGovernanceException {
 
         return null;
-    }
-
-    /**
-     * Get the URLs  which need to send back in case of failure.
-     *
-     * @return list of failed urls
-     */
-    private List<String> getFailedUrlList() {
-
-        List<String> failedRedirectUrls = new ArrayList<>();
-
-        String failedRedirectUrlStr = CaptchaDataHolder.getInstance().getReCaptchaErrorRedirectUrls();
-
-        if (StringUtils.isNotBlank(failedRedirectUrlStr)) {
-            failedRedirectUrls = new ArrayList<>(Arrays.asList(failedRedirectUrlStr.split(",")));
-        }
-
-        failedRedirectUrls.add(ON_FAIL_REDIRECT_URL);
-        return failedRedirectUrls;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaComponent.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaComponent.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.ComponentContext;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticationDataPublisher;
 import org.wso2.carbon.identity.captcha.connector.CaptchaConnector;
+import org.wso2.carbon.identity.captcha.connector.recaptcha.GenericAuthenticatorReCaptchaConnector;
 import org.wso2.carbon.identity.captcha.connector.recaptcha.LiteUserSelfSignUpReCaptchaConnector;
 import org.wso2.carbon.identity.captcha.connector.recaptcha.PasswordRecoveryReCaptchaConnector;
 import org.wso2.carbon.identity.captcha.connector.recaptcha.ResendConfirmationReCaptchaConnector;
@@ -81,6 +82,11 @@ public class CaptchaComponent {
             captchaConnector = new LiteUserSelfSignUpReCaptchaConnector();
             captchaConnector.init(CaptchaDataHolder.getInstance().getIdentityGovernanceService());
             CaptchaDataHolder.getInstance().addCaptchaConnector(captchaConnector);
+            // Initialize and register GenericReCaptchaConnector.
+            captchaConnector = new GenericAuthenticatorReCaptchaConnector();
+            captchaConnector.init(CaptchaDataHolder.getInstance().getIdentityGovernanceService());
+            CaptchaDataHolder.getInstance().addCaptchaConnector(captchaConnector);
+            // Initialize and register AccountRecoveryReCaptchaConnector.
             AuthenticationDataPublisher failedLoginAttemptValidator = new FailLoginAttemptValidator();
             context.getBundleContext().registerService(AuthenticationDataPublisher.class,
                     failedLoginAttemptValidator, null);

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaComponent.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaComponent.java
@@ -89,7 +89,6 @@ public class CaptchaComponent {
             CaptchaDataHolder.getInstance().addCaptchaConnector(captchaConnector);
             // Initialize and register EmailOTPRecaptchaConnector.
             captchaConnector = new EmailOTPCaptchaConnector();
-            // Initialize and register AccountRecoveryReCaptchaConnector.
             captchaConnector.init(CaptchaDataHolder.getInstance().getIdentityGovernanceService());
             CaptchaDataHolder.getInstance().addCaptchaConnector(captchaConnector);
             AuthenticationDataPublisher failedLoginAttemptValidator = new FailLoginAttemptValidator();

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaConstants.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaConstants.java
@@ -28,6 +28,7 @@ public class CaptchaConstants {
     public static final String CARBON_HOME = "carbon.home";
 
     public static final String ERROR_PAGE = "/authenticationendpoint/retry.do";
+    public static final String ON_FAILED_LOGIN_REDIRECT_URL = "/authenticationendpoint/login.do";
 
     public static final String CAPTCHA_CONFIG_FILE_NAME = "captcha-config.properties";
 
@@ -59,6 +60,12 @@ public class CaptchaConstants {
     public static final String CAPTCHA_SCORE = "score";
 
     public static final String CAPTCHA_SUCCESS = "success";
+    public static final String ENABLE_GENERIC_CAPTCHA_VALIDATION = "enable_captcha_validation";
+    public static final String RE_CAPTCHA = "reCaptcha";
+    public static final String AUTH_FAILURE = "authFailure";
+    public static final String AUTH_FAILURE_MSG = "authFailureMsg";
+    public static final String RECAPTCHA_FAIL_MSG_KEY = "recaptcha.fail.message";
+    public static final String TRUE = "true";
 
     // Default value for threshold for score in reCAPTCHA v3.
     public static final double CAPTCHA_V3_DEFAULT_THRESHOLD = 0.5;

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaUtil.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaUtil.java
@@ -71,6 +71,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -79,6 +80,8 @@ import java.util.Properties;
 import javax.servlet.ServletRequest;
 
 import static org.wso2.carbon.identity.captcha.util.CaptchaConstants.BASIC_AUTH_MECHANISM;
+import static org.wso2.carbon.identity.captcha.util.CaptchaConstants.ENABLE_GENERIC_CAPTCHA_VALIDATION;
+import static org.wso2.carbon.identity.captcha.util.CaptchaConstants.ON_FAILED_LOGIN_REDIRECT_URL;
 import static org.wso2.carbon.identity.captcha.util.CaptchaConstants.ReCaptchaConnectorPropertySuffixes;
 
 /**
@@ -747,5 +750,44 @@ public class CaptchaUtil {
             }
         }
         return Boolean.parseBoolean(enable);
+    }
+
+    /**
+     * Check whether generic ReCaptcha validation is enabled for the given authenticator.
+     * This method is used by the jsp pages to check whether the ReCaptcha validation is enabled for the current
+     * authenticator.
+     *
+     * @param authenticatorName Name of the authenticator.
+     * @return True if generic ReCaptcha validation is enabled.
+     */
+    public static boolean isGenericRecaptchaEnabledAuthenticator(String authenticatorName) {
+
+        if (StringUtils.isBlank(authenticatorName)) {
+            return false;
+        }
+        AuthenticatorConfig authenticatorConfig =
+                ConfigurationFacade.getInstance().getAuthenticatorConfig(authenticatorName);
+
+        Map<String, String> params = authenticatorConfig.getParameterMap();
+
+        return params != null && params.get(ENABLE_GENERIC_CAPTCHA_VALIDATION) != null &&
+                Boolean.parseBoolean(params.get(ENABLE_GENERIC_CAPTCHA_VALIDATION));
+    }
+
+    /**
+     * Get the URLs  which need to send back in case of captcha failure in login.
+     *
+     * @return list of failed urls
+     */
+    public static List<String> getOnFailedLoginUrls() {
+
+        List<String> failedRedirectUrls = new ArrayList<>();
+        String failedRedirectUrlStr = CaptchaDataHolder.getInstance().getReCaptchaErrorRedirectUrls();
+        if (StringUtils.isNotBlank(failedRedirectUrlStr)) {
+            failedRedirectUrls = new ArrayList<>(Arrays.asList(failedRedirectUrlStr.split(",")));
+        }
+        failedRedirectUrls.add(ON_FAILED_LOGIN_REDIRECT_URL);
+
+        return failedRedirectUrls;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -661,7 +661,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.203-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.207</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.20.211, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -661,7 +661,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.98</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.203-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.20.211, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request

$subject. 

This PR adds a generic ReCaptcha connector that would make it possible to enable ReCaptcha validation to local authenticators, where validation is carried out with the most basic form. 

### When should this PR be merged

This PR should be merged once the identity-apps PR and the framework PR is merged. 
