### PR TITLE
Add Recovery Callback URL Regex validation

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
@@ -17,6 +17,8 @@ package org.wso2.carbon.identity.recovery.connector;
 
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.governance.IdentityGovernanceException;
 import org.wso2.carbon.identity.governance.IdentityMgtConstants;
@@ -358,6 +360,17 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
             enableUsernameRecoveryReCaptcha = userNameRecoveryReCaptcha;
         }
         if (StringUtils.isNotEmpty(recoveryCallbackRegexProperty)) {
+            try {
+                int proxyPort = ServiceURLBuilder.create().build().getPort();
+                if (proxyPort == 443 && recoveryCallbackRegexProperty.contains("https")
+                        && recoveryCallbackRegexProperty.contains(":443\\")) {
+                    // remove 443 if added to the regex since it's the proxy port.
+                    recoveryCallbackRegexProperty = recoveryCallbackRegexProperty + "|" +
+                            recoveryCallbackRegexProperty.replace(":443\\", "\\");
+                }
+            } catch (URLBuilderException e) {
+                throw new IdentityGovernanceException(e);
+            }
             recoveryCallbackRegex = recoveryCallbackRegexProperty;
         }
         if (StringUtils.isNotEmpty(adminPasswordResetAutoLoginProperty)) {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
@@ -235,6 +235,8 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         String enableAdminPasswordResetAutoLoginProperty = "false";
         String recoveryMaxFailedAttempts = "3";
         String recoveryMaxResendAttempts = "5";
+        int httpsProxyPort = 443;
+        String secureHttpProtocol = "https";
 
         String notificationBasedPasswordRecovery = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY);
@@ -362,11 +364,11 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         if (StringUtils.isNotEmpty(recoveryCallbackRegexProperty)) {
             try {
                 int proxyPort = ServiceURLBuilder.create().build().getPort();
-                if (proxyPort == 443 && recoveryCallbackRegexProperty.contains("https")
-                        && recoveryCallbackRegexProperty.contains(":443\\")) {
+                if (proxyPort == httpsProxyPort && recoveryCallbackRegexProperty.contains(secureHttpProtocol)
+                        && recoveryCallbackRegexProperty.contains(":" + httpsProxyPort + "\\")) {
                     // remove 443 if added to the regex since it's the proxy port.
                     recoveryCallbackRegexProperty = recoveryCallbackRegexProperty + "|" +
-                            recoveryCallbackRegexProperty.replace(":443\\", "\\");
+                            recoveryCallbackRegexProperty.replace(":" + httpsProxyPort + "\\", "\\");
                 }
             } catch (URLBuilderException e) {
                 throw new IdentityGovernanceException(e);


### PR DESCRIPTION
Add validation to avoid recovery flow being blocked by https proxyPort (443) getting added to the Recovery Callback URL Regex.

Issue : https://github.com/wso2/product-is/issues/18911