### PR TITLE
Resolve users according to userstore preference order if configured.

### DIFF
--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
@@ -255,20 +255,21 @@ public class RegexResolver implements MultiAttributeLoginResolver {
             throws org.wso2.carbon.user.core.UserStoreException {
 
         IterativeUserStoreManager initialUserStoreManager = null;
-        IterativeUserStoreManager prevUserStoreManager = null;
+        IterativeUserStoreManager currentUserStoreManager = null;
         for (String domainName : userStorePreferenceOrder) {
             UserStoreManager userStoreManager = abstractUserStoreManager.getSecondaryUserStoreManager(domainName);
             // If the user store manager is instance of AbstractUserStoreManager then generate a user store chain using
             // IterativeUserStoreManager.
             if (userStoreManager instanceof AbstractUserStoreManager) {
                 if (initialUserStoreManager == null) {
-                    prevUserStoreManager = new IterativeUserStoreManager((AbstractUserStoreManager) userStoreManager);
-                    initialUserStoreManager = prevUserStoreManager;
+                    currentUserStoreManager =
+                            new IterativeUserStoreManager((AbstractUserStoreManager) userStoreManager);
+                    initialUserStoreManager = currentUserStoreManager;
                 } else {
-                    IterativeUserStoreManager currentUserStoreManager = new IterativeUserStoreManager(
+                    IterativeUserStoreManager nextUserStoreManager = new IterativeUserStoreManager(
                             (AbstractUserStoreManager) userStoreManager);
-                    prevUserStoreManager.setNextUserStoreManager(currentUserStoreManager);
-                    prevUserStoreManager = currentUserStoreManager;
+                    currentUserStoreManager.setNextUserStoreManager(nextUserStoreManager);
+                    currentUserStoreManager = nextUserStoreManager;
                 }
             } else {
                 return null;

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.multi.attribute.login.resolver.regex;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginResolver;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
 import org.wso2.carbon.identity.multi.attribute.login.resolver.regex.utils.UserResolverUtil;
@@ -211,8 +212,10 @@ public class RegexResolver implements MultiAttributeLoginResolver {
         List<org.wso2.carbon.user.core.common.User> userList = new ArrayList<>();
         IterativeUserStoreManager currentUserStoreManager = userStoreManager;
         while (currentUserStoreManager != null) {
+            String domainName = UserCoreUtil.getDomainName(currentUserStoreManager.getRealmConfiguration());
+            String domainAwareUsername = domainName + CarbonConstants.DOMAIN_SEPARATOR + loginAttribute;
             userList.addAll(currentUserStoreManager.getAbstractUserStoreManager().getUserListWithID(claimURI,
-                    loginAttribute, null));
+                    domainAwareUsername, null));
             currentUserStoreManager = currentUserStoreManager.nextUserStoreManager();
         }
 

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/src/main/java/org/wso2/carbon/identity/multi/attribute/login/resolver/regex/RegexResolver.java
@@ -28,12 +28,20 @@ import org.wso2.carbon.user.api.Claim;
 import org.wso2.carbon.user.api.ClaimManager;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UniqueIDUserStoreManager;
+import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.common.AuthenticationResult;
+import org.wso2.carbon.user.core.common.IterativeUserStoreManager;
 import org.wso2.carbon.user.core.common.User;
+import org.wso2.carbon.user.core.config.UserStorePreferenceOrderSupplier;
 import org.wso2.carbon.user.core.constants.UserCoreClaimConstants;
+import org.wso2.carbon.user.core.model.UserMgtContext;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -79,6 +87,7 @@ public class RegexResolver implements MultiAttributeLoginResolver {
 
         Set<String> uniqueUserIds = new HashSet<>();
         Map<String, List<User>> distinctUsers = new HashMap<>();
+        List<String> userStorePreferenceOrder  = getUserStorePreferenceOrder();
 
         // Resolve the user from the regex matching.
         for (String claimURI : allowedAttributes) {
@@ -91,7 +100,8 @@ public class RegexResolver implements MultiAttributeLoginResolver {
             String domainSeparateAttribute = UserCoreUtil.removeDomainFromName(loginAttribute);
 
             if (pattern.matcher(domainSeparateAttribute).matches()) {
-                List<User> userList = userStoreManager.getUserListWithID(claimURI, loginAttribute, null);
+                List<User> userList = getUserList(claimURI, loginAttribute, userStorePreferenceOrder, userStoreManager);
+
                 if (userList.isEmpty()) {
                     continue;
                 }
@@ -132,8 +142,8 @@ public class RegexResolver implements MultiAttributeLoginResolver {
         Claim usernameClaim = claimManager.getClaim(UserCoreClaimConstants.USERNAME_CLAIM_URI);
         if (allowedAttributes.contains(UserCoreClaimConstants.USERNAME_CLAIM_URI)
                 && StringUtils.isBlank(usernameClaim.getRegEx())) {
-            List<User> userList = userStoreManager.getUserListWithID(UserCoreClaimConstants.USERNAME_CLAIM_URI,
-                    loginAttribute, null);
+            List<User> userList = getUserList(UserCoreClaimConstants.USERNAME_CLAIM_URI, loginAttribute,
+                    userStorePreferenceOrder, userStoreManager);
             if (!userList.isEmpty()) {
                 List<User> allowedDistinctUsersForClaim = userList.stream()
                         .filter(user -> uniqueUserIds.add(user.getUserID()))
@@ -156,6 +166,116 @@ public class RegexResolver implements MultiAttributeLoginResolver {
             resolvedUserResult.setErrorMessage("Found multiple users for " + allowedAttributes +
                     " to value " + loginAttribute);
         }
+    }
+
+    /**
+     * This method is used to get the user list according to the user store preference order if configured.
+     * If the login attribute contains a domain name, resolve users from the corresponding user store.
+     *
+     * @param claimURI                 Claim URI.
+     * @param loginAttribute           Login attribute.
+     * @param userStorePreferenceOrder User store preference order.
+     * @param userStoreManager         User store manager.
+     * @return User list.
+     * @throws org.wso2.carbon.user.core.UserStoreException If an error occurred while getting the user list.
+     */
+    private List<User> getUserList(String claimURI, String loginAttribute, List<String> userStorePreferenceOrder,
+                                   UniqueIDUserStoreManager userStoreManager)
+            throws org.wso2.carbon.user.core.UserStoreException {
+
+        if (!loginAttribute.contains(UserCoreConstants.DOMAIN_SEPARATOR) && userStorePreferenceOrder != null
+                && !userStorePreferenceOrder.isEmpty()) {
+            IterativeUserStoreManager iterativeUserStoreManager = generateUserStoreChain(userStorePreferenceOrder,
+                    (AbstractUserStoreManager) userStoreManager);
+            if (iterativeUserStoreManager != null) {
+                return getUserListAccordingToUserStorePreferenceOrder(claimURI, loginAttribute,
+                        iterativeUserStoreManager);
+            }
+        }
+        return userStoreManager.getUserListWithID(claimURI, loginAttribute, null);
+    }
+
+    /**
+     * This method is used to get the user list according to the user store preference order.
+     *
+     * @param claimURI                 Claim URI.
+     * @param loginAttribute           Login attribute.
+     * @param userStoreManager         User store manager.
+     * @return User list.
+     * @throws org.wso2.carbon.user.core.UserStoreException If an error occurred while getting the user list.
+     */
+    private List<User> getUserListAccordingToUserStorePreferenceOrder(String claimURI, String loginAttribute,
+                                                                      IterativeUserStoreManager userStoreManager)
+            throws org.wso2.carbon.user.core.UserStoreException {
+
+        List<org.wso2.carbon.user.core.common.User> userList = new ArrayList<>();
+        IterativeUserStoreManager currentUserStoreManager = userStoreManager;
+        while (currentUserStoreManager != null) {
+            userList.addAll(currentUserStoreManager.getAbstractUserStoreManager().getUserListWithID(claimURI,
+                    loginAttribute, null));
+            currentUserStoreManager = currentUserStoreManager.nextUserStoreManager();
+        }
+
+        return userList;
+    }
+
+    /**
+     * This method is used to get the user store preference order.
+     *
+     * @return User store preference order.
+     * @throws org.wso2.carbon.user.core.UserStoreException If an error occurred while getting the user store
+     */
+    private List<String> getUserStorePreferenceOrder() throws org.wso2.carbon.user.core.UserStoreException {
+
+        UserMgtContext userMgtContext = UserCoreUtil.getUserMgtContextFromThreadLocal();
+        if (userMgtContext != null) {
+            UserStorePreferenceOrderSupplier<List<String>>
+                    userStorePreferenceSupplier = userMgtContext.getUserStorePreferenceOrderSupplier();
+            if (userStorePreferenceSupplier != null) {
+                List<String> userStorePreferenceOrder = userStorePreferenceSupplier.get();
+                if (userStorePreferenceOrder != null) {
+                    return userStorePreferenceOrder;
+                }
+            }
+        }
+
+        return Collections.emptyList();
+    }
+
+    /**
+     * This method is used to generate a user store chain using the user store preference order.
+     *
+     * @param userStorePreferenceOrder User store preference order.
+     * @param abstractUserStoreManager Abstract user store manager.
+     * @return IterativeUserStoreManager.
+     * @throws org.wso2.carbon.user.core.UserStoreException If an error occurred while generating the user store chain.
+     */
+    private IterativeUserStoreManager generateUserStoreChain(List<String> userStorePreferenceOrder,
+                                                             AbstractUserStoreManager abstractUserStoreManager)
+            throws org.wso2.carbon.user.core.UserStoreException {
+
+        IterativeUserStoreManager initialUserStoreManager = null;
+        IterativeUserStoreManager prevUserStoreManager = null;
+        for (String domainName : userStorePreferenceOrder) {
+            UserStoreManager userStoreManager = abstractUserStoreManager.getSecondaryUserStoreManager(domainName);
+            // If the user store manager is instance of AbstractUserStoreManager then generate a user store chain using
+            // IterativeUserStoreManager.
+            if (userStoreManager instanceof AbstractUserStoreManager) {
+                if (initialUserStoreManager == null) {
+                    prevUserStoreManager = new IterativeUserStoreManager((AbstractUserStoreManager) userStoreManager);
+                    initialUserStoreManager = prevUserStoreManager;
+                } else {
+                    IterativeUserStoreManager currentUserStoreManager = new IterativeUserStoreManager(
+                            (AbstractUserStoreManager) userStoreManager);
+                    prevUserStoreManager.setNextUserStoreManager(currentUserStoreManager);
+                    prevUserStoreManager = currentUserStoreManager;
+                }
+            } else {
+                return null;
+            }
+        }
+        // Authenticate using the initial user store from the user store preference list.
+        return initialUserStoreManager;
     }
 
     private void setResolvedUserResult(List<User> userList, String claimURI,


### PR DESCRIPTION
### Proposed changes in this pull request
Changes proposed in this PR contains resolving users according to the user store preference order if configured. Note that, if the userstore domain is appended to the login identifier of the user, user store preference will not be taken into consideration.

### Support Flows
When multi attribute is enabled, you can configure a particular SP to be authenticated only by one userstore. This is called userstore binding. No other SPs can be authenticated with the users in this userstore. Other SPs can be authenticated with the rest of the userstores as usual.

Note: 
- Users with the same loginidentifier across userstores considered as duplicate users and will not be authentictaed. It is considered as a not supported flow. This is the default behaviour of the multi attribute login even without userstore preference support.

### When should this PR be merged
After the https://github.com/wso2/carbon-kernel/pull/3682 got merged and released.

### Peer verification steps:

Pre-requisits
1. Enable multi-attribute login to use claims `http://wso2.org/claims/username,http://wso2.org/claims/mobile,http://wso2.org/claims/emailaddress`.
2. Add two secondary user stores called SECONDARY and TERTIARY.
3. Create two users in PRIMARY and SECONDARY user stores, having the same mobile number `0711234567`.
4. Create an admin user in the secondary userstore.
5. Create three admin users with the same username as `test` in all 3 userstores.
6. Configure the user store preference order extension[1] and bind one user store to a service provider.
    - Bind SECONDARY userstore to My Account application.
    - [2] contains the above specified logic. Therefore build the default branch of [2] and add the jar to the dropins folder.

Test Cases:
1. Try to login to `My Account` using the PRIMARY user store user `0711234567`.
    - Can be login using users from the binded userstore SECONDARY.
    - Should Fail.
2. Try to login to `My Account` using the SECONDARY user store user `0711234567`.
    - Login using a user from the binded userstore SECONDARY.
    - Should succesfully authenticate.
3. Try to login to `Console` using the PRIMARY user store admin's credentials.
    - Login by only PRIMARY and TERTIARY admins.
    - Should succesfully authenticate.
4. Try to login to `Console` using the SECONDARY user store admin's credentials.
    - Can be login by only PRIMARY and TERTIARY admins.
    - Should Fail.
5. Try to login to `Console` using the PRIMARY user store user `test`.
    - `test` user available in both PRIMARY and TERTIARY userstores.
    - Should Fail.

Try the same test flows without the user preference order. 

[1] https://medium.com/@nilasini/user-store-preference-order-per-service-provider-available-from-5-9-0-onwards-bcd7648a485c
[2] https://github.com/mpmadhavig/user-store-order-callback-handler

Resolves https://github.com/wso2/product-is/issues/12503