### PR TITLE
Handle self user registration failure when the email domain is not matched with organization email domain

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -351,6 +351,7 @@ public class IdentityRecoveryConstants {
                 "requirements of the selected registration option."),
         ERROR_CODE_INVALID_REGISTRATION_OPTION("USR-10007", "Invalid registration option."),
         ERROR_CODE_MULTIPLE_REGISTRATION_OPTIONS("USR-10008", "Multiple registration options are not supported."),
+        ERROR_CODE_INVALID_DOMAIN("USR-10009", "The email domain is not match with organization email domain."),
 
         // USR - User Self Registration - server exceptions.
         ERROR_CODE_UNEXPECTED_ERROR_VALIDATING_ATTRIBUTES("USR-15001", "Unexpected error while validating user " +

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -351,7 +351,7 @@ public class IdentityRecoveryConstants {
                 "requirements of the selected registration option."),
         ERROR_CODE_INVALID_REGISTRATION_OPTION("USR-10007", "Invalid registration option."),
         ERROR_CODE_MULTIPLE_REGISTRATION_OPTIONS("USR-10008", "Multiple registration options are not supported."),
-        ERROR_CODE_INVALID_DOMAIN("USR-10009", "The email domain is not match with organization email domain."),
+        ERROR_CODE_INVALID_DOMAIN("USR-10009", "The email domain does not match the organization's email domain."),
 
         // USR - User Self Registration - server exceptions.
         ERROR_CODE_UNEXPECTED_ERROR_VALIDATING_ATTRIBUTES("USR-15001", "Unexpected error while validating user " +

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -116,6 +116,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AUDIT_SUCCESS;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.USERNAME;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_GETTING_EXISTING_CONFIGURATIONS;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_EMAIL_DOMAIN_NOT_MAPPED_TO_ORGANIZATION;
 import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_MULTIPLE_REGISTRATION_OPTIONS;
 import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.SIGNUP_PROPERTY_REGISTRATION_OPTION;
 
@@ -366,6 +367,13 @@ public class UserSelfRegistrationManager {
                     ERROR_CODE_DOMAIN_VIOLATED, user.getUserStoreDomain(), e);
         }
 
+        if (e instanceof org.wso2.carbon.user.core.UserStoreException) {
+            String errorCode = ((org.wso2.carbon.user.core.UserStoreException) e).getErrorCode();
+            if (ERROR_CODE_EMAIL_DOMAIN_NOT_MAPPED_TO_ORGANIZATION.getCode().equals(errorCode)) {
+                throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages.
+                        ERROR_CODE_INVALID_DOMAIN, user.getUserName(), e);
+            }
+        }
         throw Utils.handleServerException(IdentityRecoveryConstants.ErrorMessages.
                 ERROR_CODE_ADD_SELF_USER, user.getUserName(), e);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -515,7 +515,6 @@
                 <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
                 <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
                 <version>${org.wso2.carbon.identity.organization.management.core.version}</version>
-                <scope>test</scope>
             </dependency>
             <!-- Pax Logging -->
             <dependency>
@@ -724,7 +723,7 @@
         <identity.auth.otp.commons.version.range>[1.0.0, 2.0.0)</identity.auth.otp.commons.version.range>
 
         <!--Carbon Identity Organization Management Version-->
-        <org.wso2.carbon.identity.organization.management.core.version>1.0.0
+        <org.wso2.carbon.identity.organization.management.core.version>1.1.2
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.core.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request

1. Enable self registration for orgs

```
[identity_mgt.user_self_registration]
allow_self_registration=true
lock_on_creation=true
enable_recaptcha=true
verification_email_validity="1440"
callback_url="[${carbon.protocol}://${carbon.host}:${carbon.management.port}].*[/authenticationendpoint/login.do]*"
enable_resend_confirmation_recaptcha=true

[identity_mgt.user_self_registration.notification]
manage_internally=true   
```

2. Set email domain organization discovery for an organization.

3. Try self registering with setting email as not matching email domain

### Related Issues
- https://github.com/wso2/product-is/issues/19911

### After the fix

<img width="889" alt="Screenshot 2024-10-02 at 16 45 20" src="https://github.com/user-attachments/assets/c4a15099-cd2f-4487-9162-3d75996bcad6">
