### PR TITLE
[DRAFT] Re-issue existing confirmation code for self registration and ask-pasword flows.

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1279,7 +1279,11 @@ public class Utils {
         int codeToleranceInMinutes = getEmailCodeToleranceInMinutes();
         if (recoveryDataDO != null && codeToleranceInMinutes != 0) {
             if (RecoveryScenarios.NOTIFICATION_BASED_PW_RECOVERY.toString().
-                    equals(recoveryDataDO.getRecoveryScenario().toString())) {
+                    equals(recoveryDataDO.getRecoveryScenario().toString()) ||
+                    RecoveryScenarios.SELF_SIGN_UP.toString().
+                            equals(recoveryDataDO.getRecoveryScenario().toString()) ||
+                    RecoveryScenarios.ASK_PASSWORD.toString().
+                            equals(recoveryDataDO.getRecoveryScenario().toString())) {
                 long codeToleranceTimeInMillis = recoveryDataDO.getTimeCreated().getTime() +
                         TimeUnit.MINUTES.toMillis(codeToleranceInMinutes);
                 return System.currentTimeMillis() < codeToleranceTimeInMillis;


### PR DESCRIPTION
### Proposed changes in this pull request

We have previously implemented a feature[1][2] to Re-issue Existing Password Recovery Confirmation Code in password reset flow within a time period. That time period was decided based on the below toml config.

  ```
  [identity_mgt.password_reset_email]
  confirmation_code_tolerance_period=3
  ```


We have a similar requirement to send the same account confirmation link(same confirmation code) when a user tries to resend the activation link multiple times within a specified time period. This activation link can be a PENDING_AP user activation link(Ask Password Flow) or a PENDING_SR user activation link(Self Registration Flow).

With this Draft PR I have improved the previously done feature to provide the support to Re-issue  Confirmation Code in Ask Password flow & Self registration flow within a time period. That time period was decided a based on the above same toml config.

### TO-DO
- [ ] Decide the recovery flows which support to re-issue Existing confrimation codes based on a config
- [ ] Decide whether are we going to use the same toml config to configure to specify `confirmation_code_tolerance_period`

#### Tests

- [ ] Need to Create

#### Documentation

- [ ] Need to Create

#### References

- [1] https://github.com/wso2/product-is/issues/10985
- [2] https://wso2.com/blogs/thesource/re-issue-existing-password-recovery-confirmation-code-in-followed-recovery-or-resend-requests/ 