### PR TITLE
Improve governance configs for SMS OTP based password recovery and add multi attribute support to password recovery.

### DIFF
--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/constants/MultiAttributeLoginConstants.java
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/src/main/java/org/wso2/carbon/identity/multi/attribute/login/constants/MultiAttributeLoginConstants.java
@@ -24,6 +24,7 @@ package org.wso2.carbon.identity.multi.attribute.login.constants;
 public class MultiAttributeLoginConstants {
 
     public static final String USERNAME_CLAIM_URI = "http://wso2.org/claims/username";
+    public static final String MULTI_ATTRIBUTE_USER_IDENTIFIER_CLAIM_URI = "internal.user.identifier.claim.uri";
 
     public static final String MULTI_ATTRIBUTE_LOGIN_PROPERTY = "account.multiattributelogin.handler.enable";
     public static final String ALLOWED_LOGIN_ATTRIBUTES = "account.multiattributelogin.handler.allowedattributes";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -307,6 +307,8 @@ public class IdentityRecoveryConstants {
         ERROR_CODE_STORING_RECOVERY_FLOW_DATA("20063", "Error while storing recovery data."),
         ERROR_CODE_UPDATING_RECOVERY_FLOW_DATA("20064", "Error while updating recovery data."),
         ERROR_CODE_NO_HASHING_ALGO_FOR_CODE("20065", "Error while hashing the code."),
+        ERROR_CODE_MULTIPLE_CLAIMS_WITH_MULTI_ATTRIBUTE_URI("20066", "Multiple claims not allowed " +
+                "when user identifier claim is used."),
 
         ERROR_CODE_ERROR_RETRIVING_CLAIM("18004", "Error when retrieving the locale claim of user '%s' of '%s' domain."),
         ERROR_CODE_RECOVERY_DATA_NOT_FOUND_FOR_USER("18005", "Recovery data not found."),

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -680,6 +680,8 @@ public class IdentityRecoveryConstants {
                 ".Password.MaxFailedAttempts";
         public static final String RECOVERY_NOTIFICATION_PASSWORD_MAX_RESEND_ATTEMPTS = "Recovery.Notification" +
                 ".Password.MaxResendAttempts";
+        public static final String PASSWORD_RECOVERY_EMAIL_LINK_ENABLE = "Recovery.Notification.Password.emailLink.Enable";
+        public static final String PASSWORD_RECOVERY_SMS_OTP_ENABLE = "Recovery.Notification.Password.smsOtp.Enable";
     }
 
     public static class DBConstants {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
@@ -74,8 +74,6 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
     public Map<String, String> getPropertyNameMapping() {
 
         Map<String, String> nameMapping = new HashMap<>();
-        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY,
-                "Notification based password recovery");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SEND_OTP_IN_EMAIL,
                 "Send OTP in e-mail");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_USE_UPPERCASE_CHARACTERS_IN_OTP,
@@ -179,7 +177,6 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
     public String[] getPropertyNames() {
 
         List<String> properties = new ArrayList<>();
-        properties.add(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SEND_OTP_IN_EMAIL);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_USE_UPPERCASE_CHARACTERS_IN_OTP);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_USE_LOWERCASE_CHARACTERS_IN_OTP);
@@ -214,7 +211,6 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
     @Override
     public Properties getDefaultPropertyValues(String tenantDomain) throws IdentityGovernanceException {
 
-        String enableNotificationBasedPasswordRecovery = "false";
         String enableSendOTPInEmail = "false";
         String useUppercaseCharactersInOTP = StringUtils.EMPTY;
         String useLowercaseCharactersInOTP = StringUtils.EMPTY;
@@ -246,8 +242,6 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         String enableEmailNotificationBasedPasswordRecovery = "false";
         String enableSMSNotificationBasedPasswordRecovery = "false";
 
-        String notificationBasedPasswordRecovery = IdentityUtil.getProperty(
-                IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY);
         String sendOTPInEmailProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SEND_OTP_IN_EMAIL);
         String useUppercaseCharactersInOTPProperty = IdentityUtil.getProperty(
@@ -309,9 +303,6 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         }
         if (StringUtils.isNotEmpty(smsOtpRegexProperty)) {
             smsOtpRegex = smsOtpRegexProperty;
-        }
-        if (StringUtils.isNotEmpty(notificationBasedPasswordRecovery)) {
-            enableNotificationBasedPasswordRecovery = notificationBasedPasswordRecovery;
         }
         if (StringUtils.isNotEmpty(sendOTPInEmailProperty)) {
             enableSendOTPInEmail = sendOTPInEmailProperty;
@@ -404,8 +395,6 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         }
 
         Map<String, String> defaultProperties = new HashMap<>();
-        defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY,
-                enableNotificationBasedPasswordRecovery);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SEND_OTP_IN_EMAIL,
                 enableSendOTPInEmail);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_USE_UPPERCASE_CHARACTERS_IN_OTP,
