### PR TITLE
Mask PII in AccountConfirmationValidationHandler

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AccountConfirmationValidationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AccountConfirmationValidationHandler.java
@@ -1,17 +1,19 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2024, WSO2 LLC. (http://www.wso2.com).
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations und
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.recovery.handler;
@@ -63,10 +65,12 @@ public class AccountConfirmationValidationHandler extends AbstractEventHandler {
 
         Map<String, Object> eventProperties = event.getEventProperties();
         String userName = (String) eventProperties.get(IdentityEventConstants.EventProperty.USER_NAME);
-        UserStoreManager userStoreManager = (UserStoreManager) eventProperties.get(IdentityEventConstants.EventProperty.USER_STORE_MANAGER);
+        UserStoreManager userStoreManager =
+                (UserStoreManager) eventProperties.get(IdentityEventConstants.EventProperty.USER_STORE_MANAGER);
 
         String tenantDomain = (String) eventProperties.get(IdentityEventConstants.EventProperty.TENANT_DOMAIN);
-        String domainName = userStoreManager.getRealmConfiguration().getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
+        String domainName = userStoreManager.getRealmConfiguration()
+                .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
 
         User user = new User();
         user.setUserName(userName);
@@ -88,7 +92,9 @@ public class AccountConfirmationValidationHandler extends AbstractEventHandler {
 
         if (IdentityEventConstants.Event.POST_AUTHENTICATION.equals(event.getEventName())) {
             if (log.isDebugEnabled()) {
-                log.debug("Handling PostAuthenticate for " + user);
+                log.debug(
+                        String.format("Handling PostAuthenticate for user: %s in userstore: %s in tenant: %s",
+                                Utils.maskIfRequired(userName), domainName, tenantDomain));
             }
             boolean isAccountLocked;
             try {
@@ -115,17 +121,18 @@ public class AccountConfirmationValidationHandler extends AbstractEventHandler {
                         IdentityCoreConstants.USER_ACCOUNT_NOT_CONFIRMED_ERROR_CODE);
                 IdentityUtil.setIdentityErrorMsg(customErrorMessageContext);
                 throw new IdentityEventException(IdentityCoreConstants.USER_ACCOUNT_NOT_CONFIRMED_ERROR_CODE,
-                        "User : " + userName + " not confirmed yet.");
+                        "User : " + Utils.maskIfRequired(userName) + " not confirmed yet.");
             } else if (isInvalidCredentialsScenario(operationStatus, user)) {
                 if (log.isDebugEnabled()) {
                     log.debug(String.format("Account unconfirmed user: %s in userstore: %s in tenant: %s is trying " +
-                            "to log in with an invalid password", userName, domainName, tenantDomain));
+                                    "to log in with an invalid password", Utils.maskIfRequired(userName), domainName,
+                            tenantDomain));
                 }
                 IdentityErrorMsgContext customErrorMessageContext =
                         new IdentityErrorMsgContext(IdentityCoreConstants.USER_INVALID_CREDENTIALS);
                 IdentityUtil.setIdentityErrorMsg(customErrorMessageContext);
                 throw new IdentityEventException(IdentityCoreConstants.USER_INVALID_CREDENTIALS,
-                        "Invalid login attempt by self registered user: " + userName);
+                        "Invalid login attempt by self registered user: " + Utils.maskIfRequired(userName));
             }
         }
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2024, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -1091,8 +1091,8 @@ public class Utils {
 
         if (!isLegacyAuditLogsDisabled()) {
             AUDIT_LOG.info(String
-                    .format(AuditConstants.AUDIT_MESSAGE, getInitiator(), action, LoggerUtils.isLogMaskingEnable ?
-                            LoggerUtils.getMaskedContent(target) : target, dataObject, result));
+                    .format(AuditConstants.AUDIT_MESSAGE, getInitiator(), action, maskIfRequired(target),
+                    dataObject, result));
         }
     }
 
@@ -1652,6 +1652,17 @@ public class Utils {
                 ERROR_CODE_UNEXPECTED_ERROR_VALIDATING_ATTRIBUTES.getMessage(),
                 e.getMessage(),
                 e);
+    }
+
+    /**
+     * Mask the given value if it is required.
+     *
+     * @param value Value to be masked.
+     * @return Masked/unmasked value.
+     */
+    public static String maskIfRequired(String value) {
+
+        return LoggerUtils.isLogMaskingEnable ? LoggerUtils.getMaskedContent(value) : value;
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request

- Mask sensitive information and prevent them from being logged in `AccountConfirmationValidationHandler`.
