### PR TITLE
Convert Property UseNumericChars to UseAlphanumericChars

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceServiceImpl.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceServiceImpl.java
@@ -16,7 +16,6 @@
 
 package org.wso2.carbon.identity.governance;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
@@ -239,7 +238,7 @@ public class IdentityGovernanceServiceImpl implements IdentityGovernanceService 
         for (ConnectorConfig connectorConfig : connectorListWithConfigs) {
             if (connectorConfig.getName().equals(connectorName)) {
                 // Should remove this logic eventually.
-                if (isEmailOTPConnector(connectorName)) {
+                if (isEmailOTPConnectorWithNewConfig(connectorName, connectorConfig)) {
                     convertPropertyUseNumericToUseAlphaNumeric(connectorName, connectorConfig);
                 }
                 return connectorConfig;
@@ -272,9 +271,8 @@ public class IdentityGovernanceServiceImpl implements IdentityGovernanceService 
     private void convertPropertyUseNumericToUseAlphaNumeric(String connectorName, ConnectorConfig connectorConfig) {
 
         // Verify the order of the connector properties hasn't changed.
-        if (connectorConfig.getProperties()[3].getName().equals(EMAIL_OTP_USE_ALPHANUMERIC_CHARS) &&
-                connectorConfig.getProperties()[4].getName().equals(EMAIL_OTP_USE_NUMERIC_CHARS)) {
-
+        if (EMAIL_OTP_USE_ALPHANUMERIC_CHARS.equals(connectorConfig.getProperties()[3].getName()) &&
+                EMAIL_OTP_USE_NUMERIC_CHARS.equals(connectorConfig.getProperties()[4].getName())) {
             if (connectorConfig.getProperties()[4].getValue() != null) {
                 // Extract the value of the useNumericCharacters property.
                 boolean useAlphanumericChars = !Boolean.parseBoolean(connectorConfig.getProperties()[4].getValue());
@@ -289,11 +287,18 @@ public class IdentityGovernanceServiceImpl implements IdentityGovernanceService 
     /**
      * This method is used to check whether the connector is email OTP connector or not.
      *
-     * @param connectorName Name of the connector.
-     * @return True if the connector is email OTP connector.
+     * @param connectorName   Name of the connector.
+     * @param connectorConfig Connector configuration.
+     *
+     * @return True if the connector is email OTP connector and have both old and new email OTP type related configs.
      */
-    private boolean isEmailOTPConnector(String connectorName) {
+    private boolean isEmailOTPConnectorWithNewConfig(String connectorName, ConnectorConfig connectorConfig) {
 
-        return connectorName.equals(EMAIL_OTP_AUTHENTICATOR);
+        /*
+        If the new config is also added, the length of the properties will be 5 with both old
+        and new OTP type properties. Here the purpose of adding 'at least check' is to allow
+        developers to safely add new configs.
+         */
+        return EMAIL_OTP_AUTHENTICATOR.equals(connectorName) && connectorConfig.getProperties().length >= 5;
     }
 }

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceServiceImpl.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceServiceImpl.java
@@ -16,6 +16,7 @@
 
 package org.wso2.carbon.identity.governance;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
@@ -238,7 +239,9 @@ public class IdentityGovernanceServiceImpl implements IdentityGovernanceService 
         for (ConnectorConfig connectorConfig : connectorListWithConfigs) {
             if (connectorConfig.getName().equals(connectorName)) {
                 // Should remove this logic eventually.
-                convertPropertyUseNumericToUseAlphaNumeric(connectorName, connectorConfig);
+                if (isEmailOTPConnector(connectorName)) {
+                    convertPropertyUseNumericToUseAlphaNumeric(connectorName, connectorConfig);
+                }
                 return connectorConfig;
             }
         }
@@ -268,9 +271,8 @@ public class IdentityGovernanceServiceImpl implements IdentityGovernanceService 
      */
     private void convertPropertyUseNumericToUseAlphaNumeric(String connectorName, ConnectorConfig connectorConfig) {
 
-        // If any of the following conditions are false, it simply doesn't migrate the config.
-        if (connectorName.equals(EMAIL_OTP_AUTHENTICATOR) &&
-                connectorConfig.getProperties()[3].getName().equals(EMAIL_OTP_USE_ALPHANUMERIC_CHARS) &&
+        // Verify the order of the connector properties hasn't changed.
+        if (connectorConfig.getProperties()[3].getName().equals(EMAIL_OTP_USE_ALPHANUMERIC_CHARS) &&
                 connectorConfig.getProperties()[4].getName().equals(EMAIL_OTP_USE_NUMERIC_CHARS)) {
 
             if (connectorConfig.getProperties()[4].getValue() != null) {
@@ -279,6 +281,19 @@ public class IdentityGovernanceServiceImpl implements IdentityGovernanceService 
                 // Assign the value to the alphanumeric property.
                 connectorConfig.getProperties()[3].setValue(String.valueOf(useAlphanumericChars));
             }
+        } else {
+            log.debug("The order of the connector properties has changed for the connector: " + connectorName);
         }
+    }
+
+    /**
+     * This method is used to check whether the connector is email OTP connector or not.
+     *
+     * @param connectorName Name of the connector.
+     * @return True if the connector is email OTP connector.
+     */
+    private boolean isEmailOTPConnector(String connectorName) {
+
+        return connectorName.equals(EMAIL_OTP_AUTHENTICATOR);
     }
 }

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceServiceImpl.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceServiceImpl.java
@@ -42,7 +42,7 @@ public class IdentityGovernanceServiceImpl implements IdentityGovernanceService 
 
     private static final Log log = LogFactory.getLog(IdentityGovernanceServiceImpl.class);
     private static final String EMAIL_OTP_AUTHENTICATOR = "email-otp-authenticator";
-    public static final String EMAIL_OTP_USE_ALPHANUMERIC_CHARS = "EmailOTP.OtpRegex.UseAlphanumericChars";
+    public static final String EMAIL_OTP_USE_ALPHANUMERIC_CHARS = "EmailOTP.UseAlphanumericChars";
     public static final String EMAIL_OTP_USE_NUMERIC_CHARS = "EmailOTP.OtpRegex.UseNumericChars";
 
     public void updateConfiguration(String tenantDomain, Map<String, String> configurationDetails)
@@ -279,9 +279,6 @@ public class IdentityGovernanceServiceImpl implements IdentityGovernanceService 
                 // Assign the value to the alphanumeric property.
                 connectorConfig.getProperties()[3].setValue(String.valueOf(useAlphanumericChars));
             }
-        } else {
-            log.warn("Connector property migration skipped due to invalid email OTP authenticator property " +
-                    "configuration.");
         }
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

This effort will contain the migration related logic added to migrate the governance connector property from `EmailOTP.OtpRegex.UseNumericChars` to `EmailOTP.OtpRegex.UseAlphanumericChars`. 

Resolves https://github.com/wso2/product-is/issues/17073