### PR TITLE
Refactor recaptcha prevalidator to handle multi attribute login scenario

### DIFF
--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -197,6 +197,8 @@
                             version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
                             org.wso2.securevault.*; version="${org.wso2.securevault.import.version.range}",
                             org.wso2.carbon.context; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.identity.multi.attribute.login.mgt.*;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
### Purpose
- $subject

### Changes from the PR
- Currently we are not reading the failed attempts of the user when multi attribute login is enabled and use another identifier than username.
- From this fix, we are fix to handle multi attribute login scenarios in the recaptcha pre validator.

### Related issue
https://github.com/wso2/product-is/issues/16918