### PR TITLE
Add service to identify the idle user accounts

### DIFF
--- a/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
+++ b/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org).
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>identity-governance</artifactId>
+        <groupId>org.wso2.carbon.identity.governance</groupId>
+        <version>1.8.53-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>org.wso2.carbon.identity.idle.account.identification</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Idle User Account Identification</name>
+    <description>
+        This is a Carbon bundle that represent the Idle User Account Identification Module.
+    </description>
+    <url>http://wso2.org</url>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.2.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>
+                            ${project.artifactId}
+                        </Bundle-SymbolicName>
+                        <Private-Package>
+                            org.wso2.carbon.identity.idle.account.identification.internal
+                        </Private-Package>
+                        <Export-Package>
+                            org.wso2.carbon.identity.idle.account.identification.*; version="${project.version}",
+                            !org.wso2.carbon.identity.idle.account.identification.internal
+                        </Export-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                        <Import-Package>
+                            org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
+                            org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.governance;version="${identity.governance.imp.pkg.version.range}"
+                        </Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-prepare-agent-integration</id>
+                        <goals>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report-integration</id>
+                        <goals>
+                            <goal>report-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <!--<minimum>0.10</minimum>-->
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.mgt</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.governance</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
+++ b/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
@@ -112,7 +112,6 @@
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <!--<minimum>0.10</minimum>-->
                                         </limit>
                                     </limits>
                                 </rule>

