### PR TITLE
Update config names for max failed attempts and max resend attempts in password recovery

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -632,9 +632,9 @@ public class IdentityRecoveryConstants {
         public static final String ENABLE_AUTO_LGOIN_AFTER_PASSWORD_RESET = "Recovery.AutoLogin.Enable";
         public static final String SELF_REGISTRATION_AUTO_LOGIN = "SelfRegistration.AutoLogin.Enable";
         public static final String SELF_REGISTRATION_AUTO_LOGIN_ALIAS_NAME = "SelfRegistration.AutoLogin.AliasName";
-        public static final String RECOVERY_OTP_PASSWORD_MAX_FAILED_ATTEMPTS = "Recovery.OTP" +
+        public static final String RECOVERY_NOTIFICATION_PASSWORD_MAX_FAILED_ATTEMPTS = "Recovery.Notification" +
                 ".Password.MaxFailedAttempts";
-        public static final String RECOVERY_OTP_PASSWORD_MAX_RESEND_ATTEMPTS = "Recovery.OTP" +
+        public static final String RECOVERY_NOTIFICATION_PASSWORD_MAX_RESEND_ATTEMPTS = "Recovery.Notification" +
                 ".Password.MaxResendAttempts";
     }
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
@@ -154,7 +154,7 @@ public class ResendConfirmationManager {
                 userRecoveryData);
         int resendCount = userRecoveryFlowData.getResendCount();
         if (resendCount >= Integer.parseInt(Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.
-                RECOVERY_OTP_PASSWORD_MAX_RESEND_ATTEMPTS, tenantDomain))) {
+                RECOVERY_NOTIFICATION_PASSWORD_MAX_RESEND_ATTEMPTS, tenantDomain))) {
             userAccountRecoveryManager.invalidateRecoveryData(recoveryFlowId);
             throw Utils.handleClientException(
                     IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_RECOVERY_FLOW_ID.getCode(),

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
@@ -112,10 +112,10 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
                 "Recovery callback URL regex");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_AUTO_LGOIN_AFTER_PASSWORD_RESET,
                 "Enable Auto Login After Password Reset");
-        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_OTP_PASSWORD_MAX_FAILED_ATTEMPTS,
-                "Max failed attempts for OTP based recovery");
-        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_OTP_PASSWORD_MAX_RESEND_ATTEMPTS,
-                "Max resend attempts for OTP based recovery");
+        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_NOTIFICATION_PASSWORD_MAX_FAILED_ATTEMPTS,
+                "Max failed attempts for password recovery");
+        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_NOTIFICATION_PASSWORD_MAX_RESEND_ATTEMPTS,
+                "Max resend attempts for password recovery");
         return nameMapping;
     }
 
@@ -172,8 +172,8 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         properties.add(IdentityRecoveryConstants.ConnectorConfig.FORCE_MIN_NO_QUESTION_ANSWERED);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_CALLBACK_REGEX);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_AUTO_LGOIN_AFTER_PASSWORD_RESET);
-        properties.add(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_OTP_PASSWORD_MAX_FAILED_ATTEMPTS);
-        properties.add(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_OTP_PASSWORD_MAX_RESEND_ATTEMPTS);
+        properties.add(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_NOTIFICATION_PASSWORD_MAX_FAILED_ATTEMPTS);
+        properties.add(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_NOTIFICATION_PASSWORD_MAX_RESEND_ATTEMPTS);
         return properties.toArray(new String[0]);
     }
 
@@ -200,8 +200,8 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         String minimumForcedChallengeQuestionsAnswered = "1";
         String recoveryCallbackRegex = IdentityRecoveryConstants.DEFAULT_CALLBACK_REGEX;
         String enableAdminPasswordResetAutoLoginProperty = "false";
-        String recoveryOTPMaxFailedAttempts = "3";
-        String recoveryOTPMaxResendAttempts = "5";
+        String recoveryMaxFailedAttempts = "3";
+        String recoveryMaxResendAttempts = "5";
 
         String notificationBasedPasswordRecovery = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY);
@@ -242,10 +242,10 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
                 IdentityRecoveryConstants.ConnectorConfig.RECOVERY_CALLBACK_REGEX);
         String adminPasswordResetAutoLoginProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.ENABLE_AUTO_LGOIN_AFTER_PASSWORD_RESET);
