### PR TITLE
Add governance config to enable/disable multiple emails and mobiles per user feature

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImpl.java
@@ -59,6 +59,7 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
     private static final String DEFAULT_MOBILE_NUM_VERIFICATION_ON_UPDATE_SMS_OTP_EXPIRY_TIME = "5";
     private static final String DEFAULT_ENABLE_VALUE_FOR_MOBILE_NUMBER_VERIFICATION_ON_UPDATE = "false";
     private static final String DEFAULT_MOBILE_NUM_VERIFICATION_BY_PRIVILEGED_USERS = "false";
+    private static final String DEFAULT_SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS = "false";
     private static final String USER_CLAIM_UPDATE_ELEMENT = "UserClaimUpdate";
     private static final String ENABLE_ELEMENT = "Enable";
     private static final String SEND_OTP_IN_EMAIL_ELEMENT = "SendOTPInEmail";
@@ -74,6 +75,8 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
     private static final String VERIFICATION_ON_UPDATE_ELEMENT = "VerificationOnUpdate";
     private static final String NOTIFICATION_ON_UPDATE_ELEMENT = "NotificationOnUpdate";
     private static final String ENABLE_MOBILE_VERIFICATION_PRIVILEGED_USER = "EnableVerificationByPrivilegedUser";
+    private static final String ENABLE_MULTIPLE_EMAILS_AND_MOBILE_NUMBERS_ELEMENT =
+            "EnableMultipleEmailsAndMobileNumbers";
     private static String enableEmailVerificationOnUpdateProperty = null;
     private static String enableSendOTPInEmailProperty = null;
     private static String useUppercaseCharactersInOTPProperty = null;
@@ -85,6 +88,7 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
     private static String enableMobileNumVerificationOnUpdateProperty = null;
     private static String mobileNumVerificationOnUpdateCodeExpiryProperty = null;
     private static String mobileNumVerificationByPrivilegedUsersProperty = null;
+    private static String supportMultiEmailsAndMobileNumbersProperty = null;
 
     @Override
     public String getName() {
@@ -142,6 +146,8 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
                 "Enable mobile number verification by privileged users");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME,
                 "Mobile number verification on update SMS OTP expiry time");
+        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER,
+                "Support multiple emails and mobile numbers per user");
         return nameMapping;
     }
 
@@ -174,6 +180,8 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
                 "Validity time of the mobile number confirmation OTP in minutes.");
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER,
                 "Allow privileged users to initiate mobile number verification on update.");
+        descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER,
+                "Allow users to add multiple email addresses and mobile numbers to their account.");
         return descriptionMapping;
     }
 
@@ -192,6 +200,7 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
         properties.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_NUM_VERIFICATION_ON_UPDATE);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER);
+        properties.add(IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER);
         return properties.toArray(new String[0]);
     }
 
@@ -209,6 +218,7 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
         String enableMobileNumVerificationOnUpdate = DEFAULT_ENABLE_VALUE_FOR_MOBILE_NUMBER_VERIFICATION_ON_UPDATE;
         String mobileNumVerificationOnUpdateCodeExpiry = DEFAULT_MOBILE_NUM_VERIFICATION_ON_UPDATE_SMS_OTP_EXPIRY_TIME;
         String mobileNumVerificationByPrivilegedUsers = DEFAULT_MOBILE_NUM_VERIFICATION_BY_PRIVILEGED_USERS;
+        String supportMultiEmailsAndMobileNumbers = DEFAULT_SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS;
 
         loadConfigurations();
 
@@ -245,6 +255,9 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
         if (StringUtils.isNotBlank(mobileNumVerificationByPrivilegedUsersProperty)) {
             mobileNumVerificationByPrivilegedUsers = mobileNumVerificationByPrivilegedUsersProperty;
         }
+        if (StringUtils.isNotBlank(supportMultiEmailsAndMobileNumbersProperty)) {
+            supportMultiEmailsAndMobileNumbers = supportMultiEmailsAndMobileNumbersProperty;
+        }
 
         Properties properties = new Properties();
         properties.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION_ON_UPDATE,
