### PR TITLE
Handle Username Recovery for Domain appended Claim Values

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -355,6 +355,8 @@ public class IdentityRecoveryConstants {
                 + "recovery request"),
         ERROR_CODE_USERNAME_RECOVERY_VALIDATION_FAILED("UNR-10003",
                 "Username recovery validation failed for user account : '%s'"),
+        ERROR_CODE_USERNAME_RECOVERY_MULTIPLE_DOMAINS("UNR-10004", "Multiple domains found in the " +
+                "given claim set"),
 
         // UAR - User Account Recovery.
         ERROR_CODE_INVALID_RECOVERY_CODE("UAR-10001", "Invalid recoveryCode : '%s'"),


### PR DESCRIPTION
This PR fixes the issue in username recovery flow when the userstore domain is appended to the user claims that are being sent by a user to invoke the username-recovery API. Adding back this behaviour which was removed with the change from https://github.com/wso2-extensions/identity-governance/pull/623

After this fix:

- If there is at least 1 claim having the userstore domain concatenated, that domain will be considered as the user's domain and the user account will be searched only inside that userstore.
- If there are multiple domains attached to the claims, a client error will be thrown.
- If there is no domain attached, the user account will be searched inside all available userstores.

Related issue: https://github.com/wso2-enterprise/wso2-iam-internal/issues/1308