### PR TITLE
[2.0.x] Changing debug log to a warn log when multiple users matched for give…

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -312,10 +312,7 @@ public class UserAccountRecoveryManager {
                 resultedUserList.addAll(abstractUserStoreManager.getUserListWithID(operationalCondition, domain,
                         UserCoreConstants.DEFAULT_PROFILE, 2, 1, null, null));
                 if (resultedUserList.size() > 1) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Multiple users matched for given claims set : " +
-                                Arrays.toString(resultedUserList.toArray()));
-                    }
+                    log.warn("Multiple users matched for given claims set: " + claims.keySet());
                     throw Utils.handleClientException(
                             IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_MULTIPLE_MATCHING_USERS, null);
                 }


### PR DESCRIPTION
### Proposed changes in this pull request

> Changing debug log to a warn log when multiple users matched for given claims in username recovery flow.

### Related master PR

- https://github.com/wso2-extensions/identity-governance/pull/732

### Related git issue

- https://github.com/wso2/product-is/issues/16208

