### PR TITLE
Fix multi attribute login issue when claims have the same regex pattern

### DIFF
--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
@@ -34,8 +34,13 @@ import org.wso2.carbon.user.core.common.User;
 import org.wso2.carbon.user.core.constants.UserCoreClaimConstants;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * This class is used to implement MultiAttributeLoginResolver. In this class, users will be resolved using a regex
@@ -56,29 +61,19 @@ public class RegexResolver implements MultiAttributeLoginResolver {
             UserRealm userRealm = UserResolverUtil.getUserRealm(tenantDomain);
             UniqueIDUserStoreManager userStoreManager = UserResolverUtil.getUserStoreManager(tenantDomain);
             ClaimManager claimManager = userRealm.getClaimManager();
-            for (String claimURI : allowedAttributes) {
-                Claim claim = claimManager.getClaim(claimURI);
-                if (claim == null) {
-                    continue;
-                }
-                String regex = claim.getRegEx();
-                if (StringUtils.isBlank(regex)) {
-                    continue;
-                }
-                Pattern pattern = Pattern.compile(regex);
-                String domainSeparateAttribute = UserCoreUtil.removeDomainFromName(loginAttribute);
-                if (pattern.matcher(domainSeparateAttribute).matches()) {
-                    setResolvedUserResult(userStoreManager, claimURI, loginAttribute, resolvedUserResult, claim);
-                    break;
-                }
-            }
+
+            resolveDistinctUsersForClaims(loginAttribute, allowedAttributes, claimManager, userStoreManager,
+                    resolvedUserResult);
+
             /*
             resolve user if allowed attributes has only username claim,
             but username claim has no configured regex pattern.
              */
             if (allowedAttributes.size() == 1 &&
                     allowedAttributes.contains(UserCoreClaimConstants.USERNAME_CLAIM_URI)) {
-                setResolvedUserResult(userStoreManager, UserCoreClaimConstants.USERNAME_CLAIM_URI, loginAttribute,
+                List<User> userList = userStoreManager.getUserListWithID(UserCoreClaimConstants.USERNAME_CLAIM_URI,
+                        loginAttribute, null);
+                setResolvedUserResult(userList, UserCoreClaimConstants.USERNAME_CLAIM_URI, loginAttribute,
                         resolvedUserResult, claimManager.getClaim(UserCoreClaimConstants.USERNAME_CLAIM_URI));
             }
         } catch (UserStoreException e) {
@@ -87,11 +82,77 @@ public class RegexResolver implements MultiAttributeLoginResolver {
         return resolvedUserResult;
     }
 
-    private void setResolvedUserResult(UniqueIDUserStoreManager userStoreManager, String claimURI,
-                                           String loginAttribute, ResolvedUserResult resolvedUserResult, Claim claim)
+    private void resolveDistinctUsersForClaims(String loginAttribute, List<String> allowedAttributes,
+                                               ClaimManager claimManager,
+                                               UniqueIDUserStoreManager userStoreManager,
+                                               ResolvedUserResult resolvedUserResult)
+            throws UserStoreException {
+
+        Set<String> uniqueUserIds = new HashSet<>();
+        Map<String, List<User>> distinctUsers = new HashMap<>();
+
+        for (String claimURI : allowedAttributes) {
+            Claim claim = claimManager.getClaim(claimURI);
+            if (claim == null || StringUtils.isBlank(claim.getRegEx())) {
+                continue;
+            }
+
+            Pattern pattern = Pattern.compile(claim.getRegEx());
+            String domainSeparateAttribute = UserCoreUtil.removeDomainFromName(loginAttribute);
+
+            if (pattern.matcher(domainSeparateAttribute).matches()) {
+                List<User> userList = userStoreManager.getUserListWithID(claimURI, loginAttribute, null);
+                if (userList.isEmpty()) {
+                    continue;
+                }
+                /*
+                This is to make sure that the same user is not added to the list multiple times from different claims.
+                */
+                List<User> allowedDistinctUsersForClaim = userList.stream()
+                        .filter(user -> uniqueUserIds.add(user.getUserID()))
+                        .collect(Collectors.toList());
+
+                if (allowedDistinctUsersForClaim.size() == 1) {
+                    /*
+                    If the disctinctUsers map already contains a record that means multiple users has been resolved
+                    for the login identifier from different claims. Hence, terminate the iteration and set the error
+                    message.
+                    */
+                    if (distinctUsers.size() > 0) {
+                        resolvedUserResult.setErrorMessage("Found multiple users for " + allowedAttributes +
+                                " to value " + loginAttribute);
+                        return;
+                    } else {
+                        distinctUsers.put(claimURI, allowedDistinctUsersForClaim);
+                    }
+                    /*
+                    If the allowedDistinctUsersForClaim size is greater than 1, that means multiple users has been
+                    resolved for the same login identifier from the same claim. Hence, terminate the iteration and set
+                    the error message.
+                    */
+                } else if (allowedDistinctUsersForClaim.size() > 1) {
+                    resolvedUserResult.setErrorMessage("Found multiple users for " + claim.getDisplayTag() +
+                            " to value " + loginAttribute);
+                    return;
+                }
+            }
+        }
+
+        /*
+        At this point distinctUsers map will contain only one entry if the login identifier is resolved to a single
+        user from multiple claims. If the map is empty, that means the login identifier is not resolved to any user.
+        */
+        if (distinctUsers.size() == 1) {
+            Map.Entry<String, List<User>> entry = distinctUsers.entrySet().iterator().next();
+            setResolvedUserResult(entry.getValue(), entry.getKey(), loginAttribute, resolvedUserResult,
+                    claimManager.getClaim(entry.getKey()));
+        }
+    }
+
+    private void setResolvedUserResult(List<User> userList, String claimURI,
+                                       String loginAttribute, ResolvedUserResult resolvedUserResult, Claim claim)
             throws org.wso2.carbon.user.core.UserStoreException {
 
-        List<User> userList = userStoreManager.getUserListWithID(claimURI, loginAttribute, null);
         if (userList.size() == 1) {
             resolvedUserResult.setResolvedStatus(ResolvedUserResult.UserResolvedStatus.SUCCESS);
             resolvedUserResult.setResolvedClaim(claimURI);


### PR DESCRIPTION
### Proposed changes in this pull request

This PR will fix the issue of multi-attribute login when there are multiple claims configured in the "Allowed Attribute Claim List" with the same regex patterns. 
With this improvement, we will iterate through all the claims in the "Allowed Attribute Claim List" to resolve users. After going through all the claims if and only if it is resolved to a single user, it will proceed. Otherwise, it will throw an error ensuring only the allowed users are proceeding further.

### Related Issue

- https://github.com/wso2/product-is/issues/16308