### PR TITLE
Fix erroneous addition and retrival of lite user identity claims

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
@@ -705,6 +705,16 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
                 userClaimSearchEntry.setClaims(new HashMap<String, String>());
             }
 
+            if (!isHybridDataStoreEnable) {
+                /*
+                If hybrid data store is disabled, we need to use the identity claim value only from the identity data
+                store. Hence, we need to remove the identity claim values from the claimMap to avoid use of values from
+                user store for identity claims.
+                 */
+                userClaimSearchEntry.getClaims().entrySet().removeIf(
+                        entry -> entry.getKey().contains(UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI_PREFIX));
+            }
+
             // There is/are identity claim/s load the dto.
             UserIdentityClaim identityDTO = identityDataStoreService
                     .getIdentityClaimData(userClaimSearchEntry.getUserName(), userStoreManager

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -1744,9 +1744,8 @@ public class UserSelfRegistrationManager {
                         .isNotEmpty(preferredChannel)) {
                     claimsMap.put(IdentityRecoveryConstants.PREFERRED_CHANNEL_CLAIM, preferredChannel);
                 }
-                userStoreManager
-                        .addUser(IdentityUtil.addDomainToName(user.getUserName(), user.getUserStoreDomain()), Utils.generateRandomPassword(12),
-                                userRoles, claimsMap, null);
+                userStoreManager.addUser(IdentityUtil.addDomainToName(user.getUserName(), user.getUserStoreDomain()),
+                        new String(Utils.generateRandomPassword(12)), userRoles, claimsMap, null);
             } catch (UserStoreException e) {
                 Throwable cause = e;
                 while (cause != null) {


### PR DESCRIPTION
### Purpose
To fix - https://github.com/wso2/product-is/issues/16187

### Approach
In adduser we are expecting the credential object as a String.
https://github.com/wso2/carbon-kernel/blob/174bfdf78b62012cd6e1f1c603a87d8338e31ce4/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java#L4898-L4909

