### PR TITLE
Disable current recovery service

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -354,6 +354,7 @@ public class IdentityRecoveryConstants {
         ERROR_CODE_EXPIRED_RECOVERY_CODE("UAR-10013", "Invalid recovery code: '%s'"),
         ERROR_CODE_USER_ACCOUNT_RECOVERY_VALIDATION_FAILED("UAR-10014",
                 "User account recovery validation failed for user account: '%s'"),
+        ERROR_CODE_API_DISABLED("UAR-10017", "Recovery API is disabled"),
         ERROR_CODE_ERROR_STORING_RECOVERY_DATA("UAR-15001", "Error storing user recovery data"),
         ERROR_CODE_ERROR_GETTING_USERSTORE_MANAGER("UAR-15002", "Error getting userstore manager"),
         ERROR_CODE_ERROR_RETRIEVING_USER_CLAIM("UAR-15003", "Error getting the claims: '%s' "

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/password/PasswordRecoveryManagerImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/password/PasswordRecoveryManagerImpl.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventException;
@@ -184,6 +185,11 @@ public class PasswordRecoveryManagerImpl implements PasswordRecoveryManager {
     public PasswordResetCodeDTO confirm(String confirmationCode, String tenantDomain, Map<String, String> properties)
             throws IdentityRecoveryException {
 
+        if (!Boolean.parseBoolean(IdentityUtil.getProperty(
+                IdentityConstants.Recovery.RECOVERY_V1_API_ENABLE))) {
+            throw Utils.handleClientException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_API_DISABLED, null);
+        }
         validateTenantDomain(tenantDomain);
         UserAccountRecoveryManager userAccountRecoveryManager = UserAccountRecoveryManager.getInstance();
         // Get Recovery data.
@@ -216,6 +222,11 @@ public class PasswordRecoveryManagerImpl implements PasswordRecoveryManager {
     public SuccessfulPasswordResetDTO reset(String resetCode, char[] password, Map<String, String> properties)
             throws IdentityRecoveryException {
 
+        if (!Boolean.parseBoolean(IdentityUtil.getProperty(
+                IdentityConstants.Recovery.RECOVERY_V1_API_ENABLE))) {
+            throw Utils.handleClientException(
+                    IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_API_DISABLED, null);
+        }
         // Validate the password.
         if (ArrayUtils.isEmpty(password)) {
             throw Utils.handleClientException(


### PR DESCRIPTION
### Proposed changes in this pull request
Due to the encountered issues with the current V1 API, a new V2 API is provided. Hence, current recovery service will be disabled. There will be a config to enable/disable the service.

When the V1 API is invoked while it's disabled, the response will be as follows.

**Status code**: 404 Not Found
**Response body**:
```
{
    "code": "UAR-10017",
    "message": "Not Found",
    "description": "Recovery API is disabled",
    "traceId": "7078d34c-63de-4fbc-b212-d59cac942b0a"
}
```

Related issue: https://github.com/wso2/product-is/issues/16536

### When should this PR be merged
This should be merged after https://github.com/wso2/carbon-identity-framework/pull/4878