### PR TITLE
Ignore user realm attribute when set to null

### DIFF
--- a/components/org.wso2.carbon.identity.recovery.endpoint/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
@@ -49,7 +49,10 @@ public class RecoverPasswordApiServiceImpl extends RecoverPasswordApiService {
 
         UserDTO user = recoveryInitiatingRequest.getUser();
         int tenantIdFromContext = IdentityTenantUtil.getTenantId(user.getTenantDomain());
-
+        if (StringUtils.isNotBlank(user.getRealm())) {
+            String userDomainQualifiedUsername = UserCoreUtil.addDomainToName(user.getUsername(), user.getRealm());
+            user.setUsername(userDomainQualifiedUsername);
+        }
         ResolvedUserResult resolvedUserResult =
                 FrameworkUtils.processMultiAttributeLoginIdentification(user.getUsername(), user.getTenantDomain());
         if (resolvedUserResult != null && ResolvedUserResult.UserResolvedStatus.SUCCESS.


### PR DESCRIPTION
## Purpose
Generating userDomainQualifiedUsername with the realm each time leads to having null as the realm when user does not pass the realm attribute at password reset request. This leads to user note being found. 

This PR changes the implementation to only user the realm value if it is provided by the user. 

## Related Issue
https://github.com/wso2/product-is/issues/19181