@@ -269,6 +282,8 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
                 mobileNumVerificationOnUpdateCodeExpiry);
         properties.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER,
                 mobileNumVerificationByPrivilegedUsers);
+        properties.put(IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER,
+                supportMultiEmailsAndMobileNumbers);
         return properties;
     }
 
@@ -297,11 +312,15 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
         OMElement userClaimUpdate = IdentityConfigParser.getInstance().getConfigElement(USER_CLAIM_UPDATE_ELEMENT);
         Iterator claims = null;
         OMElement otpConfigs = null;
+        OMElement supportMultiEmailsAndMobileNumbers = null;
         if (userClaimUpdate != null) {
             claims = userClaimUpdate.getChildrenWithName(new QName(IdentityCoreConstants
                     .IDENTITY_DEFAULT_NAMESPACE, CLAIM_ELEMENT));
             otpConfigs = userClaimUpdate.getFirstChildWithName(new QName
                     (IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, OTP_ELEMENT));
+            supportMultiEmailsAndMobileNumbers = userClaimUpdate.getFirstChildWithName(
+                    new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                            ENABLE_MULTIPLE_EMAILS_AND_MOBILE_NUMBERS_ELEMENT));
         }
 
         if (claims != null) {
@@ -365,6 +384,9 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
             otpLengthProperty = otpConfigs.getFirstChildWithName(new QName
                     (IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, OTP_LENGTH_ELEMENT)).getText();
         }
+        if (supportMultiEmailsAndMobileNumbers != null) {
+            supportMultiEmailsAndMobileNumbersProperty = supportMultiEmailsAndMobileNumbers.getText();
+        }
     }
 
     @Override
@@ -401,6 +423,9 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME,
                 getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         return meta;
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
@@ -96,7 +96,8 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
             claims = new HashMap<>();
         }
 
-        boolean supportMultipleMobileNumbers = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled();
+        boolean supportMultipleMobileNumbers =
+                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain());
 
         boolean enable = isMobileVerificationOnUpdateEnabled(user.getTenantDomain());
 
@@ -326,7 +327,8 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
             Utils.unsetThreadLocalToSkipSendingSmsOtpVerificationOnUpdate();
         }
 
-        boolean supportMultipleMobileNumbers = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled();
+        boolean supportMultipleMobileNumbers =
+                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain());
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
 
         String mobileNumber = claims.get(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -99,7 +99,7 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
             claims = new HashMap<>();
         }
 
-        boolean supportMultipleEmails = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled();
+        boolean supportMultipleEmails = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain());
 
         boolean enable = false;
 
@@ -568,7 +568,7 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
             Utils.unsetThreadLocalToSkipSendingEmailVerificationOnUpdate();
         }
 
