### PR TITLE
Use otpTokenString parameter to pass OTP code to SMSNotificationHandler

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -132,17 +132,6 @@
             <groupId>org.wso2.carbon.identity.governance</groupId>
             <artifactId>org.wso2.carbon.identity.multi.attribute.login.service</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity.auth.otp.commons</groupId>
-            <artifactId>org.wso2.carbon.identity.auth.otp.core</artifactId>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.wso2.carbon.identity.framework</groupId>
-                    <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>
@@ -199,8 +188,6 @@
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.multi.attribute.login.service;
                             version="${identity.governance.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.auth.otp.core.model;
-                            version="${identity.auth.otp.commons.version.range}",
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -74,6 +74,7 @@ public class IdentityRecoveryConstants {
     public static final String INITIATED_PLATFORM = "initiated-platform";
     public static final String CONFIRMATION_CODE = "confirmation-code";
     public static final String OTP_TOKEN = "otpToken";
+    public static final String OTP_TOKEN_STRING = "otpTokenString";
     public static final String VERIFICATION_PENDING_EMAIL = "verification-pending-email";
     public static final String NEW_EMAIL_ADDRESS = "new-email-address";
     public static final String NOTIFY = "notify";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
@@ -25,7 +25,6 @@ import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.common.model.User;
-import org.wso2.carbon.identity.auth.otp.core.model.OTP;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
@@ -278,7 +277,7 @@ public class ResendConfirmationManager {
         }
         if (StringUtils.isNotBlank(code)) {
             if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)) {
-                properties.put(IdentityRecoveryConstants.OTP_TOKEN, new OTP(code, 0, 0));
+                properties.put(IdentityRecoveryConstants.OTP_TOKEN_STRING, code);
             } else {
                 properties.put(IdentityRecoveryConstants.CONFIRMATION_CODE, code);
             }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -24,7 +24,6 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.identity.auth.otp.core.model.OTP;
 import org.json.JSONObject;
 import org.slf4j.MDC;
 import org.wso2.carbon.base.MultitenantConstants;
@@ -1022,9 +1021,7 @@ public class NotificationPasswordRecoveryManager {
         }
         if (StringUtils.isNotBlank(code)) {
             if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)) {
-                /* Generate time and validity period not added since only used to pass the otp code to notification
-                event handler. */
-                properties.put(IdentityRecoveryConstants.OTP_TOKEN, new OTP(code, 0,0));
+                properties.put(IdentityRecoveryConstants.OTP_TOKEN_STRING, code);
             } else {
                 properties.put(IdentityRecoveryConstants.CONFIRMATION_CODE, code);
             }
@@ -1116,9 +1113,7 @@ public class NotificationPasswordRecoveryManager {
         }
         if (StringUtils.isNotBlank(code)) {
             properties.put(IdentityRecoveryConstants.CONFIRMATION_CODE, code);
-            /* Generate time and validity period not added since only used to pass the otp code to notification
-            event handler. */
-            properties.put(IdentityRecoveryConstants.OTP_TOKEN, new OTP(code, 0,0));
+            properties.put(IdentityRecoveryConstants.OTP_TOKEN_STRING, code);
         }
 
         if (StringUtils.isNotBlank(notify)) {

--- a/pom.xml
+++ b/pom.xml
@@ -506,11 +506,6 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.identity.auth.otp.commons</groupId>
-                <artifactId>org.wso2.carbon.identity.auth.otp.core</artifactId>
-                <version>${identity.auth.otp.commons.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.wso2.carbon.identity.governance</groupId>
                 <artifactId>org.wso2.carbon.identity.multi.attribute.login.server.feature</artifactId>
                 <version>${project.version}</version>


### PR DESCRIPTION
## Purpose
The OTP code used to pass the OTP code to the SMSNotificationHandler creates a circular dependency. This PR removes the use of the object and uses a string parameter to pass the OTP code to the notification handler. 

## Related Issues
- https://github.com/wso2-enterprise/iam-engineering/issues/534
- https://github.com/wso2-enterprise/asgardeo-product/issues/25335

## Related PRs
- https://github.com/wso2-extensions/identity-local-auth-smsotp/pull/23 [Dependent]