### PR TITLE
Fix sending Identity claim attributes to the userstores to fetch data

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
@@ -221,6 +221,55 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
     }
 
     @Override
+    public boolean doPreGetUserClaimValues(String userName, String[] claims, String profileName,
+                                           Map<String, String> claimMap,
+                                           UserStoreManager storeManager) {
+
+        if (!isEnable()) {
+            return true;
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("doPreGetUserClaimValues getting executed in the IdentityStoreEventListener for user: " +
+                    userName);
+        }
+
+        // No need to separately handle if identity `data store is user store based
+        if (isUserStoreBasedIdentityDataStore() || isStoreIdentityClaimsInUserStoreEnabled(storeManager)) {
+            return true;
+        }
+
+        // If hybrid data store is enabled, we need to send all claims to user store
+        if (isHybridDataStoreEnable) {
+            return true;
+        }
+        removeIdentityClaims(claims, UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI);
+        return true;
+    }
+
+    /**
+     * Removes all identity claims that contain the specified identity claim URI from the given array of claims.
+     *
+     * @param claims           Array of claims to be filtered
+     * @param identityClaimURI Identity claim URI to be removed from the claims
+     */
+    private static void removeIdentityClaims(String[] claims, String identityClaimURI) {
+
+        int validCount = 0;
+
+        for (int i = 0; i < claims.length; i++) {
+            if (claims[i] != null && !claims[i].contains(identityClaimURI)) {
+                claims[validCount++] = claims[i];
+            }
+        }
+
+        // Set the remaining elements to null
+        while (validCount < claims.length) {
+            claims[validCount++] = null;
+        }
+    }
+
+    @Override
     public boolean doPostGetUserClaimValues(String userName, String[] claims, String profileName,
                                             Map<String, String> claimMap,
                                             UserStoreManager storeManager) {
@@ -241,16 +290,6 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
 
         if (claimMap == null) {
             claimMap = new HashMap<>();
-        }
-
-        if (!isHybridDataStoreEnable) {
-            /*
-            If hybrid data store is disabled, we need to use the identity claim value only from the identity data store.
-            Hence, we need to remove the identity claim values from the claimMap to avoid use of values from user store
-            for identity claims.
-             */
-            claimMap.entrySet().removeIf(
-                    entry -> entry.getKey().contains(UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI_PREFIX));
         }
 
         // check if there are identity claims

--- a/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListenerTest.java
+++ b/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListenerTest.java
@@ -228,11 +228,27 @@ public class IdentityStoreEventListenerTest {
     }
 
     @Test(dataProvider = "getUserClaimHandler")
+    public void testDoPreGetUserClaimValues(String userName, Object pwd, String[] claimList, Map<String, String> claims,
+                                            String prof) throws Exception {
+
+        realmConfiguration = mock(RealmConfiguration.class);
+        userIdentityDataStore = mock(UserIdentityDataStore.class);
+
+        Field fieldIdentityStore = IdentityStoreEventListener.class.getDeclaredField("identityDataStore");
+        fieldIdentityStore.setAccessible(true);
+        fieldIdentityStore.set(identityStoreEventListener, userIdentityDataStore);
+
+        assertTrue(identityStoreEventListener.doPostGetUserClaimValues(userName, claimList, prof, claims,
+                userStoreManager));
+    }
+
+    @Test(dataProvider = "getUserClaimHandler")
     public void testDoPostGetUserClaimValues(String userName,
                                              Object pwd,
                                              String[] claimList,
                                              Map<String, String> claims,
                                              String prof) throws Exception {
+
         realmConfiguration = mock(RealmConfiguration.class);
         Mockito.when(userStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
         Mockito.when(realmConfiguration.getUserStoreProperty(STORE_IDENTITY_CLAIMS)).thenReturn(String.valueOf(false));


### PR DESCRIPTION
## Purpose
In the current implementation, all the local claims configured are resolved for attributes and sent to the user stores to fetch data. This includes Identity claims which should not be sent if an Identity Database is configured. Here we use config [1],

```
[event.default_listener.governance_identity_store] 
enable_hybrid_data_store = false 
```

to stop sending identity claims to the user store.

### Related issue
- https://github.com/wso2/product-is/issues/20490