### PR TITLE
Change the SMS handler to default in username recovery notify.

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/username/UsernameRecoveryManagerImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/username/UsernameRecoveryManagerImpl.java
@@ -172,8 +172,8 @@ public class UsernameRecoveryManagerImpl implements UsernameRecoveryManager {
         // If the notifications are externally managed we do not need to send notifications internally.
         if (!NotificationChannels.EXTERNAL_CHANNEL.getChannelType().equals(notificationChannel)) {
             String eventName;
-            if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)){
-                eventName =  IdentityRecoveryConstants.NOTIFICATION_EVENTNAME_PREFIX + notificationChannel
+            if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)) {
+                eventName = IdentityRecoveryConstants.NOTIFICATION_EVENTNAME_PREFIX + notificationChannel
                         + IdentityRecoveryConstants.NOTIFICATION_EVENTNAME_SUFFIX;
             } else {
                 eventName = Utils.resolveEventName(notificationChannel);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/username/UsernameRecoveryManagerImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/username/UsernameRecoveryManagerImpl.java
@@ -171,7 +171,13 @@ public class UsernameRecoveryManagerImpl implements UsernameRecoveryManager {
 
         // If the notifications are externally managed we do not need to send notifications internally.
         if (!NotificationChannels.EXTERNAL_CHANNEL.getChannelType().equals(notificationChannel)) {
-            String eventName = Utils.resolveEventName(notificationChannel);
+            String eventName;
+            if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)){
+                eventName =  IdentityRecoveryConstants.NOTIFICATION_EVENTNAME_PREFIX + notificationChannel
+                        + IdentityRecoveryConstants.NOTIFICATION_EVENTNAME_SUFFIX;
+            } else {
+                eventName = Utils.resolveEventName(notificationChannel);
+            }
             validateCallbackURL(properties, userRecoveryData.getUser());
             triggerNotification(userRecoveryData.getUser(), notificationChannel, eventName, properties);
         }


### PR DESCRIPTION
### Proposed changes in this pull request
- $title

### Problem
- The current sms handler is not working in the username recovery notification since it requires user mobile number and other properties as properties in the event.