-        boolean supportMultipleEmails = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled();
+        boolean supportMultipleEmails = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain());
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
 
         String emailAddress = claims.get(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -768,7 +768,8 @@ public class UserSelfRegistrationManager {
         HashMap<String, String> userClaims = getClaimsListToUpdate(user, verifiedChannelType,
                 externallyVerifiedClaim, recoveryData.getRecoveryScenario().toString());
 
-        boolean supportMultipleEmailsAndMobileNumbers = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled();
+        boolean supportMultipleEmailsAndMobileNumbers =
+                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain());
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
 
         if (RecoverySteps.VERIFY_EMAIL.equals(recoveryData.getRecoveryStep())) {
@@ -990,7 +991,8 @@ public class UserSelfRegistrationManager {
         UserStoreManager userStoreManager = getUserStoreManager(user);
         HashMap<String, String> userClaims = new HashMap<>();
 
-        boolean supportMultipleEmailsAndMobileNumbers = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled();
+        boolean supportMultipleEmailsAndMobileNumbers =
+                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain());
 
         String pendingMobileNumberClaimValue = recoveryData.getRemainingSetIds();
         if (StringUtils.isNotBlank(pendingMobileNumberClaimValue)) {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1397,10 +1397,16 @@ public class Utils {
      *
      * @return True if the config is set to true, false otherwise.
      */
-    public static boolean isMultiEmailsAndMobileNumbersPerUserEnabled() {
+    public static boolean isMultiEmailsAndMobileNumbersPerUserEnabled(String tenantDomain) {
 
-        return Boolean.parseBoolean(IdentityUtil.getProperty(
-                IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER));
+        try {
+            return Boolean.parseBoolean(getConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
+                    .SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER, tenantDomain));
+        } catch (IdentityEventException e) {
+            log.error("Error while getting connector configurations support multi emails and mobile numbers per" +
+                    " user.", e);
+            return true;
+        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImplTest.java
@@ -142,6 +142,8 @@ public class UserClaimUpdateConfigImplTest {
                 "Mobile number verification on update SMS OTP expiry time");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER,
                 "Enable mobile number verification by privileged users");
+        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER,
+                "Support multiple emails and mobile numbers per user");
         Map<String, String> nameMapping = userClaimUpdateConfig.getPropertyNameMapping();
         assertEquals(nameMapping, nameMappingExpected, "Maps are not equal.");
     }
@@ -176,6 +178,8 @@ public class UserClaimUpdateConfigImplTest {
                 "Validity time of the mobile number confirmation OTP in minutes.");
         descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER,
                 "Allow privileged users to initiate mobile number verification on update.");
+        descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER,
+                "Allow users to add multiple email addresses and mobile numbers to their account.");
         Map<String, String> descriptionMapping = userClaimUpdateConfig.getPropertyDescriptionMapping();
         assertEquals(descriptionMapping, descriptionMappingExpected, "Maps are not equal.");
     }
@@ -195,6 +199,7 @@ public class UserClaimUpdateConfigImplTest {
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_NUM_VERIFICATION_ON_UPDATE);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER);
+        propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER);
         String[] propertiesArrayExpected = propertiesExpected.toArray(new String[0]);
 
         String[] properties = userClaimUpdateConfig.getPropertyNames();
@@ -252,7 +257,8 @@ public class UserClaimUpdateConfigImplTest {
                 EMAIL_VERIFICATION_ON_UPDATE_OTP_LENGTH, IdentityRecoveryConstants.ConnectorConfig
                 .EMAIL_VERIFICATION_ON_UPDATE_EXPIRY_TIME, IdentityRecoveryConstants.ConnectorConfig
                 .ENABLE_MOBILE_NUM_VERIFICATION_ON_UPDATE, IdentityRecoveryConstants.ConnectorConfig
-                .MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME, "testproperty"};
+                .MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME, IdentityRecoveryConstants.ConnectorConfig
+                .SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER, "testproperty"};
 
         IdentityConfigParser mockConfigParser = mock(IdentityConfigParser.class);
         mockedIdentityConfigParser.when(IdentityConfigParser::getInstance).thenReturn(mockConfigParser);
@@ -266,6 +272,6 @@ public class UserClaimUpdateConfigImplTest {
     public void testGetMetaData() {
 
         Map<String, Property> metaData = userClaimUpdateConfig.getMetaData();
-        Assert.assertEquals(metaData.size(), 10);
+        Assert.assertEquals(metaData.size(), 11);
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImplTest.java
@@ -233,6 +233,8 @@ public class UserClaimUpdateConfigImplTest {
                 EXPIRY_TIME_ELEMENT))).thenReturn(mockOMElement);
         when(mockOMElement.getFirstChildWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
                 USER_CLAIM_UPDATE_ELEMENT))).thenReturn(mockOMElement);