-        String otpMaxFailedAttempts = IdentityUtil.getProperty(IdentityRecoveryConstants.
-                ConnectorConfig.RECOVERY_OTP_PASSWORD_MAX_FAILED_ATTEMPTS);
-        String otpMaxResendAttempts = IdentityUtil.getProperty(IdentityRecoveryConstants.
-                ConnectorConfig.RECOVERY_OTP_PASSWORD_MAX_RESEND_ATTEMPTS);
+        String maxFailedAttempts = IdentityUtil.getProperty(IdentityRecoveryConstants.
+                ConnectorConfig.RECOVERY_NOTIFICATION_PASSWORD_MAX_FAILED_ATTEMPTS);
+        String maxResendAttempts = IdentityUtil.getProperty(IdentityRecoveryConstants.
+                ConnectorConfig.RECOVERY_NOTIFICATION_PASSWORD_MAX_RESEND_ATTEMPTS);
 
         if (StringUtils.isNotEmpty(expiryTimeSMSOTPProperty)) {
             expiryTimeSMSOTP = expiryTimeSMSOTPProperty;
@@ -307,11 +307,11 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         if (StringUtils.isNotEmpty(adminPasswordResetAutoLoginProperty)) {
             enableAdminPasswordResetAutoLoginProperty = adminPasswordResetAutoLoginProperty;
         }
-        if (StringUtils.isNotEmpty(otpMaxFailedAttempts)) {
-            recoveryOTPMaxFailedAttempts = otpMaxFailedAttempts;
+        if (StringUtils.isNotEmpty(maxFailedAttempts)) {
+            recoveryMaxFailedAttempts = maxFailedAttempts;
         }
-        if (StringUtils.isNotEmpty(otpMaxResendAttempts)) {
-            recoveryOTPMaxResendAttempts = otpMaxResendAttempts;
+        if (StringUtils.isNotEmpty(maxResendAttempts)) {
+            recoveryMaxResendAttempts = maxResendAttempts;
         }
 
         Map<String, String> defaultProperties = new HashMap<>();
@@ -354,10 +354,10 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_CALLBACK_REGEX, recoveryCallbackRegex);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_AUTO_LGOIN_AFTER_PASSWORD_RESET,
                 enableAdminPasswordResetAutoLoginProperty);
-        defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_OTP_PASSWORD_MAX_FAILED_ATTEMPTS,
-                recoveryOTPMaxFailedAttempts);
-        defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_OTP_PASSWORD_MAX_RESEND_ATTEMPTS,
-                recoveryOTPMaxResendAttempts);
+        defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig
+                .RECOVERY_NOTIFICATION_PASSWORD_MAX_FAILED_ATTEMPTS, recoveryMaxFailedAttempts);
+        defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig
+                .RECOVERY_NOTIFICATION_PASSWORD_MAX_RESEND_ATTEMPTS, recoveryMaxResendAttempts);
 
         Properties properties = new Properties();
         properties.putAll(defaultProperties);
@@ -433,10 +433,10 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         meta.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_CALLBACK_REGEX,
                 getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
 
-        meta.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_OTP_PASSWORD_MAX_FAILED_ATTEMPTS,
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_NOTIFICATION_PASSWORD_MAX_FAILED_ATTEMPTS,
                 getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
 
