### PR TITLE
Check 'StoreIdentityClaims' property, user wise due to multiple userstores.

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
@@ -670,8 +670,7 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
         UserStoreManager userStoreManager = getUserStoreManager();
 
         // No need to separately handle if identity data store is user store based.
-        if (identityDataStore instanceof UserStoreBasedIdentityDataStore ||
-                isStoreIdentityClaimsInUserStoreEnabled(userStoreManager)) {
+        if (identityDataStore instanceof UserStoreBasedIdentityDataStore) {
             return true;
         }
 
@@ -698,6 +697,12 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
                     log.debug("Username found to be null while method doPostGetUsersClaimValues getting executed in " +
                             "the IdentityStoreEventListener.");
                 }
+                continue;
+            }
+
+            // No need to separately handle if identity data store is user store based for the users' userstore domain.
+            if (isStoreIdentityClaimsInUserStoreEnabled(userStoreManager
+                    .getSecondaryUserStoreManager(UserCoreUtil.extractDomainFromName(username)))) {
                 continue;
             }
 


### PR DESCRIPTION
### Proposed changes in this pull request

- To the `doPostGetUsersClaimValues` method we don't pass the userstore of the users since there can be many users from different userstores. 
- So when deciding the user's identity claim retrieving place(identity claims are in userstore/identity db) we need to check value of `StoreIdentityClaims` in all the users's userstore before retrieving identity claims.
- Previously we have checked this property only in the primary userstore. Due to that if we enabled `StoreIdentityClaims` property in primary userstore, from `scim/Users` endpoint only return the identity claims of PRIMARY userstore users. 

