### PR TITLE
Add config to skip backend recaptcha validation for self-registration API

### DIFF
--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/SelfSignUpReCaptchaConnector.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/SelfSignUpReCaptchaConnector.java
@@ -30,6 +30,8 @@ import org.wso2.carbon.identity.captcha.internal.CaptchaDataHolder;
 import org.wso2.carbon.identity.captcha.util.CaptchaUtil;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 
+import java.util.List;
+
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
@@ -66,7 +68,9 @@ public class SelfSignUpReCaptchaConnector extends AbstractReCaptchaConnector {
 
         String path = ((HttpServletRequest) servletRequest).getRequestURI();
 
-        if (StringUtils.isBlank(path) || (!CaptchaUtil.isPathAvailable(path, SELF_REGISTRATION_INITIATE_URL) &&
+        List<String> reCaptchaBypassedApiEndpoints = CaptchaDataHolder.getInstance().getReCaptchaBypassedApiEndpoints();
+        if (StringUtils.isBlank(path) || reCaptchaBypassedApiEndpoints.contains(path) ||
+                (!CaptchaUtil.isPathAvailable(path, SELF_REGISTRATION_INITIATE_URL) &&
                 !CaptchaUtil.isPathAvailable(path, SELF_REGISTRATION_URL))) {
             return false;
         }

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaDataHolder.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaDataHolder.java
@@ -77,6 +77,8 @@ public class CaptchaDataHolder {
 
     private boolean forcefullyEnabledRecaptchaForAllTenants;
 
+    private List<String> reCaptchaBypassedApiEndpoints = new ArrayList<>();
+
     private CaptchaDataHolder() {
 
     }
@@ -267,5 +269,15 @@ public class CaptchaDataHolder {
     public void setForcefullyEnabledRecaptchaForAllTenants(boolean forcefullyEnabledRecaptchaForAllTenants) {
 
         this.forcefullyEnabledRecaptchaForAllTenants = forcefullyEnabledRecaptchaForAllTenants;
+    }
+
+    public List<String> getReCaptchaBypassedApiEndpoints() {
+
+        return reCaptchaBypassedApiEndpoints;
+    }
+
+    public void setReCaptchaBypassedApiEndpoints(List<String> reCaptchaBypassedApiEndpoints) {
+
+        this.reCaptchaBypassedApiEndpoints = reCaptchaBypassedApiEndpoints;
     }
 }

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaConstants.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaConstants.java
@@ -79,6 +79,7 @@ public class CaptchaConstants {
     public static final String CAPTCHA_RISK_ANALYSIS = "riskAnalysis";
     // Captcha Types.
     public static final String RE_CAPTCHA_TYPE_ENTERPRISE = "recaptcha-enterprise";
+    public static final String RE_CAPTCHA_BYPASSED_API_ENDPOINTS = "recaptcha.bypassed.api.endpoints";
 
     // Default value for threshold for score in reCAPTCHA v3.
     public static final double CAPTCHA_V3_DEFAULT_THRESHOLD = 0.5;

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaUtil.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaUtil.java
@@ -614,6 +614,13 @@ public class CaptchaUtil {
         }
         CaptchaDataHolder.getInstance().setReCaptchaRequestWrapUrls(reCaptchaRequestWrapUrls);
 
+        String reCaptchaBypassedApiEndpointsString = properties.getProperty(
+                CaptchaConstants.RE_CAPTCHA_BYPASSED_API_ENDPOINTS);
+        if (StringUtils.isNotBlank(reCaptchaBypassedApiEndpointsString)) {
+            CaptchaDataHolder.getInstance().setReCaptchaBypassedApiEndpoints(
+                    Arrays.asList(reCaptchaBypassedApiEndpointsString.split(",")));
+        }
+
         try {
             Double reCaptchaScoreThreshold = getReCaptchaThreshold(properties);
             CaptchaDataHolder.getInstance().setReCaptchaScoreThreshold(reCaptchaScoreThreshold);

--- a/features/org.wso2.carbon.identity.captcha.server.feature/resources/conf/captcha-config.properties.j2
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/resources/conf/captcha-config.properties.j2
@@ -51,6 +51,12 @@ recaptcha.failed.redirect.urls={{recaptcha.redirect_urls}}
 #recaptcha.failed.redirect.urls=
 []
 
+{% if recaptcha.bypassed_api_endpoints is defined %}
+# reCaptcha bypassed API endpoints
+{% set bypassed_api_endpoints = recaptcha.bypassed_api_endpoints %}
+recaptcha.bypassed.api.endpoints={{ bypassed_api_endpoints | join(',') }}
+{% endif %}
+
 # recaptcha request wrapping paths comma separated
 recaptcha.request.wrap.urls={{recaptcha.request_wrap_urls}}
 


### PR DESCRIPTION
### Purpose

$subject

Following config should be added to the deployment.toml

```
[recaptcha] 
bypassed_api_endpoints = ["/api/identity/user/v1.0/me"]
```

### Related issue
- https://github.com/wso2/product-is/issues/20726