### PR TITLE
Avoid federated users idp domain being dropped when email as username is not enabled. 

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -1287,13 +1287,13 @@ public class UserSelfRegistrationManager {
 
         if (StringUtils.isBlank(tenantDomain)) {
             tenantDomain = MultitenantUtils.getTenantDomain(username);
+            // If tenant domain is not provided, tenant domain is derived from the username.
+            username = MultitenantUtils.getTenantAwareUsername(username);
         }
         try {
-            String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
-
             UserRealm userRealm = getUserRealm(tenantDomain);
             if (userRealm != null) {
-                isUsernameAlreadyTaken = userRealm.getUserStoreManager().isExistingUser(tenantAwareUsername) ||
+                isUsernameAlreadyTaken = userRealm.getUserStoreManager().isExistingUser(username) ||
                         hasPendingAddUserWorkflow(username, tenantDomain);
             }
         } catch (CarbonException | org.wso2.carbon.user.core.UserStoreException e) {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -1287,7 +1287,7 @@ public class UserSelfRegistrationManager {
 
         if (StringUtils.isBlank(tenantDomain)) {
             tenantDomain = MultitenantUtils.getTenantDomain(username);
-            // If tenant domain is not provided, tenant domain is derived from the username.
+            // If tenant domain is not provided, domain from the username is assumed to be the tenant domain.
             username = MultitenantUtils.getTenantAwareUsername(username);
         }
         try {


### PR DESCRIPTION
## Purpose 
In the current implementation when a federated user is trying to provision through provisioning types other than silent provisioning, if the username locally exists after removing the domain from the remote idp username (eg: "foo" from "foo@gmail.com"), it is identified as same username and an error is thrown. However this is incorrect since "foo" and "foo@gmail.com" are two different usernames. This is due to when tenant aware username is generated, it removing the last domain after the domain separator symbol. 
This PR fixes the issue by adding the tenant domain at the end of the federating user's name.

## Related Issue 
https://github.com/wso2/product-is/issues/19294 

## Dependent PR 
https://github.com/wso2/carbon-identity-framework/pull/5468