### PR TITLE
[UsernameValidation] get tenantDomain  from Context

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImpl.java
@@ -223,16 +223,8 @@ public class ValidateUsernameApiServiceImpl extends ValidateUsernameApiService {
 
     private String getTenantDomainFromContext() {
 
-        String tenantDomain = null;
-        if (IdentityUtil.threadLocalProperties.get().get(Constants.TENANT_NAME_FROM_CONTEXT) != null) {
-            tenantDomain = (String) IdentityUtil.threadLocalProperties.get().get(Constants
-                    .TENANT_NAME_FROM_CONTEXT);
-        }
-
-        if (StringUtils.isBlank(tenantDomain)) {
-            tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
-        }
-
-        return tenantDomain;
+        String tenantDomain = (String) IdentityUtil.threadLocalProperties.get().get(Constants.TENANT_NAME_FROM_CONTEXT);
+        return StringUtils.isNotBlank(tenantDomain) ? tenantDomain : MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
     }
+
 }

--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImpl.java
@@ -226,5 +226,4 @@ public class ValidateUsernameApiServiceImpl extends ValidateUsernameApiService {
         String tenantDomain = (String) IdentityUtil.threadLocalProperties.get().get(Constants.TENANT_NAME_FROM_CONTEXT);
         return StringUtils.isNotBlank(tenantDomain) ? tenantDomain : MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
     }
-
 }

--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ValidateUsernameApiServiceImpl.java
@@ -64,7 +64,7 @@ public class ValidateUsernameApiServiceImpl extends ValidateUsernameApiService {
         }
 
         try {
-            String tenantDomain = MultitenantUtils.getTenantDomain(username);
+            String tenantDomain = getTenantDomainFromContext();
             String realm = null;
             List<PropertyDTO> propertyDTOList = user.getProperties();
             boolean skipSelfSignUpEnabledCheck = false;
@@ -218,6 +218,21 @@ public class ValidateUsernameApiServiceImpl extends ValidateUsernameApiService {
             throw new IdentityRecoveryClientException(String.format("Tenant domain in the request: %s does not match "
                     + "with the domain specified in the URL: %s", tenantDomainInValidationRequest, tenantDomain));
         }
+        return tenantDomain;
+    }
+
+    private String getTenantDomainFromContext() {
+
+        String tenantDomain = null;
+        if (IdentityUtil.threadLocalProperties.get().get(Constants.TENANT_NAME_FROM_CONTEXT) != null) {
+            tenantDomain = (String) IdentityUtil.threadLocalProperties.get().get(Constants
+                    .TENANT_NAME_FROM_CONTEXT);
+        }
+
+        if (StringUtils.isBlank(tenantDomain)) {
+            tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+        }
+
         return tenantDomain;
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request
Issue: https://github.com/wso2/product-is/issues/16357

Rather than deriving the tenant Domain from the username, we should get the tenant domain from the URL context.
