### PR TITLE
Deprecating obsolete method

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/notification/NotificationTemplateManager.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/notification/NotificationTemplateManager.java
@@ -107,6 +107,7 @@ public interface NotificationTemplateManager {
      * @param tenantDomain        Tenant domain
      * @throws NotificationTemplateManagerException If an error occurred while adding the default notification templates
      */
+    @Deprecated
     default void addDefaultNotificationTemplates(String notificationChannel, String tenantDomain)
             throws NotificationTemplateManagerException {
 


### PR DESCRIPTION
With [1], we no longer need to persist default templates with server startup and tenant creation. Hence removing and deprecating the related implementation.

Addressing : https://github.com/wso2-extensions/identity-event-handler-notification/pull/256#issuecomment-2316811960
Related PR : https://github.com/wso2-extensions/identity-event-handler-notification/pull/258

[1] https://github.com/wso2-enterprise/asgardeo-product/issues/26100