@@ -478,9 +467,6 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
     public Map<String, Property> getMetaData() {
 
         Map<String, Property> meta = new HashMap<>();
-
-        meta.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY,
-                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SEND_OTP_IN_EMAIL,
                 getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
@@ -127,6 +127,10 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
                 "Max failed attempts for password recovery");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_NOTIFICATION_PASSWORD_MAX_RESEND_ATTEMPTS,
                 "Max resend attempts for password recovery");
+        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_EMAIL_LINK_ENABLE,
+                "Notification based password recovery via an email");
+        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_ENABLE,
+                "Notification based password recovery using SMS OTP");
         return nameMapping;
     }
 
@@ -202,6 +206,8 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         properties.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_AUTO_LGOIN_AFTER_PASSWORD_RESET);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_NOTIFICATION_PASSWORD_MAX_FAILED_ATTEMPTS);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_NOTIFICATION_PASSWORD_MAX_RESEND_ATTEMPTS);
+        properties.add(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_EMAIL_LINK_ENABLE);
+        properties.add(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_ENABLE);
         return properties.toArray(new String[0]);
     }
 
@@ -237,6 +243,8 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         String recoveryMaxResendAttempts = "5";
         int httpsProxyPort = 443;
         String secureHttpProtocol = "https";
+        String enableEmailNotificationBasedPasswordRecovery = "false";
+        String enableSMSNotificationBasedPasswordRecovery = "false";
 
         String notificationBasedPasswordRecovery = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY);
@@ -291,6 +299,10 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
                 ConnectorConfig.RECOVERY_NOTIFICATION_PASSWORD_MAX_FAILED_ATTEMPTS);
         String maxResendAttempts = IdentityUtil.getProperty(IdentityRecoveryConstants.
                 ConnectorConfig.RECOVERY_NOTIFICATION_PASSWORD_MAX_RESEND_ATTEMPTS);
+        String emailNotificationBasedPasswordRecovery = IdentityUtil.getProperty(
+                IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_EMAIL_LINK_ENABLE);
+        String smsNotificationBasedPasswordRecovery = IdentityUtil.getProperty(
+                IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_ENABLE);
 
         if (StringUtils.isNotEmpty(expiryTimeSMSOTPProperty)) {
             expiryTimeSMSOTP = expiryTimeSMSOTPProperty;
@@ -384,6 +396,12 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
         if (StringUtils.isNotEmpty(maxResendAttempts)) {
             recoveryMaxResendAttempts = maxResendAttempts;
         }
+        if (StringUtils.isNotEmpty(emailNotificationBasedPasswordRecovery)) {
+            enableEmailNotificationBasedPasswordRecovery = emailNotificationBasedPasswordRecovery;
+        }
+        if (StringUtils.isNotEmpty(smsNotificationBasedPasswordRecovery)) {
+            enableSMSNotificationBasedPasswordRecovery = smsNotificationBasedPasswordRecovery;
+        }
 
         Map<String, String> defaultProperties = new HashMap<>();
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY,
@@ -439,6 +457,10 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
                 .RECOVERY_NOTIFICATION_PASSWORD_MAX_FAILED_ATTEMPTS, recoveryMaxFailedAttempts);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig
                 .RECOVERY_NOTIFICATION_PASSWORD_MAX_RESEND_ATTEMPTS, recoveryMaxResendAttempts);
+        defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_EMAIL_LINK_ENABLE,
+                enableEmailNotificationBasedPasswordRecovery);
+        defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_ENABLE,
+                enableSMSNotificationBasedPasswordRecovery);
 
         Properties properties = new Properties();
         properties.putAll(defaultProperties);
