### PR TITLE
Change resend code API error response

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImpl.java
@@ -80,8 +80,8 @@ public class ResendCodeApiServiceImpl extends ResendCodeApiService {
         if (notificationResponseBean == null) {
             ErrorDTO errorDTO = new ErrorDTO();
             errorDTO.setRef(Utils.getCorrelation());
-            errorDTO.setMessage("This service is not yet implemented.");
-            return Response.status(Response.Status.NOT_IMPLEMENTED).entity(errorDTO).build();
+            errorDTO.setMessage("User recovery data is not found. Please re-initiate the recovery flow.");
+            return Response.status(Response.Status.BAD_REQUEST).entity(errorDTO).build();
         }
 
         //when notifications internally managed key might not be set.

--- a/components/org.wso2.carbon.identity.api.user.governance/src/test/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/test/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImplTest.java
@@ -95,11 +95,11 @@ public class ResendCodeApiServiceImplTest {
         assertEquals(resendCodeApiService.resendCodePost(multipleResendCodeRequestDTO()).getStatus(), 201);
 
         mockedUtils.when(() -> Utils.getUserRecoveryData(recoveryScenarioResendCodeRequestDTO())).thenReturn(null);
-        assertEquals(resendCodeApiService.resendCodePost(recoveryScenarioResendCodeRequestDTO()).getStatus(), 501);
+        assertEquals(resendCodeApiService.resendCodePost(recoveryScenarioResendCodeRequestDTO()).getStatus(), 400);
 
         mockedUtils.when(() -> Utils.getUserRecoveryData(recoveryScenarioResendCodeRequestDTO())).thenReturn(
                 userRecoveryData);
-        assertEquals(resendCodeApiService.resendCodePost(recoveryScenarioResendCodeRequestDTO()).getStatus(), 501);
+        assertEquals(resendCodeApiService.resendCodePost(recoveryScenarioResendCodeRequestDTO()).getStatus(), 400);
         assertEquals(resendCodeApiService.resendCodePost(duplicateScenarioResendCodeRequestDTO()).getStatus(), 201);
     }
 
@@ -109,7 +109,7 @@ public class ResendCodeApiServiceImplTest {
         Mockito.when(userSelfRegistrationManager.resendConfirmationCode(
                 Utils.getUser(resendCodeRequestDTO().getUser()),
                 Utils.getProperties(resendCodeRequestDTO().getProperties()))).thenThrow(new IdentityRecoveryException("Recovery Exception"));
-        assertEquals(resendCodeApiService.resendCodePost(resendCodeRequestDTO()).getStatus(), 501);
+        assertEquals(resendCodeApiService.resendCodePost(resendCodeRequestDTO()).getStatus(), 400);
     }
 
     @Test
@@ -118,7 +118,7 @@ public class ResendCodeApiServiceImplTest {
         Mockito.when(userSelfRegistrationManager.resendConfirmationCode(
                 Utils.getUser(resendCodeRequestDTO().getUser()),
                 Utils.getProperties(resendCodeRequestDTO().getProperties()))).thenThrow(new IdentityRecoveryClientException("Recovery Exception"));
-        assertEquals(resendCodeApiService.resendCodePost(resendCodeRequestDTO()).getStatus(), 501);
+        assertEquals(resendCodeApiService.resendCodePost(resendCodeRequestDTO()).getStatus(), 400);
     }
 
     private ResendCodeRequestDTO resendCodeRequestDTO() {


### PR DESCRIPTION
### Proposed changes in this pull request

Change the 501 API error response that is getting thrown by resend-code API into 400 Bad Request type. When the recovery data is not available in the database, the API returns a 501 error response. But it should return 400 bad request error responses mentioning that the recovery data is not found.