### PR TITLE
Resolve possible users from all user stores

### DIFF
--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
@@ -92,7 +92,7 @@ public class RegexResolver implements MultiAttributeLoginResolver {
                     resolvedUserResults);
 
             /*
-            resolve user if allowed attributes has only username claim,
+            Resolve user if allowed attributes has only username claim,
             but username claim has no configured regex pattern.
              */
             if (allowedAttributes.size() == 1 && resolvedUserResults.isEmpty() &&

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/service/MultiAttributeLoginServiceServiceImpl.java
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/service/MultiAttributeLoginServiceServiceImpl.java
@@ -168,6 +168,4 @@ public class MultiAttributeLoginServiceServiceImpl implements MultiAttributeLogi
         }
         return resolvedUserResults;
     }
-
-
 }

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/service/MultiAttributeLoginServiceServiceImpl.java
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/service/MultiAttributeLoginServiceServiceImpl.java
@@ -149,4 +149,25 @@ public class MultiAttributeLoginServiceServiceImpl implements MultiAttributeLogi
         }
         return resolvedUserResult;
     }
+
+    /**
+     * This method is used to resolve possible users from given login identifier.
+     *
+     * @param loginIdentifierValue User entered login identifier value.
+     * @param tenantDomain         User tenant domain.
+     * @return List of ResolvedUserResult objects with possible users with their resolved login identifier claim.
+     */
+    @Override
+    public List<ResolvedUserResult> resolvePossibleUsers(String loginIdentifierValue, String tenantDomain) {
+
+        List<ResolvedUserResult> resolvedUserResults = null;
+        if (StringUtils.isNotBlank(loginIdentifierValue) && StringUtils.isNotBlank(tenantDomain)) {
+            List<String> allowedAttributes = getAllowedClaimsForTenant(tenantDomain);
+            resolvedUserResults = MultiAttributeLoginDataHolder.getInstance().getMultiAttributeLoginResolver().
+                    resolvePossibleUsers(loginIdentifierValue, allowedAttributes, tenantDomain);
+        }
+        return resolvedUserResults;
+    }
+
+
 }


### PR DESCRIPTION
### Description
- Add support for multi-attribute login when user store preference order extension is used. Therefore adding methods that resolves possible users from all the available user stores to send to filtering with the configured user store preference order.

### When this PR should be merged:
After https://github.com/wso2/carbon-identity-framework/pull/4980

Resolves https://github.com/wso2/product-is/issues/12503