@@ -534,6 +556,15 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.RECOVERY_NOTIFICATION_PASSWORD_MAX_RESEND_ATTEMPTS,
                 getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_EMAIL_LINK_ENABLE,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_ENABLE,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_REGEX,
+                getPropertyObject(IdentityMgtConstants.DataTypes.STRING.getValue()));
 
         return meta;
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/password/PasswordRecoveryManagerImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/password/PasswordRecoveryManagerImpl.java
@@ -630,10 +630,7 @@ public class PasswordRecoveryManagerImpl implements PasswordRecoveryManager {
      */
     private void validateConfigurations(String tenantDomain) throws IdentityRecoveryException {
 
-        boolean isRecoveryEnable = Boolean.parseBoolean(
-                Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY,
-                        tenantDomain));
-        if (!isRecoveryEnable) {
+        if (!isNotificationBasedRecoveryEnabled(tenantDomain)) {
             throw Utils.handleClientException(
                     IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PASSWORD_RECOVERY_WITH_NOTIFICATIONS_NOT_ENABLED,
                     null);
@@ -674,9 +671,13 @@ public class PasswordRecoveryManagerImpl implements PasswordRecoveryManager {
 
         // Check whether the challenge question based recovery is enabled.
         try {
-            return Boolean.parseBoolean(
-                    Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY,
+            boolean isEmailRecoveryEnable = Boolean.parseBoolean(
+                    Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_EMAIL_LINK_ENABLE,
                             tenantDomain));
+            boolean isSMSOtpRecoveryEnable = Boolean.parseBoolean(
+                    Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_ENABLE,
+                            tenantDomain));
+            return isEmailRecoveryEnable || isSMSOtpRecoveryEnable;
         } catch (IdentityRecoveryServerException e) {
             // Prepend scenario to the thrown exception.
             String errorCode = Utils

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -510,6 +510,10 @@ public class NotificationPasswordRecoveryManager {
         boolean isRecoveryEnable = Boolean.parseBoolean(
                 Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY,
                         tenantDomain));
+        boolean isSMSOtpRecoveryEnable = Boolean.parseBoolean(
+                Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_ENABLE,
+                        tenantDomain));
+        boolean isRecoveryEnable = isEmailRecoveryEnable || isSMSOtpRecoveryEnable;
         if (!isRecoveryEnable) {
             throw Utils.handleClientException(
                     IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NOTIFICATION_BASED_PASSWORD_RECOVERY_NOT_ENABLE,

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -507,8 +507,8 @@ public class NotificationPasswordRecoveryManager {
      */
     private void validatePasswordRecoveryConfiguration(String tenantDomain) throws IdentityRecoveryException {
 
-        boolean isRecoveryEnable = Boolean.parseBoolean(
-                Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY,
+        boolean isEmailRecoveryEnable = Boolean.parseBoolean(
+                Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_EMAIL_LINK_ENABLE,
                         tenantDomain));
         boolean isSMSOtpRecoveryEnable = Boolean.parseBoolean(
                 Utils.getRecoveryConfigs(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_ENABLE,

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImplTest.java
@@ -135,6 +135,10 @@ public class RecoveryConfigImplTest {
                 .RECOVERY_NOTIFICATION_PASSWORD_MAX_FAILED_ATTEMPTS, "Max failed attempts for password recovery");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig
                 .RECOVERY_NOTIFICATION_PASSWORD_MAX_RESEND_ATTEMPTS,"Max resend attempts for password recovery");
+        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_EMAIL_LINK_ENABLE,
+                "Notification based password recovery via an email");
+        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SMS_OTP_ENABLE,
+                "Notification based password recovery using SMS OTP");
 
         Map<String, String> nameMapping = recoveryConfigImpl.getPropertyNameMapping();
 
@@ -253,6 +257,8 @@ public class RecoveryConfigImplTest {
         String enableAutoLoginAfterPasswordReset = "false";
         String recoveryOTPMaxFailedAttempts = "3";
         String recoveryOTPMaxResendAttempts = "5";
+        String enableEmailNotificationBasedPasswordRecovery = "false";
+        String enableSMSNotificationBasedPasswordRecovery = "false";
 
         Map<String, String> defaultPropertiesExpected = new HashMap<>();
         defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY,
@@ -309,6 +315,10 @@ public class RecoveryConfigImplTest {
                 RECOVERY_NOTIFICATION_PASSWORD_MAX_FAILED_ATTEMPTS, recoveryOTPMaxFailedAttempts);
         defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.
                 RECOVERY_NOTIFICATION_PASSWORD_MAX_RESEND_ATTEMPTS, recoveryOTPMaxResendAttempts);
+        defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.
+                PASSWORD_RECOVERY_EMAIL_LINK_ENABLE, enableEmailNotificationBasedPasswordRecovery);
+        defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.
+                PASSWORD_RECOVERY_SMS_OTP_ENABLE, enableSMSNotificationBasedPasswordRecovery);
 
         String tenantDomain = "admin";
         // Here tenantDomain parameter is not used by method itself

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImplTest.java
@@ -80,8 +80,6 @@ public class RecoveryConfigImplTest {
     public void testGetPropertyNameMapping() {
 
         Map<String, String> nameMappingExpected = new HashMap<>();
-        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY,
-                "Notification based password recovery");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SEND_OTP_IN_EMAIL,
                 "Send OTP in e-mail");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_USE_UPPERCASE_CHARACTERS_IN_OTP,
@@ -192,7 +190,6 @@ public class RecoveryConfigImplTest {
     public void testGetPropertyNames() {
 
         List<String> propertiesExpected = new ArrayList<>();
-        propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SEND_OTP_IN_EMAIL);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_USE_UPPERCASE_CHARACTERS_IN_OTP);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_USE_LOWERCASE_CHARACTERS_IN_OTP);
@@ -261,8 +258,6 @@ public class RecoveryConfigImplTest {
         String enableSMSNotificationBasedPasswordRecovery = "false";
 
         Map<String, String> defaultPropertiesExpected = new HashMap<>();
-        defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY,
-                testEnableNotificationBasedPasswordRecovery);
         defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SEND_OTP_IN_EMAIL,
                 testEnableSendOTPInEmail);
         defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_USE_UPPERCASE_CHARACTERS_IN_OTP,

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManagerTest.java
@@ -34,6 +34,7 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
@@ -98,6 +99,9 @@ public class UserAccountRecoveryManagerTest {
 
     @Mock
     ClaimManager claimManager;
+
+    @Mock
+    MultiAttributeLoginService multiAttributeLoginService;
 
     /**
      * User claims map.
@@ -292,6 +296,9 @@ public class UserAccountRecoveryManagerTest {
             when(abstractUserStoreManager.getUserListWithID(any(Condition.class),anyString(),anyString(),
                     anyInt(),anyInt(),isNull(), isNull())).
                     thenReturn(new ArrayList<org.wso2.carbon.user.core.common.User>());
+            when(identityRecoveryServiceDataHolder.getMultiAttributeLoginService())
+                    .thenReturn(multiAttributeLoginService);
+            when(multiAttributeLoginService.isEnabled(anyString())).thenReturn(false);
             userAccountRecoveryManager
                     .retrieveUserRecoveryInformation(userClaims, StringUtils.EMPTY, RecoveryScenarios.USERNAME_RECOVERY,
                             null);
@@ -428,6 +435,9 @@ public class UserAccountRecoveryManagerTest {
                     anyInt(),anyInt(),isNull(), isNull())).thenReturn(getFilteredUsers());
             when(claimManager.getAttributeName(anyString(),anyString())).
                     thenReturn("http://wso2.org/claims/mockedClaim");
+            when(identityRecoveryServiceDataHolder.getMultiAttributeLoginService())
+                    .thenReturn(multiAttributeLoginService);
+            when(multiAttributeLoginService.isEnabled(anyString())).thenReturn(false);
             String username = userAccountRecoveryManager
                     .getUsernameByClaims(userClaims, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
             assertNull(username, "UserAccountRecoveryManager: Exception should be thrown. Therefore, a "


### PR DESCRIPTION
### Proposed changes in this pull request
Introduces the following configurations to support sms otp based password recovery. 

- Recovery.Notification.Password.emailLink.Enable
- Recovery.Notification.Password.smsOtp.Enable

### Related Issues
- https://github.com/wso2-enterprise/iam-product-management/issues/51
- https://github.com/wso2-enterprise/iam-engineering/issues/534

### Related PRs
- https://github.com/wso2-extensions/identity-governance/pull/718

