### PR TITLE
Disable password policy validation handler by default

### DIFF
--- a/components/org.wso2.carbon.identity.password.policy/src/main/java/org/wso2/carbon/identity/password/policy/constants/PasswordPolicyConstants.java
+++ b/components/org.wso2.carbon.identity.password.policy/src/main/java/org/wso2/carbon/identity/password/policy/constants/PasswordPolicyConstants.java
@@ -26,6 +26,7 @@ public class PasswordPolicyConstants {
     public static final String PW_POLICY_LENGTH_CLASS = "passwordPolicy.class.PasswordLengthPolicy";
     public static final String PW_POLICY_NAME_CLASS = "passwordPolicy.class.PasswordNamePolicy";
     public static final String PW_POLICY_PATTERN_CLASS = "passwordPolicy.class.PasswordPatternPolicy";
+    public static final String PW_POLICY_HANDLER_ENABLED = "PasswordPolicy.PasswordPolicyValidationHandler.Enable";
 
     public enum ErrorMessages {
 

--- a/components/org.wso2.carbon.identity.password.policy/src/main/java/org/wso2/carbon/identity/password/policy/handler/PasswordPolicyValidationHandler.java
+++ b/components/org.wso2.carbon.identity.password.policy/src/main/java/org/wso2/carbon/identity/password/policy/handler/PasswordPolicyValidationHandler.java
@@ -232,8 +232,6 @@ public class PasswordPolicyValidationHandler extends AbstractEventHandler implem
     public void init(InitConfig configuration) throws IdentityRuntimeException {
 
         super.init(configuration);
-        IdentityPasswordPolicyServiceDataHolder.getInstance().getBundleContext().registerService
-                (IdentityConnectorConfig.class.getName(), this, null);
     }
 
     public String[] getPropertyNames() {

--- a/components/org.wso2.carbon.identity.password.policy/src/main/java/org/wso2/carbon/identity/password/policy/internal/IdentityPasswordPolicyServiceComponent.java
+++ b/components/org.wso2.carbon.identity.password.policy/src/main/java/org/wso2/carbon/identity/password/policy/internal/IdentityPasswordPolicyServiceComponent.java
@@ -21,6 +21,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.service.component.ComponentContext;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
 import org.wso2.carbon.identity.password.policy.handler.PasswordPolicyValidationHandler;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -43,11 +44,13 @@ public class IdentityPasswordPolicyServiceComponent {
             if (log.isDebugEnabled()) {
                 log.debug("Password Policy Service component is enabled");
             }
+            BundleContext bundleContext = context.getBundleContext();
+            IdentityPasswordPolicyServiceDataHolder.getInstance().setBundleContext(bundleContext);
             if (IdentityPasswordPolicyServiceDataHolder.getInstance().isPasswordPolicyHandlerEnabled()) {
-                BundleContext bundleContext = context.getBundleContext();
-                IdentityPasswordPolicyServiceDataHolder.getInstance().setBundleContext(bundleContext);
+
                 PasswordPolicyValidationHandler handler = new PasswordPolicyValidationHandler();
                 context.getBundleContext().registerService(AbstractEventHandler.class.getName(), handler, null);
+                context.getBundleContext().registerService(IdentityConnectorConfig.class.getName(), handler, null);
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("Password Policy Validation Handler is disabled.");

--- a/components/org.wso2.carbon.identity.password.policy/src/main/java/org/wso2/carbon/identity/password/policy/internal/IdentityPasswordPolicyServiceComponent.java
+++ b/components/org.wso2.carbon.identity.password.policy/src/main/java/org/wso2/carbon/identity/password/policy/internal/IdentityPasswordPolicyServiceComponent.java
@@ -43,10 +43,16 @@ public class IdentityPasswordPolicyServiceComponent {
             if (log.isDebugEnabled()) {
                 log.debug("Password Policy Service component is enabled");
             }
-            BundleContext bundleContext = context.getBundleContext();
-            IdentityPasswordPolicyServiceDataHolder.getInstance().setBundleContext(bundleContext);
-            PasswordPolicyValidationHandler handler = new PasswordPolicyValidationHandler();
-            context.getBundleContext().registerService(AbstractEventHandler.class.getName(), handler, null);
+            if (IdentityPasswordPolicyServiceDataHolder.getInstance().isPasswordPolicyHandlerEnabled()) {
+                BundleContext bundleContext = context.getBundleContext();
+                IdentityPasswordPolicyServiceDataHolder.getInstance().setBundleContext(bundleContext);
+                PasswordPolicyValidationHandler handler = new PasswordPolicyValidationHandler();
+                context.getBundleContext().registerService(AbstractEventHandler.class.getName(), handler, null);
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("Password Policy Validation Handler is disabled.");
+                }
+            }
         } catch (Exception e) {
             log.error("Error while activating password policy component.", e);
         }

--- a/components/org.wso2.carbon.identity.password.policy/src/main/java/org/wso2/carbon/identity/password/policy/internal/IdentityPasswordPolicyServiceDataHolder.java
+++ b/components/org.wso2.carbon.identity.password.policy/src/main/java/org/wso2/carbon/identity/password/policy/internal/IdentityPasswordPolicyServiceDataHolder.java
@@ -16,8 +16,11 @@
 
 package org.wso2.carbon.identity.password.policy.internal;
 
+import org.apache.commons.lang.StringUtils;
 import org.osgi.framework.BundleContext;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.password.policy.constants.PasswordPolicyConstants;
 
 public class IdentityPasswordPolicyServiceDataHolder {
 
@@ -31,6 +34,19 @@ public class IdentityPasswordPolicyServiceDataHolder {
     public static IdentityPasswordPolicyServiceDataHolder getInstance() {
 
         return instance;
+    }
+
+    public boolean isPasswordPolicyHandlerEnabled() {
+
+        String passwordPolicyHandlerEnabled =
+                IdentityUtil.getProperty(PasswordPolicyConstants.PW_POLICY_HANDLER_ENABLED);
+        if (StringUtils.isBlank(passwordPolicyHandlerEnabled)) {
+            /*
+            This indicates config not in the identity.xml. In that case, we need to maintain default behaviour.
+             */
+            return false;
+        }
+        return Boolean.parseBoolean(passwordPolicyHandlerEnabled);
     }
 
     public IdentityGovernanceService getIdentityGovernanceService() {


### PR DESCRIPTION
### Proposed changes in this pull request

With https://github.com/wso2/product-is/issues/16323, we are going to use an input validation handler to handle the password field. Thus, we are deprecating this policy handler. Policy handler can be enabled by following config:

```
[identity_mgt.password_policy.password_policy_validation_handler]
enable=true 
```
Config PR: https://github.com/wso2/carbon-identity-framework/pull/4836