### PR TITLE
Skip triggering email/mobile verification during email OTP/SMS OTP flows

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -844,7 +844,12 @@ public class IdentityRecoveryConstants {
 
         /* State maintained to skip triggering an email verification when the update request contains other claims
         without the email address claim. */
-        SKIP_ON_INAPPLICABLE_CLAIMS
+        SKIP_ON_INAPPLICABLE_CLAIMS,
+
+        /* State maintained to skip triggering an email verification, when the email address was updated by user during
+         the Email OTP flow at the first login where the email address is not previously set. At the moment email
+         address was already verified during the email OTP verification. So no need to verify it again. */
+        SKIP_ON_EMAIL_OTP_FLOW
     }
 
     /**
@@ -946,6 +951,11 @@ public class IdentityRecoveryConstants {
 
         /* State maintained to skip triggering an SMS OTP verification when the update request contains other claims
         without the mobile number claim. */
-        SKIP_ON_INAPPLICABLE_CLAIMS
+        SKIP_ON_INAPPLICABLE_CLAIMS,
+
+        /* State maintained to skip triggering an SMS OTP verification, when the mobile number was updated by user
+        during the SMS OTP flow at the first login where the mobile number is not previously set. At the moment mobile
+        number was already verified during the SMS OTP verification. So no need to verify it again. */
+        SKIP_ON_SMS_OTP_FLOW
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
@@ -242,6 +242,16 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
             return;
         }
 
+        /*
+        Within the SMS OTP flow, the mobile number is updated in the user profile after successfully verifying the
+        OTP. Therefore, the mobile number is already verified & no need to verify it again.
+         */
+        if (IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates.SKIP_ON_SMS_OTP_FLOW.toString().equals
+                (Utils.getThreadLocalToSkipSendingSmsOtpVerificationOnUpdate())) {
+            invalidatePendingMobileVerification(user, userStoreManager, claims);
+            return;
+        }
+
         if (Utils.getThreadLocalToSkipSendingSmsOtpVerificationOnUpdate() != null) {
             Utils.unsetThreadLocalToSkipSendingSmsOtpVerificationOnUpdate();
         }
@@ -317,7 +327,9 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
                     SkipMobileNumberVerificationOnUpdateStates.SKIP_ON_EXISTING_MOBILE_NUM.toString().equals
                     (skipMobileNumVerificationOnUpdateState) && !IdentityRecoveryConstants
                     .SkipMobileNumberVerificationOnUpdateStates.SKIP_ON_INAPPLICABLE_CLAIMS.toString().equals
-                            (skipMobileNumVerificationOnUpdateState)) {
+                            (skipMobileNumVerificationOnUpdateState) && !IdentityRecoveryConstants
+                    .SkipMobileNumberVerificationOnUpdateStates.SKIP_ON_SMS_OTP_FLOW.toString().equals
+                    (skipMobileNumVerificationOnUpdateState)) {
 
                 String verificationPendingMobileNumClaim = getVerificationPendingMobileNumValue(userStoreManager, user);
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -475,6 +475,16 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
             return;
         }
 
+        /*
+        Within the Email OTP flow, the email address is updated in the user profile after successfully verifying the
+        OTP. Therefore, the email is already verified & no need to verify it again.
+         */
+        if (IdentityRecoveryConstants.SkipEmailVerificationOnUpdateStates.SKIP_ON_EMAIL_OTP_FLOW.toString().equals
+                (Utils.getThreadLocalToSkipSendingEmailVerificationOnUpdate())) {
+            invalidatePendingEmailVerification(user, userStoreManager, claims);
+            return;
+        }
+
         if (Utils.getThreadLocalToSkipSendingEmailVerificationOnUpdate() != null) {
             Utils.unsetThreadLocalToSkipSendingEmailVerificationOnUpdate();
         }
@@ -541,7 +551,9 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
                     SkipEmailVerificationOnUpdateStates.SKIP_ON_EXISTING_EMAIL.toString().equals
                     (skipEmailVerificationOnUpdateState) && !IdentityRecoveryConstants
                     .SkipEmailVerificationOnUpdateStates.SKIP_ON_INAPPLICABLE_CLAIMS.toString().equals
-                            (skipEmailVerificationOnUpdateState)) {
+                            (skipEmailVerificationOnUpdateState) && !IdentityRecoveryConstants
+                    .SkipEmailVerificationOnUpdateStates.SKIP_ON_EMAIL_OTP_FLOW.toString().equals
+                    (skipEmailVerificationOnUpdateState)) {
 
                 String pendingVerificationEmailClaimValue = getPendingVerificationEmailValue(userStoreManager, user);
 


### PR DESCRIPTION
### Proposed changes in this pull request

- Skip triggering an email verification, when the email address was updated by user during the Email OTP flow at the first login where the email address is not previously set. At the moment email address was already verified during the email OTP verification. So no need to verify it again.

- Skip triggering an SMS OTP verification, when the mobile number was updated by user during the SMS OTP flow at the first login where the mobile number is not previously set. At the moment mobile number was already verified during the SMS OTP verification. So no need to verify it again.

### Related Issue

- https://github.com/wso2/product-is/issues/18414

### Related PRs
- https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/176
- https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/184
- https://github.com/wso2/carbon-identity-framework/pull/5350
