### PR TITLE
Modify Username Validation Logic to Support Non SaaS Username Tenant …

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.governance/src/test/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/test/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImplTest.java
@@ -105,7 +105,7 @@ public class ValidateUsernameApiServiceImplTest {
         Mockito.doReturn(false).when(userSelfRegistrationManager)
                 .isSelfRegistrationEnabled(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         Mockito.doReturn(true).when(userSelfRegistrationManager)
-                .isUsernameAlreadyTaken("test", MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+                .isUsernameAlreadyTaken("test", MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, true);
     }
 
     @AfterMethod


### PR DESCRIPTION
With the previous implementation, for both saas and non-saas applications the tenant domain will be removed from the username input and the tenant aware name will be validated (whether username is already taken and if it matches the username regex). But for non saas apps, we should not consider usernames with @ mark as tenanted usernames and should allow such users to be created without removing the part after the @ mark.
For ex: if user inputs `john@foo.com`- for saas apps we should create a user john in foo.com tenant but for non saas apps we should create a user `john@foo.com` in the app's tenant domain.

The username validation logic is modified by this PR to support the above behaviour.

Related Issue: https://github.com/wso2/product-is/issues/16228

Note: Should be merged after bumping framework with the changes of https://github.com/wso2/carbon-identity-framework/pull/4858