### PR TITLE
Improve the IdentityUserMetadataMgtHandler

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -408,7 +408,11 @@ public class IdentityRecoveryConstants {
         // UEV - User Email Verification.
         ERROR_CODE_VERIFICATION_EMAIL_NOT_FOUND("UEV-10001", "Email address not found for email verification"),
 
-        INVALID_PASSWORD_RECOVERY_REQUEST("APR-10000", "Invalid Password Recovery Request");
+        INVALID_PASSWORD_RECOVERY_REQUEST("APR-10000", "Invalid Password Recovery Request")
+        ,
+        // Idle User Account Identification related Error messages.
+        ERROR_RETRIEVING_ASSOCIATED_USER("UMM-65005",
+                "Error retrieving the associated user for the user: %s in the tenant %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/IdentityUserMetadataMgtHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/IdentityUserMetadataMgtHandler.java
@@ -18,18 +18,30 @@
 
 package org.wso2.carbon.identity.recovery.handler;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.core.handler.InitConfig;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.mgt.constants.IdentityMgtConstants;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
+import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
+import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
+import org.wso2.carbon.identity.user.profile.mgt.association.federation.exception.FederatedAssociationManagerException;
+import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.UserStoreConfigConstants;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,16 +52,13 @@ import java.util.Map;
 public class IdentityUserMetadataMgtHandler extends AbstractEventHandler {
 
     private static final Log log = LogFactory.getLog(IdentityUserMetadataMgtHandler.class);
-    private static final String POST_AUTHENTICATION = "post_authentication";
-    private static final String POST_CREDENTIAL_UPDATE = "post_credential_update";
     private static final String ENABLE_IDENTITY_USER_METADATA_MGT_HANDLER = "identityUserMetadataMgtHandler.enable";
+    private static final String PRE_SET_USER_CLAIM_VALUES = "PreSetUserClaimValues";
 
     @Override
     public void handleEvent(Event event) throws IdentityEventException {
 
         Map<String, Object> eventProperties = event.getEventProperties();
-        UserStoreManager userStoreManager = (UserStoreManager)
-                eventProperties.get(IdentityEventConstants.EventProperty.USER_STORE_MANAGER);
 
         boolean enable = Boolean.parseBoolean(configs.getModuleProperties().getProperty(
                 ENABLE_IDENTITY_USER_METADATA_MGT_HANDLER));
@@ -59,49 +68,137 @@ public class IdentityUserMetadataMgtHandler extends AbstractEventHandler {
             }
             return;
         }
-        if (IdentityEventConstants.Event.POST_AUTHENTICATION.equals(event.getEventName())) {
-            handlePostAuthenticate(eventProperties, userStoreManager);
-        } else if (IdentityEventConstants.Event.POST_UPDATE_CREDENTIAL.equals(event.getEventName()) ||
-                IdentityEventConstants.Event.POST_UPDATE_CREDENTIAL_BY_ADMIN.equals(event.getEventName())) {
-            handleCredentialUpdate(eventProperties, userStoreManager);
+
+        if (IdentityEventConstants.EventName.AUTHENTICATION_SUCCESS.name().equals(event.getEventName())) {
+            AuthenticationContext context = (AuthenticationContext) eventProperties.get(
+                    IdentityEventConstants.EventProperty.CONTEXT);
+            handleUserMetadataUpdate(context);
         }
     }
 
-    private void handlePostAuthenticate(Map<String, Object> eventProperties, UserStoreManager userStoreManager)
-            throws IdentityEventException {
+
+    /**
+     * Method to handle user metadata update during AUTHENTICATION_SUCCESS event.
+     *
+     * @param authenticationContext     Authentication context.
+     * @throws IdentityEventException   Identity Event Exception.
+     */
+    private void handleUserMetadataUpdate(AuthenticationContext authenticationContext) throws IdentityEventException {
 
         if (log.isDebugEnabled()) {
-            log.debug("Start handling post authentication event.");
+            log.debug("Start handling authentication success event.");
         }
-        if ((Boolean) eventProperties.get(IdentityEventConstants.EventProperty.OPERATION_STATUS)) {
-            String lastLoginTime = Long.toString(System.currentTimeMillis());
-            setUserClaim(userStoreManager, eventProperties, IdentityMgtConstants.LAST_LOGIN_TIME,
-                    lastLoginTime, POST_AUTHENTICATION);
+        // Check whether the authentication is passive.
+        if (authenticationContext.isPassiveAuthenticate()) {
+            return;
         }
-    }
-
-    private void handleCredentialUpdate(Map<String, Object> eventProperties, UserStoreManager userStoreManager)
-            throws IdentityEventException {
-
-        if (log.isDebugEnabled()) {
-            log.debug("Start handling post credential update event.");
+        AuthenticatedUser authenticatedUser = authenticationContext.getSequenceConfig().getAuthenticatedUser();
+        if (authenticatedUser == null) {
+            return;
         }
-        String lastPasswordUpdateTime = Long.toString(System.currentTimeMillis());
-        setUserClaim(userStoreManager, eventProperties, IdentityMgtConstants.LAST_PASSWORD_UPDATE_TIME,
-                lastPasswordUpdateTime, POST_CREDENTIAL_UPDATE);
-    }
-
-    private void setUserClaim(UserStoreManager userStoreManager, Map<String, Object> eventProperties,
-                              String claimURI, String claimValue, String eventName) throws IdentityEventException {
-
-        String username = (String) eventProperties.get(IdentityEventConstants.EventProperty.USER_NAME);
-        Map<String, String> userClaims = new HashMap<>();
-        userClaims.put(claimURI, claimValue);
-        try {
-            userStoreManager.setUserClaimValues(username, userClaims, null);
-            if (log.isDebugEnabled()) {
-                log.debug(String.format("Successfully updated the user claims related to %s event.", eventName));
+        if (authenticatedUser.isFederatedUser()) {
+            AuthenticatedUser associatedUser = getAssociatedUser(authenticatedUser);
+            if (associatedUser != null) {
+                authenticatedUser = associatedUser;
+            } else {
+                // If the user is federated and not associated with a local user,
+                // skip storing user metadata values.
+                return;
             }
+        }
+        try {
+            UserStoreManager userStoreManager = getUserStoreManager(authenticatedUser);
+            if (userStoreManager == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("User store manager is null for username: " + authenticatedUser.getUserName() +
+                            " in tenant domain: " + authenticatedUser.getTenantDomain());
+                }
+                return;
+            }
+            String lastLoginTime = Long.toString(System.currentTimeMillis());
+            Map<String, String> userClaims = new HashMap<>();
+            userClaims.put(IdentityMgtConstants.LAST_LOGIN_TIME, lastLoginTime);
+            setUserMetadataValues(userStoreManager, authenticatedUser, userClaims,
+                    IdentityEventConstants.EventName.AUTHENTICATION_SUCCESS.name());
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            IdentityRecoveryConstants.ErrorMessages error = IdentityRecoveryConstants.ErrorMessages
+                    .ERROR_CODE_ERROR_GETTING_USERSTORE_MANAGER;
+            throw new IdentityEventException(error.getCode(), error.getMessage(), e);
+        }
+    }
+
+    private AuthenticatedUser getAssociatedUser(AuthenticatedUser authenticatedUser) throws IdentityEventException {
+
+        String associatesUserName;
+        AuthenticatedUser associatedUserObj = null;
+        try {
+            String subjectIdentifierValue = authenticatedUser.getUserName();
+            FederatedAssociationManager federatedAssociationManager =
+                    IdentityRecoveryServiceDataHolder.getInstance().getFederatedAssociationManager();
+            associatesUserName = federatedAssociationManager.getUserForFederatedAssociation(
+                    authenticatedUser.getTenantDomain(), authenticatedUser.getFederatedIdPName(),
+                    subjectIdentifierValue);
+            if (associatesUserName != null) {
+                associatedUserObj = new AuthenticatedUser();
+                associatedUserObj.setUserName(UserCoreUtil.removeDomainFromName(associatesUserName));
+                associatedUserObj.setUserStoreDomain(UserCoreUtil.extractDomainFromName(associatesUserName));
+                associatedUserObj.setTenantDomain(authenticatedUser.getTenantDomain());
+            }
+        } catch (FederatedAssociationManagerException e) {
+            IdentityRecoveryConstants.ErrorMessages error = IdentityRecoveryConstants.ErrorMessages
+                    .ERROR_RETRIEVING_ASSOCIATED_USER;
+            throw new IdentityEventException(error.getCode(), error.getMessage(), e);
+        }
+        return associatedUserObj;
+    }
+
+    /**
+     * Get user store manager.
+     *
+     * @param authenticatedUser Authenticated user.
+     * @return                  User store manager.
+     * @throws UserStoreException Error when getting the user store manager.
+     */
+    private UserStoreManager getUserStoreManager(AuthenticatedUser authenticatedUser)
+            throws org.wso2.carbon.user.api.UserStoreException {
+
+        RealmService realmService = IdentityRecoveryServiceDataHolder.getInstance().getRealmService();
+        String userStoreDomainName = authenticatedUser.getUserStoreDomain();
+        if (StringUtils.isBlank(authenticatedUser.getUserStoreDomain())) {
+            if (log.isDebugEnabled()) {
+                log.error("User store domain is not found for the user: " + authenticatedUser.getUserName() +
+                        " in tenant domain: " + authenticatedUser.getTenantDomain());
+            }
+            return null;
+        }
+        int tenantId = IdentityTenantUtil.getTenantId(authenticatedUser.getTenantDomain());
+        UserRealm userRealm;
+        if (UserStoreConfigConstants.PRIMARY.equals(userStoreDomainName)) {
+            userRealm = (UserRealm) realmService.getTenantUserRealm(tenantId);
+            return userRealm.getUserStoreManager();
+        } else {
+            userRealm = (UserRealm) realmService.getTenantUserRealm(tenantId);
+            return userRealm.getUserStoreManager().getSecondaryUserStoreManager(
+                    authenticatedUser.getUserStoreDomain());
+        }
+    }
+
+    /**
+     * Store the user metadata values into the database.
+     *
+     * @param userStoreManager  User Store manager.
+     * @param authenticatedUser Authenticated user.
+     * @param userClaims        User claims.
+     * @param eventName         Event name.
+     */
+    private void setUserMetadataValues(UserStoreManager userStoreManager, AuthenticatedUser authenticatedUser,
+                                       Map<String, String> userClaims, String eventName)
+            throws IdentityEventException {
+
+        try {
+            // Storing attribute values of users into identity store database.
+            IdentityRecoveryServiceDataHolder.getInstance().getIdentityDataStoreService().storeInIdentityDataStore(
+                    authenticatedUser.getUserName(), userStoreManager, PRE_SET_USER_CLAIM_VALUES, userClaims);
         } catch (UserStoreException e) {
             throw new IdentityEventException(
                     String.format("Error occurred while updating user claims related to %s event.", eventName), e);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceComponent.java
@@ -39,6 +39,7 @@ import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
+import org.wso2.carbon.identity.governance.service.IdentityDataStoreService;
 import org.wso2.carbon.identity.governance.service.otp.OTPGenerator;
 import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.identity.input.validation.mgt.services.InputValidationManagementService;
@@ -74,6 +75,7 @@ import org.wso2.carbon.identity.recovery.services.username.UsernameRecoveryManag
 import org.wso2.carbon.identity.recovery.signup.UserSelfRegistrationManager;
 import org.wso2.carbon.identity.recovery.username.NotificationUsernameRecoveryManager;
 import org.wso2.carbon.identity.user.functionality.mgt.UserFunctionalityManager;
+import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
@@ -475,5 +477,42 @@ public class IdentityRecoveryServiceComponent {
     protected void unsetInputValidationMgtService(InputValidationManagementService inputValidationMgtService) {
 
         IdentityRecoveryServiceDataHolder.getInstance().setInputValidationMgtService(null);
+    }
+
+    @Reference(
+            name = "identity.user.profile.mgt.component",
+            service = FederatedAssociationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetFederatedAssociationManagerService"
+    )
+    protected void setFederatedAssociationManagerService(FederatedAssociationManager
+                                                                 federatedAssociationManagerService) {
+
+        IdentityRecoveryServiceDataHolder.getInstance().setFederatedAssociationManager(
+                federatedAssociationManagerService);
+    }
+
+    protected void unsetFederatedAssociationManagerService(FederatedAssociationManager
+                                                                   federatedAssociationManagerService) {
+
+        IdentityRecoveryServiceDataHolder.getInstance().setFederatedAssociationManager(null);
+    }
+
+    @Reference(
+            name = "identity.governance.service",
+            service = IdentityDataStoreService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdentityDataStoreService"
+    )
+    protected void setIdentityDataStoreService(IdentityDataStoreService identityDataStoreService) {
+
+        IdentityRecoveryServiceDataHolder.getInstance().setIdentityDataStoreService(identityDataStoreService);
+    }
+
+    protected void unsetIdentityDataStoreService(IdentityDataStoreService identityDataStoreService) {
+
+        IdentityRecoveryServiceDataHolder.getInstance().setIdentityDataStoreService(null);
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceDataHolder.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/IdentityRecoveryServiceDataHolder.java
@@ -26,13 +26,19 @@ import org.wso2.carbon.identity.consent.mgt.services.ConsentUtilityService;
 import org.wso2.carbon.identity.core.persistence.registry.RegistryResourceMgtService;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.governance.service.IdentityDataStoreService;
 import org.wso2.carbon.identity.governance.service.otp.OTPGenerator;
 import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.identity.input.validation.mgt.services.InputValidationManagementService;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.user.functionality.mgt.UserFunctionalityManager;
+import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.idp.mgt.IdpManager;
+import org.wso2.carbon.user.core.listener.UserOperationEventListener;
 import org.wso2.carbon.user.core.service.RealmService;
+
+import java.util.Map;
+import java.util.TreeMap;
 
 public class IdentityRecoveryServiceDataHolder {
 
@@ -52,6 +58,9 @@ public class IdentityRecoveryServiceDataHolder {
     private MultiAttributeLoginService multiAttributeLoginService;
     private InputValidationManagementService inputValidationMgtService;
     private AuthAttributeHandlerManager authAttributeHandlerManager;
+    private FederatedAssociationManager federatedAssociationManager;
+    private IdentityDataStoreService identityDataStoreService;
+    private static Map<Integer, UserOperationEventListener> userOperationEventListeners = new TreeMap<>();
     public static IdentityRecoveryServiceDataHolder getInstance() {
 
         return instance;
@@ -302,5 +311,25 @@ public class IdentityRecoveryServiceDataHolder {
     public void setInputValidationMgtService(InputValidationManagementService inputValidationMgtService) {
 
         this.inputValidationMgtService = inputValidationMgtService;
+    }
+
+    public FederatedAssociationManager getFederatedAssociationManager() {
+
+        return federatedAssociationManager;
+    }
+
+    public void setFederatedAssociationManager(FederatedAssociationManager federatedAssociationManager) {
+
+        this.federatedAssociationManager = federatedAssociationManager;
+    }
+
+    public IdentityDataStoreService getIdentityDataStoreService() {
+
+        return identityDataStoreService;
+    }
+
+    public void setIdentityDataStoreService(IdentityDataStoreService identityDataStoreService) {
+
+        this.identityDataStoreService = identityDataStoreService;
     }
 }


### PR DESCRIPTION
Related Issue:
- https://github.com/wso2/product-is/issues/16356

Introduce the following improvements to the IdentityUserMetadataMgtHandler handler.
- Triggered with the `AUTHENTICATION_SUCCESS` instead of  `POST_AUTHENTICATION` to be triggered at the federation login as well.
- A DAO layer has been implemented with the capability of storing the last  login time to the database directly without using the userStoreManager  to improve the performance of the storing mechanism since we won't be  invoking any redundant listeners with the newly implemented DAO layer.