### PR TITLE
Fix invalid tenant domain error

### DIFF
--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/EmailOTPCaptchaConnector.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/EmailOTPCaptchaConnector.java
@@ -127,7 +127,7 @@ public class EmailOTPCaptchaConnector extends AbstractReCaptchaConnector {
         String sessionDataKey = servletRequest.getParameter(FrameworkUtils.SESSION_DATA_KEY);
         AuthenticationContext context = FrameworkUtils.getAuthenticationContextFromCache(sessionDataKey);
         String username = context.getLastAuthenticatedUser().getUserName();
-        String tenantDomain = getTenant(context, username);
+        String tenantDomain = context.getLastAuthenticatedUser().getTenantDomain();
 
         Property[] connectorConfigs = null;
         try {
@@ -223,7 +223,7 @@ public class EmailOTPCaptchaConnector extends AbstractReCaptchaConnector {
         }
 
         String username = context.getLastAuthenticatedUser().getUserName();
-        String tenantDomain = getTenant(context, username);
+        String tenantDomain = context.getLastAuthenticatedUser().getTenantDomain();
 
         Property[] connectorConfigs;
         try {
@@ -254,22 +254,6 @@ public class EmailOTPCaptchaConnector extends AbstractReCaptchaConnector {
         }
 
         return CaptchaDataHolder.getInstance().isReCaptchaEnabled();
-    }
-
-    /**
-     * Get tenant from authentication context or username.
-     *
-     * @param context   Authentication context.
-     * @param username  Username.
-     * @return          Derived tenant domain.
-     */
-    private String getTenant(AuthenticationContext context, String username) {
-
-        if (IdentityTenantUtil.isTenantedSessionsEnabled() || IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-            return context.getUserTenantDomain();
-        } else {
-            return MultitenantUtils.getTenantDomain(username);
-        }
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request
When trying to authenticate with email OTP (first factor or multi factor) with an email username when the email as username feature is disabled, getting invalid tenant domain error. Added this fix to get the tenant domain from authenticated user.

Related Issue - 
https://github.com/wso2/product-is/issues/16376

Related PRs -
https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/166