### PR TITLE
Remove V2 from passwordExpiry config name

### DIFF
--- a/components/org.wso2.carbon.identity.password.expiry/src/main/java/org/wso2/carbon/identity/password/expiry/constants/PasswordPolicyConstants.java
+++ b/components/org.wso2.carbon.identity.password.expiry/src/main/java/org/wso2/carbon/identity/password/expiry/constants/PasswordPolicyConstants.java
@@ -44,8 +44,8 @@ public class PasswordPolicyConstants {
             "Allow users to reset the password after configured number of days";
     public static final String CONNECTOR_CONFIG_SUB_CATEGORY = "DEFAULT";
     public static final String PASSWORD_EXPIRED_ERROR_MESSAGE = "Password has expired";
-    public static final String CONNECTOR_CONFIG_NAME = "passwordExpiryV2";
-    public static final String CONNECTOR_CONFIG_FRIENDLY_NAME = "Password Expiry v2";
+    public static final String CONNECTOR_CONFIG_NAME = "passwordExpiry";
+    public static final String CONNECTOR_CONFIG_FRIENDLY_NAME = "Password Expiry";
     public static final String CONNECTOR_CONFIG_CATEGORY = "Password Policies";
     public static final String PASSWORD_GRANT_POST_AUTHENTICATION_EVENT = "PASSWORD_GRANT_POST_AUTHENTICATION";
     public static final String AUTHENTICATION_STATUS = "authenticationStatus";


### PR DESCRIPTION
### Proposed changes in this pull request
The old Password Expiry connector will be marked as deprecated [1] and the `Password Expiry V2` is being renamed as `Password Expiry`.

Issue : https://github.com/wso2/product-is/issues/17735

[1] https://github.com/wso2-extensions/identity-outbound-auth-passwordPolicy/pull/46