### PR TITLE
Revert "Add CAMPAIGN parameter to pardot registrations."

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/LiteApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/LiteApiServiceImpl.java
@@ -118,7 +118,26 @@ public class LiteApiServiceImpl extends LiteApiService {
                     if (userNotConfirmed && isResendVerificationEnabledOnUserExistence) {
                         try {
                             ResendConfirmationManager resendConfirmationManager = Utils.getResendConfirmationManager();
-                            Property[] propertiesList = getPropertyDTOList(properties);
+                            Property[] propertiesList = null;
+                            if (properties.size() > 1) {
+                                propertiesList = new Property[2];
+                                for (PropertyDTO property : properties) {
+                                    String key = property.getKey();
+                                    String value = property.getValue();
+                                    if (IdentityRecoveryConstants.RESEND_EMAIL_TEMPLATE_NAME.equals(key)) {
+                                        Property templateDTO = new Property();
+                                        templateDTO.setKey(IdentityRecoveryConstants.RESEND_EMAIL_TEMPLATE_NAME);
+                                        templateDTO.setValue(value);
+                                        propertiesList[0] = templateDTO;
+                                    }
+                                    if (IdentityRecoveryConstants.INITIATED_PLATFORM.equals(key)) {
+                                        Property initiatedPlatformDTO = new Property();
+                                        initiatedPlatformDTO.setKey(IdentityRecoveryConstants.INITIATED_PLATFORM);
+                                        initiatedPlatformDTO.setValue(value);
+                                        propertiesList[1] = initiatedPlatformDTO;
+                                    }
+                                }
+                            }
                             notificationResponseBean =
                                     resendConfirmationManager.resendConfirmationCode(user, LITE_SIGN_UP.toString(),
                                             CONFIRM_LITE_SIGN_UP.toString(),
@@ -142,42 +161,6 @@ public class LiteApiServiceImpl extends LiteApiService {
                     .ErrorMessages.ERROR_CODE_UNEXPECTED.getCode(), LOG, throwable);
         }
         return buildSuccessfulAPIResponse(notificationResponseBean);
-    }
-
-    /**
-     * Filter list of properties to resend confirmation from provided properties.
-     *
-     * @param properties List of properties
-     * @return Property[]
-     */
-    private static Property[] getPropertyDTOList(List<PropertyDTO> properties) {
-
-        List<PropertyDTO> propertiesList = new ArrayList<>();
-        if (properties.size() > 1) {
-            for (PropertyDTO property : properties) {
-                String key = property.getKey();
-                String value = property.getValue();
-                if (IdentityRecoveryConstants.RESEND_EMAIL_TEMPLATE_NAME.equals(key)) {
-                    PropertyDTO templateDTO = new PropertyDTO();
-                    templateDTO.setKey(IdentityRecoveryConstants.RESEND_EMAIL_TEMPLATE_NAME);
-                    templateDTO.setValue(value);
-                    propertiesList.add(templateDTO);
-                }
-                if (IdentityRecoveryConstants.INITIATED_PLATFORM.equals(key)) {
-                    PropertyDTO initiatedPlatformDTO = new PropertyDTO();
-                    initiatedPlatformDTO.setKey(IdentityRecoveryConstants.INITIATED_PLATFORM);
-                    initiatedPlatformDTO.setValue(value);
-                    propertiesList.add(initiatedPlatformDTO);
-                }
-                if (IdentityRecoveryConstants.CAMPAIGN.equals(key)) {
-                    PropertyDTO campaignDTO = new PropertyDTO();
-                    campaignDTO.setKey(IdentityRecoveryConstants.CAMPAIGN);
-                    campaignDTO.setValue(value);
-                    propertiesList.add(campaignDTO);
-                }
-            }
-        }
-        return Utils.getProperties(propertiesList);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -72,7 +72,6 @@ public class IdentityRecoveryConstants {
     public static final String EMAIL_TEMPLATE_NAME = "templateName";
     public static final String RESEND_EMAIL_TEMPLATE_NAME = "resendTemplateName";
     public static final String INITIATED_PLATFORM = "initiated-platform";
-    public static final String CAMPAIGN = "campaign";
     public static final String CONFIRMATION_CODE = "confirmation-code";
     public static final String OTP_TOKEN = "otpToken";
     public static final String OTP_TOKEN_STRING = "otpTokenString";


### PR DESCRIPTION
### Purpose
>  This PR reverts the changes done under the feature "Tracking Marketing Campaign Related User Actions."
> This is done to avoid blocker for  dev sync

### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/26074

### Related PRs
- https://github.com/wso2-extensions/identity-governance/pull/845