+        when(mockOMElement.getFirstChildWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                ENABLE_MULTIPLE_EMAILS_AND_MOBILE_NUMBERS_ELEMENT))).thenReturn(mockOMElement);
 
         Properties defaultPropertyValues = userClaimUpdateConfig.getDefaultPropertyValues(TENANT_DOMAIN);
         assertNotNull(defaultPropertyValues.getProperty(IdentityRecoveryConstants.ConnectorConfig
@@ -243,6 +245,8 @@ public class UserClaimUpdateConfigImplTest {
                 .ENABLE_MOBILE_NUM_VERIFICATION_ON_UPDATE));
         assertNotNull(defaultPropertyValues.getProperty(IdentityRecoveryConstants.ConnectorConfig
                 .MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME));
+        assertNotNull(defaultPropertyValues.getProperty(IdentityRecoveryConstants.ConnectorConfig
+                .SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER));
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandlerTest.java
@@ -575,8 +575,8 @@ public class MobileNumberVerificationHandlerTest {
     private void mockUtilMethods(boolean mobileVerificationEnabled, boolean multiAttributeEnabled,
                                  boolean useVerifyClaimEnabled) {
 
-        mockedUtils.when(
-                Utils::isMultiEmailsAndMobileNumbersPerUserEnabled).thenReturn(multiAttributeEnabled);
+        mockedUtils.when(() ->
+                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString())).thenReturn(multiAttributeEnabled);
         mockedUtils.when(Utils::isUseVerifyClaimEnabled).thenReturn(useVerifyClaimEnabled);
         mockedUtils.when(() -> Utils.getConnectorConfig(
                         eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_NUM_VERIFICATION_ON_UPDATE),

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandlerTest.java
@@ -762,8 +762,8 @@ public class UserEmailVerificationHandlerTest {
     private void mockUtilMethods(boolean emailVerificationEnabled, boolean multiAttributeEnabled,
                                  boolean userVerifyClaimEnabled, boolean notificationOnEmailUpdate) {
 
-        mockedUtils.when(
-                Utils::isMultiEmailsAndMobileNumbersPerUserEnabled).thenReturn(multiAttributeEnabled);
+        mockedUtils.when(() ->
+                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString())).thenReturn(multiAttributeEnabled);
         mockedUtils.when(Utils::isUseVerifyClaimEnabled).thenReturn(userVerifyClaimEnabled);
         mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION_ON_UPDATE,
                 emailVerificationEnabled);

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/util/UtilsTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/util/UtilsTest.java
@@ -1354,6 +1354,16 @@ public class UtilsTest {
                 Boolean.TRUE.toString());
         boolean result = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(TENANT_DOMAIN);
         assertEquals(result, true);
+
+        // Case 2: Throw IdentityEventException while retrieving connector configs.
+        when(identityGovernanceService.getConfiguration( new String[]{
+                        IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER},
+                TENANT_DOMAIN)).thenThrow(new IdentityGovernanceException("Test exception"));
+        try {
+            Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(TENANT_DOMAIN);
+        } catch (Exception e) {
+            assertTrue(e instanceof IdentityRecoveryServerException);
+        }
     }
 
     private static User getUser() {

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/util/UtilsTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/util/UtilsTest.java
@@ -1347,12 +1347,12 @@ public class UtilsTest {
     }
 
     @Test
-    public void testIsMultiEmailsAndMobileNumbersPerUserEnabled() {
+    public void testIsMultiEmailsAndMobileNumbersPerUserEnabled() throws IdentityGovernanceException {
 
-        mockedStaticIdentityUtil.when(() -> IdentityUtil.getProperty(IdentityRecoveryConstants.ConnectorConfig
-                        .SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER))
-                .thenReturn("true");
-        boolean result = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled();
+        mockGetRecoveryConfig(
+                IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER,
+                Boolean.TRUE.toString());
+        boolean result = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(TENANT_DOMAIN);
         assertEquals(result, true);
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request
Introduced a governance configuration to enable or disable the "multiple emails and mobile numbers per user" feature.

This feature is not fully onboarded yet. The original plan was to implement an identity configuration that would apply server-wide and enable this functionality by default. However, the new attributes required for this feature are not supported by default in LDAP user stores. As a result, enabling it globally is not feasible at this time. By providing a governance configuration, administrators can choose to enable this feature if desired. For LDAP user stores, the administrator must manually configure the necessary attributes in the LDAP settings to support multiple emails and mobile numbers per user.

### Related Issues
- https://github.com/wso2/product-is/issues/19991

### Related PRs
- https://github.com/wso2-extensions/identity-governance/pull/857