-        meta.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_OTP_PASSWORD_MAX_RESEND_ATTEMPTS,
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_NOTIFICATION_PASSWORD_MAX_RESEND_ATTEMPTS,
                 getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
 
         return meta;

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/password/PasswordRecoveryManagerImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/password/PasswordRecoveryManagerImpl.java
@@ -280,7 +280,7 @@ public class PasswordRecoveryManagerImpl implements PasswordRecoveryManager {
             }
             failedAttempts = failedAttempts + 1;
             if (failedAttempts >= Integer.parseInt(Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.
-                    RECOVERY_OTP_PASSWORD_MAX_FAILED_ATTEMPTS, tenantDomain))) {
+                    RECOVERY_NOTIFICATION_PASSWORD_MAX_FAILED_ATTEMPTS, tenantDomain))) {
                 userAccountRecoveryManager.invalidateRecoveryData(recoveryFlowId);
                 throw Utils.handleClientException(
                         IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_RECOVERY_FLOW_ID.getCode(),

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -701,7 +701,7 @@ public class NotificationPasswordRecoveryManager {
             if (!(StringUtils.equals(hashedCode, userRecoveryData.getSecret()) || StringUtils.equals(code,
                     userRecoveryData.getSecret()))) {
                 if ((failedAttempts + 1) >= Integer.parseInt(Utils.getRecoveryConfigs(IdentityRecoveryConstants.
-                        ConnectorConfig.RECOVERY_OTP_PASSWORD_MAX_FAILED_ATTEMPTS, userRecoveryData.getUser().
+                        ConnectorConfig.RECOVERY_NOTIFICATION_PASSWORD_MAX_FAILED_ATTEMPTS, userRecoveryData.getUser().
                         getTenantDomain()))) {
                     userRecoveryDataStore.invalidateWithRecoveryFlowId(confirmationCode);
                     throw Utils.handleClientException(

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/store/JDBCRecoveryDataStore.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/store/JDBCRecoveryDataStore.java
@@ -1062,7 +1062,8 @@ public class JDBCRecoveryDataStore implements UserRecoveryDataStore {
             codeExpiryTime = Integer.parseInt(Utils.getRecoveryConfigs(
                     IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_EXPIRY_TIME, tenantDomain));
             allowedResendAttempts = Integer.parseInt(Utils.getRecoveryConfigs(
-                    IdentityRecoveryConstants.ConnectorConfig.RECOVERY_OTP_PASSWORD_MAX_RESEND_ATTEMPTS, tenantDomain));
+                    IdentityRecoveryConstants.ConnectorConfig.RECOVERY_NOTIFICATION_PASSWORD_MAX_RESEND_ATTEMPTS,
+                    tenantDomain));
             recoveryFlowIdExpiryTime = codeExpiryTime * allowedResendAttempts;
         } else {
             recoveryFlowIdExpiryTime = Integer.parseInt(

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImplTest.java
@@ -122,10 +122,10 @@ public class RecoveryConfigImplTest {
                 "Recovery callback URL regex");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_AUTO_LGOIN_AFTER_PASSWORD_RESET,
                 "Enable Auto Login After Password Reset");
-        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_OTP_PASSWORD_MAX_FAILED_ATTEMPTS,
-                "Max failed attempts for OTP based recovery");
-        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_OTP_PASSWORD_MAX_RESEND_ATTEMPTS,
-                "Max resend attempts for OTP based recovery");
+        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig
+                .RECOVERY_NOTIFICATION_PASSWORD_MAX_FAILED_ATTEMPTS, "Max failed attempts for password recovery");
+        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig
+                .RECOVERY_NOTIFICATION_PASSWORD_MAX_RESEND_ATTEMPTS,"Max resend attempts for password recovery");
 
         Map<String, String> nameMapping = recoveryConfigImpl.getPropertyNameMapping();
 
@@ -265,9 +265,9 @@ public class RecoveryConfigImplTest {
         defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.
                 ENABLE_AUTO_LGOIN_AFTER_PASSWORD_RESET, enableAutoLoginAfterPasswordReset);
         defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.
-                RECOVERY_OTP_PASSWORD_MAX_FAILED_ATTEMPTS, recoveryOTPMaxFailedAttempts);
+                RECOVERY_NOTIFICATION_PASSWORD_MAX_FAILED_ATTEMPTS, recoveryOTPMaxFailedAttempts);
         defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.
-                RECOVERY_OTP_PASSWORD_MAX_RESEND_ATTEMPTS, recoveryOTPMaxResendAttempts);
+                RECOVERY_NOTIFICATION_PASSWORD_MAX_RESEND_ATTEMPTS, recoveryOTPMaxResendAttempts);
 
         String tenantDomain = "admin";
         // Here tenantDomain parameter is not used by method itself


### PR DESCRIPTION
### Proposed changes in this pull request

This PR updates the config names for max failed attempts and max resend attempts since they are common for both email confirmation code and the OTP.

### Related issue

- https://github.com/wso2/product-is/issues/16942