### PR TITLE
Refactor multi attribute login user resolving logic

### DIFF
--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
@@ -138,6 +138,13 @@ public class RegexResolver implements MultiAttributeLoginResolver {
             }
         }
 
+        // Check the users from username by default if there are users found from claims and regex patterns.
+        if (distinctUsers.size() == 0) {
+            List<User> usersList = userStoreManager.getUserListWithID(UserCoreClaimConstants.USERNAME_CLAIM_URI,
+                    loginAttribute, null);
+            distinctUsers.put(UserCoreClaimConstants.USERNAME_CLAIM_URI, usersList);
+        }
+
         /*
         At this point distinctUsers map will contain only one entry if the login identifier is resolved to a single
         user from multiple claims. If the map is empty, that means the login identifier is not resolved to any user.

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
@@ -65,17 +65,6 @@ public class RegexResolver implements MultiAttributeLoginResolver {
             resolveDistinctUsersForClaims(loginAttribute, allowedAttributes, claimManager, userStoreManager,
                     resolvedUserResult);
 
-            /*
-            resolve user if allowed attributes has only username claim,
-            but username claim has no configured regex pattern.
-             */
-            if (allowedAttributes.size() == 1 &&
-                    allowedAttributes.contains(UserCoreClaimConstants.USERNAME_CLAIM_URI)) {
-                List<User> userList = userStoreManager.getUserListWithID(UserCoreClaimConstants.USERNAME_CLAIM_URI,
-                        loginAttribute, null);
-                setResolvedUserResult(userList, UserCoreClaimConstants.USERNAME_CLAIM_URI, loginAttribute,
-                        resolvedUserResult, claimManager.getClaim(UserCoreClaimConstants.USERNAME_CLAIM_URI));
-            }
         } catch (UserStoreException e) {
             log.error("Error occurred while resolving user name", e);
         }
@@ -140,9 +129,11 @@ public class RegexResolver implements MultiAttributeLoginResolver {
 
         // Check the users from username by default if there are users found from claims and regex patterns.
         if (distinctUsers.size() == 0) {
-            List<User> usersList = userStoreManager.getUserListWithID(UserCoreClaimConstants.USERNAME_CLAIM_URI,
-                    loginAttribute, null);
-            distinctUsers.put(UserCoreClaimConstants.USERNAME_CLAIM_URI, usersList);
+            if (allowedAttributes.contains(UserCoreClaimConstants.USERNAME_CLAIM_URI)) {
+                List<User> userList = userStoreManager.getUserListWithID(UserCoreClaimConstants.USERNAME_CLAIM_URI,
+                        loginAttribute, null);
+                distinctUsers.put(UserCoreClaimConstants.USERNAME_CLAIM_URI, userList);
+            }
         }
 
         /*

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
@@ -80,6 +80,7 @@ public class RegexResolver implements MultiAttributeLoginResolver {
         Set<String> uniqueUserIds = new HashSet<>();
         Map<String, List<User>> distinctUsers = new HashMap<>();
 
+        // Resolve the user from the regex matching.
         for (String claimURI : allowedAttributes) {
             Claim claim = claimManager.getClaim(claimURI);
             if (claim == null || StringUtils.isBlank(claim.getRegEx())) {
@@ -127,12 +128,19 @@ public class RegexResolver implements MultiAttributeLoginResolver {
             }
         }
 
-        // Check the users from username by default if there are no users found from claims and regex patterns.
-        if (distinctUsers.size() == 0) {
-            if (allowedAttributes.contains(UserCoreClaimConstants.USERNAME_CLAIM_URI)) {
-                List<User> userList = userStoreManager.getUserListWithID(UserCoreClaimConstants.USERNAME_CLAIM_URI,
-                        loginAttribute, null);
-                distinctUsers.put(UserCoreClaimConstants.USERNAME_CLAIM_URI, userList);
+        // Check the users from username by default if there is no regex for username claim.
+        Claim usernameClaim = claimManager.getClaim(UserCoreClaimConstants.USERNAME_CLAIM_URI);
+        if (allowedAttributes.contains(UserCoreClaimConstants.USERNAME_CLAIM_URI)
+                && usernameClaim.getRegEx().isEmpty()) {
+            List<User> userList = userStoreManager.getUserListWithID(UserCoreClaimConstants.USERNAME_CLAIM_URI,
+                    loginAttribute, null);
+            if (!userList.isEmpty()) {
+                List<User> allowedDistinctUsersForClaim = userList.stream()
+                        .filter(user -> uniqueUserIds.add(user.getUserID()))
+                        .collect(Collectors.toList());
+                if (allowedDistinctUsersForClaim.size() == 1) {
+                    distinctUsers.put(UserCoreClaimConstants.USERNAME_CLAIM_URI, allowedDistinctUsersForClaim);
+                }
             }
         }
 

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
@@ -131,7 +131,7 @@ public class RegexResolver implements MultiAttributeLoginResolver {
         // Check the users from username by default if there is no regex for username claim.
         Claim usernameClaim = claimManager.getClaim(UserCoreClaimConstants.USERNAME_CLAIM_URI);
         if (allowedAttributes.contains(UserCoreClaimConstants.USERNAME_CLAIM_URI)
-                && usernameClaim.getRegEx().isEmpty()) {
+                && StringUtils.isBlank(usernameClaim.getRegEx())) {
             List<User> userList = userStoreManager.getUserListWithID(UserCoreClaimConstants.USERNAME_CLAIM_URI,
                     loginAttribute, null);
             if (!userList.isEmpty()) {

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
@@ -144,6 +144,9 @@ public class RegexResolver implements MultiAttributeLoginResolver {
             Map.Entry<String, List<User>> entry = distinctUsers.entrySet().iterator().next();
             setResolvedUserResult(entry.getValue(), entry.getKey(), loginAttribute, resolvedUserResult,
                     claimManager.getClaim(entry.getKey()));
+        } else {
+            resolvedUserResult.setErrorMessage("Found multiple users for " + allowedAttributes +
+                    " to value " + loginAttribute);
         }
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request
- Change the multi attribute login user solving logic to resolve the user with username by default when there is no user found from the regex matching, 
- So, the user is checking from the username claim.
- Improve the logic to search from the username when there is no users found from the regex patterns matching.