--- a/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
+++ b/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.8.53-SNAPSHOT</version>
+        <version>1.8.57-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/constants/IdleAccIdentificationConstants.java
+++ b/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/constants/IdleAccIdentificationConstants.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.idle.account.identification.constants;
+
+/**
+ * Constants for idle account identification.
+ */
+public class IdleAccIdentificationConstants {
+
+    public static final String IDLE_ACC_IDENTIFICATION_SERVICE_ERROR_PREFIX = "IDLE_ACC-";
+
+    public static final String LAST_LOGIN_TIME_CLAIM = "http://wso2.org/claims/identity/lastLogonTime";
+
+    /**
+     * Class containing SQL queries.
+     */
+    public static class SQLConstants {
+
+        public static final String FILTER_USERS_BY_DATA_KEY_LESS_THAN_DATA_VALUE =
+                "SELECT USER_NAME, DATA_VALUE FROM IDN_IDENTITY_USER_DATA WHERE " +
+                        "DATA_KEY = ? AND TENANT_ID = ? AND DATA_VALUE < ?";
+
+        public static final String FILTER_USERS_BY_DATA_KEY_LESS_THAN_AND_GREATER_THAN_DATA_VALUES =
+                "SELECT USER_NAME, DATA_VALUE FROM IDN_IDENTITY_USER_DATA WHERE " +
+                        "DATA_KEY = ? AND TENANT_ID = ? AND DATA_VALUE < ? AND DATA_VALUE > ?";
+    }
+
+    /**
+     * Error messages.
+     */
+    public enum ErrorMessages {
+
+        // Server errors 650xx.
+        ERROR_RETRIEVE_INACTIVE_USERS_FROM_DB("65002",
+                "Error while retrieving inactive users from database.",
+                "Error while retrieving inactive users for organization: %s."),
+
+        ERROR_RETRIEVE_USER_STORE_MANAGER("65003",
+                "Error while retrieving user store manager.",
+                "Error while retrieving user store manager of user in organization: %s."),
+
+        ERROR_RETRIEVE_USER_UUID("65004",
+                "Error while retrieving UUID of the user.",
+                "Error while retrieving UUID of the user from organization: %s.");
+
+        private final String code;
+        private final String message;
+        private final String description;
+
+        ErrorMessages(String code, String message, String description) {
+
+            this.code = code;
+            this.message = message;
+            this.description = description;
+        }
+
+        /**
+         * Return the error code.
+         *
+         * @return Code.
+         */
+        public String getCode() {
+
+            return IDLE_ACC_IDENTIFICATION_SERVICE_ERROR_PREFIX + code;
+        }
+
+        /**
+         * Return the error message.
+         *
+         * @return Message.
+         */
+        public String getMessage() {
+
+            return message;
+        }
+
+        /**
+         * Return the error description.
+         *
+         * @return Description.
+         */
+        public String getDescription() {
+
+            return description;
+        }
+
+        @Override
+        public String toString() {
+
+            return code + " | " + message;
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/exception/IdleAccountIdentificationClientException.java
+++ b/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/exception/IdleAccountIdentificationClientException.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.idle.account.identification.exception;
+
+/**
+ * Idle account identification related client exceptions.
+ */
+public class IdleAccountIdentificationClientException extends IdleAccountIdentificationException {
+
+    /**
+     * Constructor with error code and message.
+     *
+     * @param errorCode Error Code.
+     * @param message   Message.
+     */
+    public IdleAccountIdentificationClientException(String errorCode, String message) {
+
+        super(errorCode, message);
+    }
+
+    /**
+     * Constructor with error code, message and description.
+     *
+     * @param errorCode     Error Code.
+     * @param message       Message.
+     * @param description   Description.
+     */
+    public IdleAccountIdentificationClientException(String errorCode, String message, String description) {
+
+        super(errorCode, message, description);
+    }
+
+    /**
+     * Constructor with error code, message and cause.
+     *
+     * @param errorCode Error Code.
+     * @param message   Error message.
+     * @param cause     If any error occurred when accessing the tenant.
+     */
+    public IdleAccountIdentificationClientException(String errorCode, String message, Throwable cause) {
+
+        super(message, errorCode, cause);
+    }
+
+/**
+     * Constructor with cause.
+     *
+     * @param cause If any error occurred when accessing the tenant.
+     */
+    public IdleAccountIdentificationClientException(Throwable cause) {
+
+        super(cause);
+    }
+}

--- a/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/exception/IdleAccountIdentificationException.java
+++ b/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/exception/IdleAccountIdentificationException.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.idle.account.identification.exception;
+
+/**
+ * Base exception for idle account identification feature.
+ */
+public class IdleAccountIdentificationException extends Exception {
+
+    private String errorCode;
+    private String description;
+
+    /**
+     * Constructor with error code and message.
+     *
+     * @param errorCode Error Code.
+     * @param message   Error message.
+     */
+    public IdleAccountIdentificationException(String errorCode, String message) {
+
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    /**
+     * Constructor with errorCode, message and description.
+     *
+     * @param errorCode     Error Code.
+     * @param message       Error Message.
+     * @param description   Error Description.
+     */
+    public IdleAccountIdentificationException(String errorCode, String message, String description) {
+
+        super(message);
+        this.errorCode = errorCode;
+        this.description = description;
+    }
+
+    /**
+     * Constructor with error code, message and cause.
+     *
+     * @param errorCode Error Code.
+     * @param message   Error message.
+     * @param cause     If any error occurred when accessing the tenant.
+     */
+    public IdleAccountIdentificationException(String errorCode, String message, Throwable cause) {
+
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    /**
+     * Constructor with cause.
+     *
+     * @param cause If any error occurred when accessing the tenant.
+     */
+    public IdleAccountIdentificationException(Throwable cause) {
+
+        super(cause);
+    }
+
+    /**
+     * Method to get error code.
+     *
+     * @return errorCode.
+     */
+    public String getErrorCode() {
+
+        return errorCode;
+    }
+
+    /**
+     * Method to get error description.
+     *
+     * @return description.
+     */
+    public String getDescription() {
+
+        return description;
+    }
+
+    /**
+     * Method to set error code.
+     *
+     * @param errorCode Error code.
+     */
+    protected void setErrorCode(String errorCode) {
+
+        this.errorCode = errorCode;
+    }
+}

--- a/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/exception/IdleAccountIdentificationServerException.java
+++ b/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/exception/IdleAccountIdentificationServerException.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.idle.account.identification.exception;
+
+/**
+ * Idle account identification related server exceptions.
+ */
+public class IdleAccountIdentificationServerException extends IdleAccountIdentificationException {
+
+    /**
+     * Constructor with error code and message.
+     *
+     * @param errorCode Error Code.
+     * @param message   Message.
+     */
+    public IdleAccountIdentificationServerException(String errorCode, String message) {
+
+        super(errorCode, message);
+    }
+
+    /**
+     * Constructor with error code, message and cause.
+     *
+     * @param errorCode Error Code.
+     * @param message   Error message.
+     * @param cause     If any error occurred when accessing the tenant.
+     */
+    public IdleAccountIdentificationServerException(String errorCode, String message, Throwable cause) {
+
+        super(errorCode, message, cause);
+    }
+
+    /**
+     * Constructor with cause.
+     *
+     * @param cause If any error occurred when accessing the tenant.
+     */
+    public IdleAccountIdentificationServerException(Throwable cause) {
+
+        super(cause);
+    }
+}

--- a/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/internal/IdleAccountIdentificationComponent.java
+++ b/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/internal/IdleAccountIdentificationComponent.java
@@ -44,7 +44,7 @@ import org.wso2.carbon.user.core.service.RealmService;
         immediate = true)
 public class IdleAccountIdentificationComponent {
 
-    private static final Log log = LogFactory.getLog(IdleAccountIdentificationComponent.class);
+    private static final Log LOG = LogFactory.getLog(IdleAccountIdentificationComponent.class);
 
     private IdleAccountIdentificationDataHolder dataHolder = IdleAccountIdentificationDataHolder.getInstance();
 
@@ -64,7 +64,7 @@ public class IdleAccountIdentificationComponent {
     @Deactivate
     protected void deactivate(ComponentContext componentContext) {
 
-        log.debug("Idle Account Identification service is deactivated");
+        LOG.debug("Idle Account Identification service is deactivated");
     }
 
     @Reference(
@@ -75,15 +75,15 @@ public class IdleAccountIdentificationComponent {
             unbind = "unsetRealmService")
     protected void setRealmService(RealmService realmService) {
 
-        if (log.isDebugEnabled()) {
-            log.debug("Setting the Realm Service");
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Setting the Realm Service");
         }
         dataHolder.setRealmService(realmService);
     }
 
     protected void unsetRealmService(RealmService realmService) {
 
-        log.debug("UnSetting the Realm Service");
+        LOG.debug("UnSetting the Realm Service");
         dataHolder.setRealmService(null);
     }
 

--- a/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/internal/IdleAccountIdentificationComponent.java
+++ b/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/internal/IdleAccountIdentificationComponent.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.idle.account.identification.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+
+import org.wso2.carbon.identity.idle.account.identification.services.IdleAccountIdentificationService;
+import org.wso2.carbon.identity.idle.account.identification.services.impl.IdleAccountIdentificationServiceImpl;
+import org.wso2.carbon.identity.governance.service.IdentityDataStoreService;
+import org.wso2.carbon.user.core.service.RealmService;
+
+
+/**
+ * OSGi declarative services component which handles registration and un-registration of idle account identification
+ * service.
+ */
+@Component(
+        name = "org.wso2.carbon.identity.idle.account.identification.task.internal.IdleAccountIdentificationComponent",
+        immediate = true)
+public class IdleAccountIdentificationComponent {
+
+    private static final Log log = LogFactory.getLog(IdleAccountIdentificationComponent.class);
+
+    private IdleAccountIdentificationDataHolder dataHolder = IdleAccountIdentificationDataHolder.getInstance();
+
+    /**
+     * Register IdleAccountIdentificationService as an OSGI service.
+     *
+     * @param componentContext OSGI service component context.
+     */
+    @Activate
+    protected void activate(ComponentContext componentContext) {
+
+        BundleContext bundleContext = componentContext.getBundleContext();
+        bundleContext.registerService(IdleAccountIdentificationService.class.getName(),
+                new IdleAccountIdentificationServiceImpl(), null);
+    }
+
+    @Deactivate
+    protected void deactivate(ComponentContext componentContext) {
+
+        log.debug("Idle Account Identification service is deactivated");
+    }
+
+    @Reference(
+            name = "realm.service",
+            service = RealmService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRealmService")
+    protected void setRealmService(RealmService realmService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Setting the Realm Service");
+        }
+        dataHolder.setRealmService(realmService);
+    }
+
+    protected void unsetRealmService(RealmService realmService) {
+
+        log.debug("UnSetting the Realm Service");
+        dataHolder.setRealmService(null);
+    }
+
+    @Reference(
+            name = "identity.governance.service",
+            service = IdentityDataStoreService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdentityDataStoreService"
+    )
+    protected void setIdentityDataStoreService(IdentityDataStoreService identityDataStoreService) {
+
+        IdleAccountIdentificationDataHolder.getInstance().setIdentityDataStoreService(identityDataStoreService);
+    }
+
+    protected void unsetIdentityDataStoreService(IdentityDataStoreService identityDataStoreService) {
+
+        IdleAccountIdentificationDataHolder.getInstance().setIdentityDataStoreService(null);
+    }
+}

--- a/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/internal/IdleAccountIdentificationDataHolder.java
+++ b/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/internal/IdleAccountIdentificationDataHolder.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.idle.account.identification.internal;
+
+import org.wso2.carbon.identity.governance.service.IdentityDataStoreService;
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ * Data holder for idle account identification service.
+ */
+public class IdleAccountIdentificationDataHolder {
+
+    private static IdleAccountIdentificationDataHolder instance = new IdleAccountIdentificationDataHolder();
+    private RealmService realmService;
+    private IdentityDataStoreService identityDataStoreService;
+
+    /**
+     * Get data holder instance.
+     *
+     * @return IdleAccountIdentificationDataHolder.
+     */
+    public static IdleAccountIdentificationDataHolder getInstance() {
+
+        return instance;
+    }
+
+    /**
+     * Get realm service.
+     *
+     * @return RealmService.
+     */
+    public RealmService getRealmService() {
+
+        return realmService;
+    }
+
+    /**
+     * Set realm service.
+     */
+    public void setRealmService(RealmService realmService) {
+
+        this.realmService = realmService;
+    }
+
+    public IdentityDataStoreService getIdentityDataStoreService() {
+
+        return identityDataStoreService;
+    }
+
+    public void setIdentityDataStoreService(IdentityDataStoreService identityDataStoreService) {
+
+        this.identityDataStoreService = identityDataStoreService;
+    }
+}

--- a/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/models/InactiveUserModel.java
+++ b/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/models/InactiveUserModel.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.idle.account.identification.models;
 
 /**

--- a/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/models/InactiveUserModel.java
+++ b/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/models/InactiveUserModel.java
@@ -1,0 +1,65 @@
+package org.wso2.carbon.identity.idle.account.identification.models;
+
+/**
+ * Object for inactive user model.
+ */
+public class InactiveUserModel {
+
+    private String userId;
+    private String username;
+    private String userStoreDomain;
+
+    /**
+     * Method to get userId.
+     *
+     * @return userId.
+     */
+    public String getUserId() {
+
+        return userId;
+    }
+
+    /**
+     * Method to set userId.
+     */
+    public void setUserId(String userId) {
+
+        this.userId = userId;
+    }
+
+    /**
+     * Method to get username.
+     *
+     * @return username.
+     */
+    public String getUsername() {
+
+        return username;
+    }
+
+    /**
+     * Method to set username.
+     */
+    public void setUsername(String username) {
+
+        this.username = username;
+    }
+
+    /**
+     * Method to get userStore domain.
+     *
+     * @return userStore domain.
+     */
+    public String getUserStoreDomain() {
+
+        return userStoreDomain;
+    }
+
+    /**
+     * Method to set userStore domain.
+     */
+    public void setUserStoreDomain(String userStoreDomain) {
+
+        this.userStoreDomain = userStoreDomain;
+    }
+}

--- a/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/services/IdleAccountIdentificationService.java
+++ b/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/services/IdleAccountIdentificationService.java
@@ -1,0 +1,41 @@
+package org.wso2.carbon.identity.idle.account.identification.services;
+
+import org.wso2.carbon.identity.idle.account.identification.exception.IdleAccountIdentificationException;
+import org.wso2.carbon.identity.idle.account.identification.models.InactiveUserModel;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Service interface for idle account identification.
+ */
+public interface IdleAccountIdentificationService {
+
+    /**
+     * Get inactive users from a specific date.
+     * (Example: Providing date object of 2023-01-31 as value for 'inactiveAfter' parameter will return all users who
+     * have not logged in since 2023-01-31 00:00:00.000)
+     *
+     * @param inactiveAfter date after which the user should be inactive.
+     * @param tenantDomain  tenant domain.
+     * @return              list of inactive users.
+     * @throws IdleAccountIdentificationException Exception when retrieving inactive users from database.
+     */
+    List<InactiveUserModel> getInactiveUsersFromSpecificDate(LocalDateTime inactiveAfter, String tenantDomain)
+            throws IdleAccountIdentificationException;
+
+    /**
+     * Get inactive users from a specific date excluding the oldest inactive users.
+     * (Example: Providing date object of 2023-01-31 as value for 'inactiveAfter' parameter and date object of
+     * 2023-01-01 as value for 'excludeBefore' parameter will return all users who have not logged in since
+     * 2023-01-31 00:00:00.000 excluding users who have not logged in since 2023-01-01 00:00:00.000)
+     *
+     * @param inactiveAfter date after which the user should be inactive.
+     * @param excludeBefore date before which the user should be excluded.
+     * @param tenantDomain  tenant domain.
+     * @return              list of inactive users.
+     * @throws IdleAccountIdentificationException Exception when retrieving inactive users from database.
+     */
+    List<InactiveUserModel> getLimitedInactiveUsersFromSpecificDate(LocalDateTime inactiveAfter,
+            LocalDateTime excludeBefore, String tenantDomain) throws IdleAccountIdentificationException;
+}

--- a/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/services/impl/IdleAccountIdentificationServiceImpl.java
+++ b/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/services/impl/IdleAccountIdentificationServiceImpl.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.idle.account.identification.services.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.context.CarbonContext;
+
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.idle.account.identification.constants.IdleAccIdentificationConstants;
+import org.wso2.carbon.identity.idle.account.identification.exception.IdleAccountIdentificationException;
+import org.wso2.carbon.identity.idle.account.identification.exception.IdleAccountIdentificationServerException;
+import org.wso2.carbon.identity.idle.account.identification.internal.IdleAccountIdentificationDataHolder;
+import org.wso2.carbon.identity.idle.account.identification.models.InactiveUserModel;
+import org.wso2.carbon.identity.idle.account.identification.services.IdleAccountIdentificationService;
+
+import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.jdbc.UniqueIDJDBCUserStoreManager;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Implementation of the service interface for idle account identification.
+ */
+public class IdleAccountIdentificationServiceImpl implements IdleAccountIdentificationService {
+
+    @Override
+    public List<InactiveUserModel> getInactiveUsersFromSpecificDate(LocalDateTime inactiveAfter, String tenantDomain)
+            throws IdleAccountIdentificationException {
+
+        List<InactiveUserModel> inactiveUsers = new ArrayList<>();
+        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+        String lastLoginTime = Long.toString(inactiveAfter.toEpochSecond(ZoneOffset.UTC));
+        try {
+            List<String> usernames = IdleAccountIdentificationDataHolder.getInstance().getIdentityDataStoreService()
+                    .getUserNamesLessThanProvidedClaimValue(IdleAccIdentificationConstants.LAST_LOGIN_TIME_CLAIM,
+                            lastLoginTime, tenantId);
+            if (!usernames.isEmpty()) {
+                inactiveUsers = buildInactiveUsers(usernames);
+            }
+        } catch (IdentityException e) {
+            IdleAccIdentificationConstants.ErrorMessages errorEnum =
+                    IdleAccIdentificationConstants.ErrorMessages.ERROR_RETRIEVE_INACTIVE_USERS_FROM_DB;
+            throw new IdleAccountIdentificationServerException(errorEnum.getCode(), errorEnum.getMessage());
+        }
+        return inactiveUsers;
+    }
+
+    @Override
+    public List<InactiveUserModel> getLimitedInactiveUsersFromSpecificDate(LocalDateTime inactiveAfter,
+                       LocalDateTime excludeBefore, String tenantDomain) throws IdleAccountIdentificationException {
+
+        List<InactiveUserModel> inactiveUsers = new ArrayList<>();
+        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+        String inactiveDateEpoch = Long.toString(inactiveAfter.toEpochSecond(ZoneOffset.UTC));
+        String excludeDateEpoch = Long.toString(excludeBefore.toEpochSecond(ZoneOffset.UTC));
+        try {
+            List<String> usernames = IdleAccountIdentificationDataHolder.getInstance().getIdentityDataStoreService()
+                    .getUserNamesBetweenProvidedClaimValues(IdleAccIdentificationConstants.LAST_LOGIN_TIME_CLAIM,
+                            excludeDateEpoch, inactiveDateEpoch, tenantId);
+            if (!usernames.isEmpty()) {
+                inactiveUsers = buildInactiveUsers(usernames);
+            }
+        } catch (IdentityException e) {
+            IdleAccIdentificationConstants.ErrorMessages errorEnum =
+                    IdleAccIdentificationConstants.ErrorMessages.ERROR_RETRIEVE_INACTIVE_USERS_FROM_DB;
+            throw new IdleAccountIdentificationServerException(errorEnum.getCode(), errorEnum.getMessage());
+        }
+        return inactiveUsers;
+    }
+
+    /**
+     * Build a list of inactive users.
+     *
+     * @param usernames        list of usernames.
+     * @return                 list of inactive user objects.
+     */
+    private List<InactiveUserModel> buildInactiveUsers(List<String> usernames)
+            throws IdleAccountIdentificationServerException {
+
+        List<InactiveUserModel> inactiveUsers = new ArrayList<>();
+        for (String username : usernames) {
+            String userId = fetchUserId(username);
+            if (StringUtils.isNotBlank(userId)) {
+                InactiveUserModel inactiveUser = new InactiveUserModel();
+                inactiveUser.setUsername(username);
+                inactiveUser.setUserId(userId);
+                inactiveUser.setUserStoreDomain(UserCoreUtil.extractDomainFromName(username));
+                inactiveUsers.add(inactiveUser);
+            }
+        }
+        return inactiveUsers;
+    }
+
+    /**
+     * Fetch UUID of the user.
+     *
+     * @param username          username of the user.
+     * @return                  UUID of the user
+     */
+    public String fetchUserId(String username) throws IdleAccountIdentificationServerException {
+
+        UserStoreManager userStoreManager = getUserStoreManager(UserCoreUtil.extractDomainFromName(username));
+        try {
+            if (userStoreManager instanceof UniqueIDJDBCUserStoreManager) {
+                return ((UniqueIDJDBCUserStoreManager) userStoreManager).getUserIDFromUserName(username);
+            }
+        } catch (UserStoreException e) {
+            IdleAccIdentificationConstants.ErrorMessages errorEnum =
+                    IdleAccIdentificationConstants.ErrorMessages.ERROR_RETRIEVE_USER_UUID;
+            throw new IdleAccountIdentificationServerException(errorEnum.getCode(), errorEnum.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Get user store manager.
+     *
+     * @return UserStoreManager.
+     * @throws IdleAccountIdentificationServerException Exception when getting user store manager.
+     */
+    private UserStoreManager getUserStoreManager(String userStore) throws IdleAccountIdentificationServerException {
+
+        try {
+            UserRealm realm = (UserRealm) CarbonContext.getThreadLocalCarbonContext().getUserRealm();
+            if (realm == null) {
+                IdleAccIdentificationConstants.ErrorMessages errorEnum =
+                        IdleAccIdentificationConstants.ErrorMessages.ERROR_RETRIEVE_USER_STORE_MANAGER;
+                throw new IdleAccountIdentificationServerException(errorEnum.getCode(), errorEnum.getMessage());
+            }
+            if (realm.getUserStoreManager() == null) {
+                IdleAccIdentificationConstants.ErrorMessages errorEnum =
+                        IdleAccIdentificationConstants.ErrorMessages.ERROR_RETRIEVE_USER_STORE_MANAGER;
+                throw new IdleAccountIdentificationServerException(errorEnum.getCode(), errorEnum.getMessage());
+            }
+            if ( IdentityUtil.getPrimaryDomainName().equals(userStore)) {
+                return realm.getUserStoreManager();
+            }
+            if (realm.getUserStoreManager().getSecondaryUserStoreManager(userStore) != null) {
+                return realm.getUserStoreManager().getSecondaryUserStoreManager(userStore);
+            }
+            IdleAccIdentificationConstants.ErrorMessages errorEnum =
+                    IdleAccIdentificationConstants.ErrorMessages.ERROR_RETRIEVE_USER_STORE_MANAGER;
+            throw new IdleAccountIdentificationServerException(errorEnum.getCode(), errorEnum.getMessage());
+        } catch (UserStoreException e) {
+            IdleAccIdentificationConstants.ErrorMessages errorEnum =
+                    IdleAccIdentificationConstants.ErrorMessages.ERROR_RETRIEVE_USER_STORE_MANAGER;
+            throw new IdleAccountIdentificationServerException(errorEnum.getCode(), errorEnum.getMessage());
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/services/impl/IdleAccountIdentificationServiceImpl.java
+++ b/components/org.wso2.carbon.identity.idle.account.identification/src/main/java/org/wso2/carbon/identity/idle/account/identification/services/impl/IdleAccountIdentificationServiceImpl.java
@@ -34,7 +34,7 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreManager;
-import org.wso2.carbon.user.core.jdbc.UniqueIDJDBCUserStoreManager;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.time.LocalDateTime;
@@ -125,8 +125,8 @@ public class IdleAccountIdentificationServiceImpl implements IdleAccountIdentifi
 
         UserStoreManager userStoreManager = getUserStoreManager(UserCoreUtil.extractDomainFromName(username));
         try {
-            if (userStoreManager instanceof UniqueIDJDBCUserStoreManager) {
-                return ((UniqueIDJDBCUserStoreManager) userStoreManager).getUserIDFromUserName(username);
+            if (userStoreManager instanceof AbstractUserStoreManager) {
+                return ((AbstractUserStoreManager) userStoreManager).getUserIDFromUserName(username);
             }
         } catch (UserStoreException e) {
             IdleAccIdentificationConstants.ErrorMessages errorEnum =
@@ -142,7 +142,7 @@ public class IdleAccountIdentificationServiceImpl implements IdleAccountIdentifi
      * @return UserStoreManager.
      * @throws IdleAccountIdentificationServerException Exception when getting user store manager.
      */
-    private UserStoreManager getUserStoreManager(String userStore) throws IdleAccountIdentificationServerException {
+    private UserStoreManager getUserStoreManager(String userStoreDomainName) throws IdleAccountIdentificationServerException {
 
         try {
             UserRealm realm = (UserRealm) CarbonContext.getThreadLocalCarbonContext().getUserRealm();
@@ -156,11 +156,11 @@ public class IdleAccountIdentificationServiceImpl implements IdleAccountIdentifi
                         IdleAccIdentificationConstants.ErrorMessages.ERROR_RETRIEVE_USER_STORE_MANAGER;
                 throw new IdleAccountIdentificationServerException(errorEnum.getCode(), errorEnum.getMessage());
             }
-            if ( IdentityUtil.getPrimaryDomainName().equals(userStore)) {
+            if (IdentityUtil.getPrimaryDomainName().equals(userStoreDomainName)) {
                 return realm.getUserStoreManager();
             }
-            if (realm.getUserStoreManager().getSecondaryUserStoreManager(userStore) != null) {
-                return realm.getUserStoreManager().getSecondaryUserStoreManager(userStore);
+            if (realm.getUserStoreManager().getSecondaryUserStoreManager(userStoreDomainName) != null) {
+                return realm.getUserStoreManager().getSecondaryUserStoreManager(userStoreDomainName);
             }
             IdleAccIdentificationConstants.ErrorMessages errorEnum =
                     IdleAccIdentificationConstants.ErrorMessages.ERROR_RETRIEVE_USER_STORE_MANAGER;

--- a/components/org.wso2.carbon.identity.idle.account.identification/src/test/java/org/wso2/carbon/identity/idle/account/identification/IdleAccountIdentificationServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.idle.account.identification/src/test/java/org/wso2/carbon/identity/idle/account/identification/IdleAccountIdentificationServiceImplTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.idle.account.identification;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.context.CarbonContext;
+
+import org.wso2.carbon.identity.idle.account.identification.internal.IdleAccountIdentificationDataHolder;
+import org.wso2.carbon.identity.idle.account.identification.models.InactiveUserModel;
+import org.wso2.carbon.identity.idle.account.identification.services.impl.IdleAccountIdentificationServiceImpl;
+import org.wso2.carbon.identity.idle.account.identification.util.TestUtils;
+
+import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.governance.service.IdentityDataStoreService;
+import org.wso2.carbon.identity.governance.service.IdentityDataStoreServiceImpl;
+import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.UserStoreManager;
+
+import java.sql.Connection;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertEquals;
+
+public class IdleAccountIdentificationServiceImplTest {
+
+    private static final String TENANT_DOMAIN = "DEFAULT";
+    private static final int TENANT_ID = 3;
+    private static final String SAMPLE_USER_ID = "sampleUserId";
+    private static final String IDENTITY_DATA_STORE_TYPE = "org.wso2.carbon.identity." +
+            "governance.store.JDBCIdentityDataStore";
+
+    private Connection connection;
+
+    private MockedStatic<IdentityDatabaseUtil> mockedIdentityDatabaseUtils;
+    private MockedStatic<IdentityTenantUtil> mockedIdentityTenantUtil;
+    private MockedStatic<CarbonContext> mockedCarbonContext;
+    private MockedStatic<IdentityUtil> mockedIdentityUtil;
+
+    private UserRealm userRealm;
+    private UserStoreManager userStoreManager;
+    IdentityDataStoreService identityDataStoreService;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        TestUtils.initiateH2Base();
+        TestUtils.mockDataSource();
+
+        connection = TestUtils.getConnection();
+        mockedIdentityDatabaseUtils = Mockito.mockStatic(IdentityDatabaseUtil.class);
+        mockedIdentityDatabaseUtils.when(() -> IdentityDatabaseUtil.getDBConnection(anyBoolean()))
+                .thenReturn(connection);
+
+        mockedIdentityTenantUtil = Mockito.mockStatic(IdentityTenantUtil.class);
+        mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString()))
+                .thenReturn(TENANT_ID);
+
+        userRealm = mock(org.wso2.carbon.user.core.UserRealm.class);
+        userStoreManager = mock(UserStoreManager.class);
+
+        mockedCarbonContext = Mockito.mockStatic(CarbonContext.class);
+        CarbonContext carbonContext = mock(CarbonContext.class);
+        mockedCarbonContext.when(CarbonContext::getThreadLocalCarbonContext).thenReturn(carbonContext);
+        mockedCarbonContext.when(carbonContext::getUserRealm).thenReturn(userRealm);
+        mockedCarbonContext.when(userRealm::getUserStoreManager).thenReturn(userStoreManager);
+        mockedCarbonContext.when(() ->
+                userStoreManager.getSecondaryUserStoreManager(anyString())).thenReturn(userStoreManager);
+
+        mockedIdentityUtil = Mockito.mockStatic(IdentityUtil.class);
+        mockedIdentityUtil.when(() -> IdentityUtil.getProperty(anyString())).thenReturn
+                (IDENTITY_DATA_STORE_TYPE);
+        identityDataStoreService = spy(new IdentityDataStoreServiceImpl());
+        IdleAccountIdentificationDataHolder.getInstance().setIdentityDataStoreService(identityDataStoreService);
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+
+        mockedIdentityDatabaseUtils.close();
+        mockedIdentityTenantUtil.close();
+        mockedCarbonContext.close();
+        mockedIdentityUtil.close();
+        TestUtils.closeH2Base();
+    }
+
+    @DataProvider
+    public Object[][] getDates1() {
+
+        return new Object[][]{
+                {LocalDate.parse("2023-01-31").atStartOfDay(), 5},
+                {LocalDate.parse("2023-01-01").atStartOfDay(), 0}
+        };
+    }
+
+    @Test(dataProvider = "getDates1")
+    public void testGetInactiveUsersFromSpecificDate(LocalDateTime inactiveAfter, int expected) throws Exception {
+
+        IdleAccountIdentificationServiceImpl idleAccountIdentificationService =
+                spy(IdleAccountIdentificationServiceImpl.class);
+        doReturn(SAMPLE_USER_ID).when(idleAccountIdentificationService).fetchUserId(anyString());
+
+        List<InactiveUserModel> inactiveUsers = idleAccountIdentificationService.
+                getInactiveUsersFromSpecificDate(inactiveAfter, TENANT_DOMAIN);
+
+        assertEquals(inactiveUsers.size(), expected);
+    }
+
+    @DataProvider
+    public Object[][] getDates2() {
+
+        return new Object[][]{
+                {LocalDate.parse("2023-01-31").atStartOfDay(), LocalDate.parse("2023-01-15").atStartOfDay(), 3},
+                {LocalDate.parse("2023-01-31").atStartOfDay(), LocalDate.parse("2023-01-30").atStartOfDay(), 0}
+        };
+    }
+
+    @Test(dataProvider = "getDates2")
+    public void testGetLimitedInactiveUsersFromSpecificDate(LocalDateTime inactiveAfter, LocalDateTime excludeBefore,
+                                                        int expected) throws Exception {
+
+        IdleAccountIdentificationServiceImpl idleAccountIdentificationService =
+                spy(IdleAccountIdentificationServiceImpl.class);
+        doReturn(SAMPLE_USER_ID).when(idleAccountIdentificationService).fetchUserId(anyString());
+
+        List<InactiveUserModel> inactiveUsers = idleAccountIdentificationService.
+                getLimitedInactiveUsersFromSpecificDate(inactiveAfter, excludeBefore, TENANT_DOMAIN);
+
+        assertEquals(inactiveUsers.size(), expected);
+    }
+}

--- a/components/org.wso2.carbon.identity.idle.account.identification/src/test/java/org/wso2/carbon/identity/idle/account/identification/util/TestUtils.java
+++ b/components/org.wso2.carbon.identity.idle.account.identification/src/test/java/org/wso2/carbon/identity/idle/account/identification/util/TestUtils.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.idle.account.identification.util;
+
+import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.base.CarbonBaseConstants;
+import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.context.internal.CarbonContextDataHolder;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.core.util.DatabaseUtil;
+
+import java.lang.reflect.Field;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import static org.mockito.Mockito.mock;
+
+public class TestUtils {
+
+    public static final String DB_NAME = "test_db";
+    public static final String H2_SCRIPT_NAME = "h2.sql";
+    public static Map<String, BasicDataSource> dataSourceMap = new HashMap<>();
+
+    public static String getFilePath(String fileName) {
+
+        if (StringUtils.isNotBlank(fileName)) {
+            return Paths.get(System.getProperty("user.dir"), "src", "test", "resources", "dbscripts",
+                    fileName).toString();
+        }
+        throw new IllegalArgumentException("DB Script file name cannot be empty.");
+    }
+
+    public static void initiateH2Base() throws Exception {
+
+        BasicDataSource dataSource = new BasicDataSource();
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUsername("username");
+        dataSource.setPassword("password");
+        dataSource.setUrl("jdbc:h2:mem:test" + DB_NAME);
+        dataSource.setTestOnBorrow(true);
+        dataSource.setValidationQuery("select 1");
+        try (Connection connection = dataSource.getConnection()) {
+            connection.createStatement().executeUpdate("RUNSCRIPT FROM '" + getFilePath(H2_SCRIPT_NAME) + "'");
+        }
+        dataSourceMap.put(DB_NAME, dataSource);
+    }
+
+    public static void closeH2Base() throws Exception {
+
+        BasicDataSource dataSource = dataSourceMap.remove(DB_NAME);
+        if (dataSource != null) {
+            dataSource.close();
+        }
+    }
+
+    public static Connection getConnection() throws SQLException {
+
+        if (dataSourceMap.get(DB_NAME) != null) {
+            return dataSourceMap.get(DB_NAME).getConnection();
+        }
+        throw new RuntimeException("No datasource initiated for database: " + DB_NAME);
+    }
+
+    public static void mockDataSource() throws Exception {
+
+        String carbonHome = Paths.get(System.getProperty("user.dir"), "target", "test-classes").toString();
+        System.setProperty(CarbonBaseConstants.CARBON_HOME, carbonHome);
+        System.setProperty(CarbonBaseConstants.CARBON_CONFIG_DIR_PATH, Paths.get(carbonHome,
+                "repository/conf").toString());
+
+        DataSource dataSource = dataSourceMap.get(DB_NAME);
+
+        setStatic(DatabaseUtil.class.getDeclaredField("dataSource"), dataSource);
+
+        Field carbonContextHolderField =
+                CarbonContext.getThreadLocalCarbonContext().getClass().getDeclaredField("carbonContextHolder");
+        carbonContextHolderField.setAccessible(true);
+        CarbonContextDataHolder carbonContextHolder
+                = (CarbonContextDataHolder) carbonContextHolderField.get(CarbonContext.getThreadLocalCarbonContext());
+        carbonContextHolder.setUserRealm(mock(UserRealm.class));
+    }
+
+    private static void setStatic(Field field, Object newValue) throws Exception {
+        field.setAccessible(true);
+        field.set(null, newValue);
+    }
+}

--- a/components/org.wso2.carbon.identity.idle.account.identification/src/test/resources/dbscripts/h2.sql
+++ b/components/org.wso2.carbon.identity.idle.account.identification/src/test/resources/dbscripts/h2.sql
@@ -1,0 +1,17 @@
+-- -----------------------------------------------------
+-- Table IDN_IDENTITY_USER_DATA
+-- -----------------------------------------------------
+CREATE TABLE IDN_IDENTITY_USER_DATA (
+            TENANT_ID INTEGER DEFAULT -1234,
+            USER_NAME VARCHAR(255) NOT NULL,
+            DATA_KEY VARCHAR(255) NOT NULL,
+            DATA_VALUE VARCHAR(2048),
+            PRIMARY KEY (TENANT_ID, USER_NAME, DATA_KEY)
+);
+
+INSERT INTO IDN_IDENTITY_USER_DATA (TENANT_ID, USER_NAME, DATA_KEY, DATA_VALUE) VALUES
+(3, 'DEFAULT/sampleUser1@xmail.com', 'http://wso2.org/claims/identity/lastLogonTime', '1672704000000'),
+(3, 'DEFAULT/sampleUser2@xmail.com', 'http://wso2.org/claims/identity/lastLogonTime', '1673481600000'),
+(3, 'DEFAULT/sampleUser3@xmail.com', 'http://wso2.org/claims/identity/lastLogonTime', '1674000000000'),
+(3, 'DEFAULT/sampleUser4@xmail.com', 'http://wso2.org/claims/identity/lastLogonTime', '1674518400000'),
+(3, 'DEFAULT/sampleUser5@xmail.com', 'http://wso2.org/claims/identity/lastLogonTime', '1674950400000');

--- a/components/org.wso2.carbon.identity.idle.account.identification/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/org.wso2.carbon.identity.idle.account.identification/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/components/org.wso2.carbon.identity.idle.account.identification/src/test/resources/repository/conf/carbon.xml
+++ b/components/org.wso2.carbon.identity.idle.account.identification/src/test/resources/repository/conf/carbon.xml
@@ -1,0 +1,684 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  ~ Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--
+    This is the main server configuration file
+
+    ${carbon.home} represents the carbon.home system property.
+    Other system properties can be specified in a similar manner.
+-->
+<Server xmlns="http://wso2.org/projects/carbon/carbon.xml">
+
+    <!--
+       Product Name
+    -->
+    <Name>WSO2 Identity Server</Name>
+
+    <!--
+       machine readable unique key to identify each product
+    -->
+    <ServerKey>IS</ServerKey>
+
+    <!--
+       Product Version
+    -->
+    <Version>5.3.0</Version>
+
+    <!--
+       Host name or IP address of the machine hosting this server
+       e.g. www.wso2.org, 192.168.1.10
+       This is will become part of the End Point Reference of the
+       services deployed on this server instance.
+    -->
+    <HostName>localhost</HostName>
+
+    <!--
+    Host name to be used for the Carbon management console
+    -->
+    <MgtHostName>localhost</MgtHostName>
+
+    <!--
+        The URL of the back end server. This is where the admin services are hosted and
+        will be used by the clients in the front end server.
+        This is required only for the Front-end server. This is used when seperating BE server from FE server
+       -->
+    <ServerURL>local:/${carbon.context}/services/</ServerURL>
+    <!--
+    <ServerURL>https://localhost:${carbon.management.port}${carbon.context}/services/</ServerURL>
+    -->
+     <!--
+     The URL of the index page. This is where the user will be redirected after signing in to the
+     carbon server.
+     -->
+    <!-- IndexPageURL>/carbon/admin/index.jsp</IndexPageURL-->
+
+    <!--
+    For cApp deployment, we have to identify the roles that can be acted by the current server.
+    The following property is used for that purpose. Any number of roles can be defined here.
+    Regular expressions can be used in the role.
+    Ex : <Role>.*</Role> means this server can act any role
+    -->
+    <ServerRoles>
+        <Role>IdentityServer</Role>
+    </ServerRoles>
+
+    <!-- uncommnet this line to subscribe to a bam instance automatically -->
+    <!--<BamServerURL>https://bamhost:bamport/services/</BamServerURL>-->
+
+    <!--
+       The fully qualified name of the server
+    -->
+    <Package>org.wso2.carbon</Package>
+
+    <!--
+       Webapp context root of WSO2 Carbon management console.
+    -->
+    <WebContextRoot>/</WebContextRoot>
+
+    <!--
+    	Proxy context path is a useful parameter to add a proxy path when a Carbon server is fronted by reverse proxy. In addtion
+        to the proxy host and proxy port this parameter allows you add a path component to external URLs. e.g.
+     		URL of the Carbon server -> https://10.100.1.1:9443/carbon
+   		URL of the reverse proxy -> https://prod.abc.com/appserver/carbon
+
+   	appserver - proxy context path. This specially required whenever you are generating URLs to displace in
+   	Carbon UI components.
+    -->
+    <!--
+    	<MgtProxyContextPath></MgtProxyContextPath>
+    	<ProxyContextPath></ProxyContextPath>
+    -->
+
+    <!-- In-order to  get the registry http Port from the back-end when the default http transport is not the same-->
+    <!--RegistryHttpPort>9763</RegistryHttpPort-->
+
+    <!--
+    Number of items to be displayed on a management console page. This is used at the
+    backend server for pagination of various items.
+    -->
+    <ItemsPerPage>15</ItemsPerPage>
+
+    <!-- The endpoint URL of the cloud instance management Web service -->
+    <!--<InstanceMgtWSEndpoint>https://ec2.amazonaws.com/</InstanceMgtWSEndpoint>-->
+
+    <!--
+       Ports used by this server
+    -->
+    <Ports>
+
+        <!-- Ports offset. This entry will set the value of the ports defined below to
+         the define value + Offset.
+         e.g. Offset=2 and HTTPS port=9443 will set the effective HTTPS port to 9445
+         -->
+        <Offset>0</Offset>
+
+        <!-- The JMX Ports -->
+        <JMX>
+            <!--The port RMI registry is exposed-->
+            <RMIRegistryPort>9999</RMIRegistryPort>
+            <!--The port RMI server should be exposed-->
+            <RMIServerPort>11111</RMIServerPort>
+        </JMX>
+
+        <!-- Embedded LDAP server specific ports -->
+        <EmbeddedLDAP>
+            <!-- Port which embedded LDAP server runs -->
+            <LDAPServerPort>10389</LDAPServerPort>
+            <!-- Port which KDC (Kerberos Key Distribution Center) server runs -->
+            <KDCServerPort>8000</KDCServerPort>
+        </EmbeddedLDAP>
+	
+	<!-- 
+             Override datasources JNDIproviderPort defined in bps.xml and datasources.properties files
+	-->
+	<!--<JNDIProviderPort>2199</JNDIProviderPort>-->
+	<!--Override receive port of thrift based entitlement service.-->
+	<ThriftEntitlementReceivePort>10500</ThriftEntitlementReceivePort>
+
+    <!--
+     This is the proxy port of the worker cluster. These need to be configured in a scenario where
+     manager node is not exposed through the load balancer through which the workers are exposed
+     therefore doesn't have a proxy port.
+    <WorkerHttpProxyPort>80</WorkerHttpProxyPort>
+    <WorkerHttpsProxyPort>443</WorkerHttpsProxyPort>
+    -->
+
+    </Ports>
+
+    <!--
+        JNDI Configuration
+    -->
+    <JNDI>
+        <!-- 
+             The fully qualified name of the default initial context factory
+        -->
+        <DefaultInitialContextFactory>org.wso2.carbon.tomcat.jndi.CarbonJavaURLContextFactory</DefaultInitialContextFactory>
+        <!-- 
+             The restrictions that are done to various JNDI Contexts in a Multi-tenant environment 
+        -->
+        <Restrictions>
+            <!--
+                Contexts that will be available only to the super-tenant
+            -->
+            <!-- <SuperTenantOnly>
+                <UrlContexts>
+                    <UrlContext>
+                        <Scheme>foo</Scheme>
+                    </UrlContext>
+                    <UrlContext>
+                        <Scheme>bar</Scheme>
+                    </UrlContext>
+                </UrlContexts>
+            </SuperTenantOnly> -->
+            <!-- 
+                Contexts that are common to all tenants
+            -->
+            <AllTenants>
+                <UrlContexts>
+                    <UrlContext>
+                        <Scheme>java</Scheme>
+                    </UrlContext>
+                    <!-- <UrlContext>
+                        <Scheme>foo</Scheme>
+                    </UrlContext> -->
+                </UrlContexts>
+            </AllTenants>
+            <!-- 
+                 All other contexts not mentioned above will be available on a per-tenant basis 
+                 (i.e. will not be shared among tenants)
+            -->
+        </Restrictions>
+    </JNDI>
+
+    <!--
+        Property to determine if the server is running an a cloud deployment environment.
+        This property should only be used to determine deployment specific details that are
+        applicable only in a cloud deployment, i.e when the server deployed *-as-a-service.
+    -->
+    <IsCloudDeployment>false</IsCloudDeployment>
+
+    <!--
+	Property to determine whether usage data should be collected for metering purposes
+    -->
+    <EnableMetering>false</EnableMetering>
+
+    <!-- The Max time a thread should take for execution in seconds -->
+    <MaxThreadExecutionTime>600</MaxThreadExecutionTime>
+
+    <!--
+        A flag to enable or disable Ghost Deployer. By default this is set to false. That is
+        because the Ghost Deployer works only with the HTTP/S transports. If you are using
+        other transports, don't enable Ghost Deployer.
+    -->
+    <GhostDeployment>
+        <Enabled>false</Enabled>
+    </GhostDeployment>
+
+
+    <!--
+        Eager loading or lazy loading is a design pattern commonly used in computer programming which
+        will initialize an object upon creation or load on-demand. In carbon, lazy loading is used to
+        load tenant when a request is received only. Similarly Eager loading is used to enable load
+        existing tenants after carbon server starts up. Using this feature, you will be able to include
+        or exclude tenants which are to be loaded when server startup.
+
+        We can enable only one LoadingPolicy at a given time.
+
+        1. Tenant Lazy Loading
+           This is the default behaviour and enabled by default. With this policy, tenants are not loaded at
+           server startup, but loaded based on-demand (i.e when a request is received for a tenant).
+           The default tenant idle time is 30 minutes.
+
+        2. Tenant Eager Loading
+           This is by default not enabled. It can be be enabled by un-commenting the <EagerLoading> section.
+           The eager loading configurations supported are as below. These configurations can be given as the
+           value for <Include> element with eager loading.
+                (i)Load all tenants when server startup             -   *
+                (ii)Load all tenants except foo.com & bar.com       -   *,!foo.com,!bar.com
+                (iii)Load only foo.com &  bar.com to be included    -   foo.com,bar.com
+    -->
+    <Tenant>
+        <LoadingPolicy>
+            <LazyLoading>
+                <IdleTime>30</IdleTime>
+            </LazyLoading>
+            <!-- <EagerLoading>
+                   <Include>*,!foo.com,!bar.com</Include>
+            </EagerLoading>-->
+        </LoadingPolicy>
+    </Tenant>
+
+    <!--
+     Caching related configurations
+    -->
+    <Cache>
+        <!-- Default cache timeout in minutes -->
+        <DefaultCacheTimeout>15</DefaultCacheTimeout>
+    </Cache>
+
+    <!--
+    Axis2 related configurations
+    -->
+    <Axis2Config>
+        <!--
+             Location of the Axis2 Services & Modules repository
+
+             This can be a directory in the local file system, or a URL.
+
+             e.g.
+             1. /home/wso2wsas/repository/ - An absolute path
+             2. repository - In this case, the path is relative to CARBON_HOME
+             3. file:///home/wso2wsas/repository/
+             4. http://wso2wsas/repository/
+        -->
+        <RepositoryLocation>${carbon.home}/repository/deployment/server/</RepositoryLocation>
+
+        <!--
+         Deployment update interval in seconds. This is the interval between repository listener
+         executions. 
+        -->
+        <DeploymentUpdateInterval>15</DeploymentUpdateInterval>
+
+        <!--
+            Location of the main Axis2 configuration descriptor file, a.k.a. axis2.xml file
+
+            This can be a file on the local file system, or a URL
+
+            e.g.
+            1. /home/repository/axis2.xml - An absolute path
+            2. repository.conf/axis2.xml - In this case, the path is relative to CARBON_HOME
+            3. file:///home/carbon/repository/axis2.xml
+            4. http://repository/conf/axis2.xml
+        -->
+        <ConfigurationFile>${carbon.home}/repository/conf/axis2/axis2.xml</ConfigurationFile>
+
+        <!--
+          ServiceGroupContextIdleTime, which will be set in ConfigurationContex
+          for multiple clients which are going to access the same ServiceGroupContext
+          Default Value is 30 Sec.
+        -->
+        <ServiceGroupContextIdleTime>30000</ServiceGroupContextIdleTime>
+
+        <!--
+          This repository location is used to crete the client side configuration
+          context used by the server when calling admin services.
+        -->
+        <ClientRepositoryLocation>${carbon.home}/repository/deployment/client/</ClientRepositoryLocation>
+        <!-- This axis2 xml is used in createing the configuration context by the FE server
+         calling to BE server -->
+        <clientAxis2XmlLocation>${carbon.home}/repository/conf/axis2/axis2_client.xml</clientAxis2XmlLocation>
+        <!-- If this parameter is set, the ?wsdl on an admin service will not give the admin service wsdl. -->
+        <HideAdminServiceWSDLs>true</HideAdminServiceWSDLs>
+	
+	<!--WARNING-Use With Care! Uncommenting bellow parameter would expose all AdminServices in HTTP transport.
+	With HTTP transport your credentials and data routed in public channels are vulnerable for sniffing attacks. 
+	Use bellow parameter ONLY if your communication channels are confirmed to be secured by other means -->
+        <!--HttpAdminServices>*</HttpAdminServices-->
+
+    </Axis2Config>
+
+    <!--
+       The default user roles which will be created when the server
+       is started up for the first time.
+    -->
+    <ServiceUserRoles>
+        <Role>
+            <Name>admin</Name>
+            <Description>Default Administrator Role</Description>
+        </Role>
+        <Role>
+            <Name>user</Name>
+            <Description>Default User Role</Description>
+        </Role>
+    </ServiceUserRoles>
+    
+    <!-- 
+      Enable following config to allow Emails as usernames. 	
+    -->	    	
+    <!--EnableEmailUserName>true</EnableEmailUserName-->	
+
+    <!--
+      Security configurations
+    -->
+    <Security>
+        <!--
+            KeyStore which will be used for encrypting/decrypting passwords
+            and other sensitive information.
+        -->
+        <KeyStore>
+            <!-- Keystore file location-->
+            <Location>${carbon.home}/repository/resources/security/wso2carbon.jks</Location>
+            <!-- Keystore type (JKS/PKCS12 etc.)-->
+            <Type>JKS</Type>
+            <!-- Keystore password-->
+            <Password>wso2carbon</Password>
+            <!-- Private Key alias-->
+            <KeyAlias>wso2carbon</KeyAlias>
+            <!-- Private Key password-->
+            <KeyPassword>wso2carbon</KeyPassword>
+        </KeyStore>
+
+        <!--
+            System wide trust-store which is used to maintain the certificates of all
+            the trusted parties.
+        -->
+        <TrustStore>
+            <!-- trust-store file location -->
+            <Location>${carbon.home}/repository/resources/security/client-truststore.jks</Location>
+            <!-- trust-store type (JKS/PKCS12 etc.) -->
+            <Type>JKS</Type>
+            <!-- trust-store password -->
+            <Password>wso2carbon</Password>
+        </TrustStore>
+
+        <!--
+            The Authenticator configuration to be used at the JVM level. We extend the
+            java.net.Authenticator to make it possible to authenticate to given servers and 
+            proxies.
+        -->
+        <NetworkAuthenticatorConfig>
+            <!-- 
+                Below is a sample configuration for a single authenticator. Please note that
+                all child elements are mandatory. Not having some child elements would lead to
+                exceptions at runtime.
+            -->
+            <!-- <Credential> -->
+                <!-- 
+                    the pattern that would match a subset of URLs for which this authenticator
+                    would be used
+                -->
+                <!-- <Pattern>regularExpression</Pattern> -->
+                <!-- 
+                    the type of this authenticator. Allowed values are:
+                    1. server
+                    2. proxy
+                -->
+                <!-- <Type>proxy</Type> -->
+                <!-- the username used to log in to server/proxy -->
+                <!-- <Username>username</Username> -->
+                <!-- the password used to log in to server/proxy -->
+                <!-- <Password>password</Password> -->
+            <!-- </Credential> -->
+        </NetworkAuthenticatorConfig>
+
+        <!--
+         The Tomcat realm to be used for hosted Web applications. Allowed values are;
+         1. UserManager
+         2. Memory
+
+         If this is set to 'UserManager', the realm will pick users & roles from the system's
+         WSO2 User Manager. If it is set to 'memory', the realm will pick users & roles from
+         CARBON_HOME/repository/repository.conf/tomcat/tomcat-users.xml
+        -->
+        <TomcatRealm>UserManager</TomcatRealm>
+
+	<!--Option to disable storing of tokens issued by STS-->
+	<DisableTokenStore>false</DisableTokenStore>
+
+ <STSCallBackHandlerName>org.wso2.carbon.identity.provider.AttributeCallbackHandler</STSCallBackHandlerName>
+
+	<!--
+	 Security token store class name. If this is not set, default class will be
+	 org.wso2.carbon.security.util.SecurityTokenStore
+	-->
+	<TokenStoreClassName>org.wso2.carbon.identity.sts.store.DBTokenStore</TokenStoreClassName>
+
+        <XSSPreventionConfig>
+            <Enabled>true</Enabled>
+            <Rule>allow</Rule>
+            <Patterns>
+                <!--Pattern></Pattern-->
+            </Patterns>
+        </XSSPreventionConfig>
+    </Security>
+<HideMenuItemIds>
+<HideMenuItemId>claim_mgt_menu</HideMenuItemId>
+<HideMenuItemId>identity_mgt_emailtemplate_menu</HideMenuItemId>
+<HideMenuItemId>identity_security_questions_menu</HideMenuItemId>
+</HideMenuItemIds>
+
+    <!--
+       The temporary work directory
+    -->
+    <WorkDirectory>${carbon.home}/tmp/work</WorkDirectory>
+
+    <!--
+       House-keeping configuration
+    -->
+    <HouseKeeping>
+
+        <!--
+           true  - Start House-keeping thread on server startup
+           false - Do not start House-keeping thread on server startup.
+                   The user will run it manually as and when he wishes.
+        -->
+        <AutoStart>true</AutoStart>
+
+        <!--
+           The interval in *minutes*, between house-keeping runs
+        -->
+        <Interval>10</Interval>
+
+        <!--
+          The maximum time in *minutes*, temp files are allowed to live
+          in the system. Files/directories which were modified more than
+          "MaxTempFileLifetime" minutes ago will be removed by the
+          house-keeping task
+        -->
+        <MaxTempFileLifetime>30</MaxTempFileLifetime>
+    </HouseKeeping>
+
+    <!--
+       Configuration for handling different types of file upload & other file uploading related
+       config parameters.
+       To map all actions to a particular FileUploadExecutor, use
+       <Action>*</Action>
+    -->
+    <FileUploadConfig>
+        <!--
+           The total file upload size limit in MB
+        -->
+        <TotalFileSizeLimit>100</TotalFileSizeLimit>
+
+        <Mapping>
+            <Actions>
+                <Action>keystore</Action>
+                <Action>certificate</Action>
+                <Action>*</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.AnyFileUploadExecutor</Class>
+        </Mapping>
+
+        <Mapping>
+            <Actions>
+                <Action>jarZip</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.JarZipUploadExecutor</Class>
+        </Mapping>
+        <Mapping>
+            <Actions>
+                <Action>dbs</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.DBSFileUploadExecutor</Class>
+        </Mapping>
+        <Mapping>
+            <Actions>
+                <Action>tools</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.ToolsFileUploadExecutor</Class>
+        </Mapping>
+        <Mapping>
+            <Actions>
+                <Action>toolsAny</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.ToolsAnyFileUploadExecutor</Class>
+        </Mapping>
+    </FileUploadConfig>
+
+    <!-- FileNameRegEx is used to validate the file input/upload/write-out names.
+    e.g.
+     <FileNameRegEx>^(?!(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(?:\.[^.])?$)[^&lt;&gt:"/\\|?*\x00-\x1F][^&lt;&gt:"/\\|?*\x00-\x1F\ .]$</FileNameRegEx>
+    -->
+    <!--<FileNameRegEx></FileNameRegEx>-->
+
+    <!--
+       Processors which process special HTTP GET requests such as ?wsdl, ?policy etc.
+
+       In order to plug in a processor to handle a special request, simply add an entry to this
+       section.
+
+       The value of the Item element is the first parameter in the query string(e.g. ?wsdl)
+       which needs special processing
+       
+       The value of the Class element is a class which implements
+       org.wso2.carbon.transport.HttpGetRequestProcessor
+    -->
+    <HttpGetRequestProcessors>
+        <Processor>
+            <Item>info</Item>
+            <Class>org.wso2.carbon.core.transports.util.InfoProcessor</Class>
+        </Processor>
+        <Processor>
+            <Item>wsdl</Item>
+            <Class>org.wso2.carbon.core.transports.util.Wsdl11Processor</Class>
+        </Processor>
+        <Processor>
+            <Item>wsdl2</Item>
+            <Class>org.wso2.carbon.core.transports.util.Wsdl20Processor</Class>
+        </Processor>
+        <Processor>
+            <Item>xsd</Item>
+            <Class>org.wso2.carbon.core.transports.util.XsdProcessor</Class>
+        </Processor>
+    </HttpGetRequestProcessors>
+
+    <!-- Deployment Synchronizer Configuration. Enable value to true when running with "svn based" dep sync.
+	In master nodes you need to set both AutoCommit and AutoCheckout to true
+	and in  worker nodes set only AutoCheckout to true.
+    -->
+    <DeploymentSynchronizer>
+        <Enabled>false</Enabled>
+        <AutoCommit>false</AutoCommit>
+        <AutoCheckout>true</AutoCheckout>
+        <RepositoryType>svn</RepositoryType>
+        <SvnUrl>http://svnrepo.example.com/repos/</SvnUrl>
+        <SvnUser>username</SvnUser>
+        <SvnPassword>password</SvnPassword>
+        <SvnUrlAppendTenantId>true</SvnUrlAppendTenantId>
+    </DeploymentSynchronizer>
+
+    <!-- Deployment Synchronizer Configuration. Uncomment the following section when running with "registry based" dep sync.
+        In master nodes you need to set both AutoCommit and AutoCheckout to true
+        and in  worker nodes set only AutoCheckout to true.
+    -->
+    <!--<DeploymentSynchronizer>
+        <Enabled>true</Enabled>
+        <AutoCommit>false</AutoCommit>
+        <AutoCheckout>true</AutoCheckout>
+    </DeploymentSynchronizer>-->
+
+    <!-- Mediation persistence configurations. Only valid if mediation features are available i.e. ESB -->
+    <!--<MediationConfig>
+        <LoadFromRegistry>false</LoadFromRegistry>
+        <SaveToFile>false</SaveToFile>
+        <Persistence>enabled</Persistence>
+        <RegistryPersistence>enabled</RegistryPersistence>
+    </MediationConfig>-->
+
+    <!--
+    Server intializing code, specified as implementation classes of org.wso2.carbon.core.ServerInitializer.
+    This code will be run when the Carbon server is initialized
+    -->
+    <ServerInitializers>
+        <!--<Initializer></Initializer>-->
+    </ServerInitializers>
+    
+    <!--
+    Indicates whether the Carbon Servlet is required by the system, and whether it should be
+    registered
+    -->
+    <RequireCarbonServlet>${require.carbon.servlet}</RequireCarbonServlet>
+
+    <!--
+    Carbon H2 OSGI Configuration
+    By default non of the servers start.
+        name="web" - Start the web server with the H2 Console
+        name="webPort" - The port (default: 8082)
+        name="webAllowOthers" - Allow other computers to connect
+        name="webSSL" - Use encrypted (HTTPS) connections
+        name="tcp" - Start the TCP server
+        name="tcpPort" - The port (default: 9092)
+        name="tcpAllowOthers" - Allow other computers to connect
+        name="tcpSSL" - Use encrypted (SSL) connections
+        name="pg" - Start the PG server
+        name="pgPort"  - The port (default: 5435)
+        name="pgAllowOthers"  - Allow other computers to connect
+        name="trace" - Print additional trace information; for all servers
+        name="baseDir" - The base directory for H2 databases; for all servers  
+    -->
+    <!--H2DatabaseConfiguration>
+        <property name="web" />
+        <property name="webPort">8082</property>
+        <property name="webAllowOthers" />
+        <property name="webSSL" />
+        <property name="tcp" />
+        <property name="tcpPort">9092</property>
+        <property name="tcpAllowOthers" />
+        <property name="tcpSSL" />
+        <property name="pg" />
+        <property name="pgPort">5435</property>
+        <property name="pgAllowOthers" />
+        <property name="trace" />
+        <property name="baseDir">${carbon.home}</property>
+    </H2DatabaseConfiguration-->
+    <!--Disabling statistics reporter by default-->
+    <StatisticsReporterDisabled>true</StatisticsReporterDisabled>
+
+    <!-- Enable accessing Admin Console via HTTP -->
+    <!-- EnableHTTPAdminConsole>true</EnableHTTPAdminConsole -->
+
+    <!--
+       Default Feature Repository of WSO2 Carbon.
+    -->
+    <FeatureRepository>
+	    <RepositoryName>default repository</RepositoryName>
+	    <RepositoryURL>http://product-dist.wso2.com/p2/carbon/releases/wilkes/</RepositoryURL>
+    </FeatureRepository>
+
+    <!--
+	Configure API Management
+   -->
+   <APIManagement>
+	
+	<!--Uses the embedded API Manager by default. If you want to use an external 
+	API Manager instance to manage APIs, configure below  externalAPIManager-->
+	
+	<Enabled>true</Enabled>
+	
+	<!--Uncomment and configure API Gateway and 
+	Publisher URLs to use external API Manager instance-->
+	
+	<!--ExternalAPIManager>
+
+		<APIGatewayURL>http://localhost:8281</APIGatewayURL>
+		<APIPublisherURL>http://localhost:8281/publisher</APIPublisherURL>
+
+	</ExternalAPIManager-->
+	
+	<LoadAPIContextsInServerStartup>true</LoadAPIContextsInServerStartup>
+   </APIManagement>
+</Server>

--- a/components/org.wso2.carbon.identity.idle.account.identification/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.idle.account.identification/src/test/resources/testng.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="org.wso2.carbon.identity.api.idle.account.identification.core.services">
+
+    <test name="idle-account-identification-tests" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.carbon.identity.idle.account.identification.IdleAccountIdentificationServiceImplTest"/>
+        </classes>
+    </test>
+</suite>

--- a/features/org.wso2.carbon.identity.governance.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.feature/pom.xml
@@ -93,6 +93,12 @@
             <version>${project.version}</version>
             <type>zip</type>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.idle.account.identification.server.feature</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+        </dependency>
     </dependencies>
 
     <build>
@@ -135,6 +141,9 @@
                                 </includedFeatureDef>
                                 <includedFeatureDef>
                                     org.wso2.carbon.identity.governance:org.wso2.carbon.identity.account.suspension.notification.task.server.feature
+                                </includedFeatureDef>
+                                <includedFeatureDef>
+                                    org.wso2.carbon.identity.governance:org.wso2.carbon.identity.idle.account.identification.server.feature
                                 </includedFeatureDef>
                                 <includedFeatureDef>
                                     org.wso2.carbon.identity.governance:org.wso2.carbon.identity.recovery.ui.feature

--- a/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.8.53-SNAPSHOT</version>
+        <version>1.8.57-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.governance</groupId>
+        <artifactId>identity-governance</artifactId>
+        <relativePath>../../pom.xml</relativePath>
+        <version>1.8.53-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.idle.account.identification.server.feature</artifactId>
+    <packaging>pom</packaging>
+    <name>WSO2 Carbon - Idle User Account Identification Feature</name>
+    <url>http://wso2.org</url>
+    <description>This feature contains the core bundles required for Idle User Account Identification
+        functionality
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.idle.account.identification</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>carbon-p2-plugin</artifactId>
+                <version>${carbon.p2.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>p2-feature-generation</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>p2-feature-gen</goal>
+                        </goals>
+                        <configuration>
+                            <id>org.wso2.carbon.identity.idle.account.identification.server</id>
+                            <propertiesFile>../../etc/feature.properties</propertiesFile>
+                            <adviceFile>
+                                <properties>
+                                    <propertyDef>org.wso2.carbon.p2.category.type:server</propertyDef>
+                                </properties>
+                            </adviceFile>
+                            <bundles>
+                                <bundleDef>org.wso2.carbon.identity.governance:org.wso2.carbon.identity.idle.account.identification</bundleDef>
+                            </bundles>
+                            <importFeatures>
+                            </importFeatures>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <module>components/org.wso2.carbon.identity.tenant.resource.manager</module>
         <module>components/org.wso2.carbon.identity.multi.attribute.login</module>
         <module>components/org.wso2.carbon.identity.auth.attribute.handler</module>
+        <module>components/org.wso2.carbon.identity.idle.account.identification</module>
 
         <module>service-stubs/identity</module>
 
@@ -73,6 +74,7 @@
         <module>features/org.wso2.carbon.identity.governance.feature</module>
         <module>features/org.wso2.carbon.identity.password.policy.server.feature</module>
         <module>features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature</module>
+        <module>features/org.wso2.carbon.identity.idle.account.identification.server.feature</module>
         <module>features/org.wso2.carbon.identity.tenant.resource.manager.feature</module>
         <module>features/org.wso2.carbon.identity.multi.attribute.login.service.server.feature</module>
         <module>features/org.wso2.carbon.identity.auth.attribute.handler.server.feature</module>
@@ -334,6 +336,11 @@
             <dependency>
                 <groupId>org.wso2.carbon.identity.governance</groupId>
                 <artifactId>org.wso2.carbon.identity.account.suspension.notification.task</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.governance</groupId>
+                <artifactId>org.wso2.carbon.identity.idle.account.identification</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -701,6 +708,7 @@
         <slf4j.api.version>1.6.1</slf4j.api.version>
         <org.slf4j.imp.pkg.version.range>[1.5.5,2.0.0)</org.slf4j.imp.pkg.version.range>
         <mockito.version>3.10.0</mockito.version>
+        <mockito-core.version>4.6.1</mockito-core.version>
         <powermock.version>2.0.8</powermock.version>
         <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
         


### PR DESCRIPTION
Related Issue:
https://github.com/wso2/product-is/issues/16356

Provide idle account identification API support to retrieve the list of users who have not successfully logged after given time stamp.

Related PRs:
- https://github.com/wso2/carbon-identity-framework/pull/4813
- https://github.com/wso2/identity-api-server/pull/470
