### PR TITLE
Toggle multi-email and mobile feature based on user store exclusion and support by default config

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
@@ -96,7 +96,8 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
             claims = new HashMap<>();
         }
 
-        boolean supportMultipleMobileNumbers = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled();
+        boolean supportMultipleMobileNumbers =
+                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
 
         boolean enable = isMobileVerificationOnUpdateEnabled(user.getTenantDomain());
 
@@ -326,7 +327,8 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
             Utils.unsetThreadLocalToSkipSendingSmsOtpVerificationOnUpdate();
         }
 
-        boolean supportMultipleMobileNumbers = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled();
+        boolean supportMultipleMobileNumbers =
+                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
 
         String mobileNumber = claims.get(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -99,7 +99,8 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
             claims = new HashMap<>();
         }
 
-        boolean supportMultipleEmails = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled();
+        boolean supportMultipleEmails =
+                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
 
         boolean enable = false;
 
@@ -568,7 +569,8 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
             Utils.unsetThreadLocalToSkipSendingEmailVerificationOnUpdate();
         }
 
-        boolean supportMultipleEmails = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled();
+        boolean supportMultipleEmails =
+                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
 
         String emailAddress = claims.get(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -132,30 +132,7 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
                     }
                     invalidatePendingEmailVerification(user, userStoreManager, claims);
                 }
-
-                if (supportMultipleEmails) {
-                    // Drop the verified email addresses claim as verification on update is not enabled.
-                    claims.remove(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM);
-
-                    if (claims.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM) &&
-                            !claims.get(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM).isEmpty()) {
-
-                        String email = claims.get(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM);
-                        List<String> existingAllEmailAddresses = Utils.getMultiValuedClaim(userStoreManager, user,
-                                IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM);
-
-                        List<String> updatedAllEmailAddresses = claims.containsKey(
-                                IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM)
-                                ? getListOfEmailAddressesFromString(
-                                        claims.get(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM))
-                                : existingAllEmailAddresses;
-                        if (!updatedAllEmailAddresses.contains(email)) {
-                            updatedAllEmailAddresses.add(email);
-                            claims.put(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM,
-                                    String.join(FrameworkUtils.getMultiAttributeSeparator(), updatedAllEmailAddresses));
-                        }
-                    }
-                }
+                claims.remove(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM);
                 claims.remove(IdentityRecoveryConstants.VERIFY_EMAIL_CLIAM);
             }
         }
@@ -571,6 +548,13 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
 
         boolean supportMultipleEmails =
                 Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
+        // Update multiple email address related claims only if they’re in the claims map.
+        // This avoids issues with updating the primary email address due to user store limitations on multiple
+        // email addresses.
+        boolean shouldUpdateMultiMobilesRelatedClaims =
+                claims.containsKey(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM) ||
+                        claims.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM);
+
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
 
         String emailAddress = claims.get(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM);
@@ -613,10 +597,12 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
             final List<String> tempUpdatedAllEmailAddresses = new ArrayList<>(updatedAllEmailAddresses);
             updatedVerifiedEmailAddresses.removeIf(number -> !tempUpdatedAllEmailAddresses.contains(number));
 
-            claims.put(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM,
-                    StringUtils.join(updatedVerifiedEmailAddresses, multiAttributeSeparator));
-            claims.put(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM,
-                    StringUtils.join(updatedAllEmailAddresses, multiAttributeSeparator));
+            if (shouldUpdateMultiMobilesRelatedClaims) {
+                claims.put(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM,
+                        StringUtils.join(updatedVerifiedEmailAddresses, multiAttributeSeparator));
+                claims.put(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM,
+                        StringUtils.join(updatedAllEmailAddresses, multiAttributeSeparator));
+            }
         } else {
             /*
             email addresses and verified email addresses should not be updated when support for multiple email
@@ -657,7 +643,7 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
                     .SkipEmailVerificationOnUpdateStates.SKIP_ON_EXISTING_EMAIL.toString());
             invalidatePendingEmailVerification(user, userStoreManager, claims);
 
-            if (supportMultipleEmails) {
+            if (supportMultipleEmails && shouldUpdateMultiMobilesRelatedClaims) {
                 if (!updatedVerifiedEmailAddresses.contains(existingEmail)) {
                     updatedVerifiedEmailAddresses.add(existingEmail);
                     claims.put(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM,

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -777,7 +777,10 @@ public class UserSelfRegistrationManager {
             if (StringUtils.isNotBlank(pendingEmailClaimValue)) {
                 eventProperties.put(IdentityEventConstants.EventProperty.VERIFIED_EMAIL, pendingEmailClaimValue);
                 userClaims.put(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM, StringUtils.EMPTY);
-                if (supportMultipleEmailsAndMobileNumbers) {
+                // Only update verified email addresses claim if the recovery scenario is
+                // EMAIL_VERIFICATION_ON_VERIFIED_LIST_UPDATE.
+                if (RecoveryScenarios.EMAIL_VERIFICATION_ON_VERIFIED_LIST_UPDATE.equals(
+                        recoveryData.getRecoveryScenario()) && supportMultipleEmailsAndMobileNumbers) {
                     try {
                         List<String> verifiedEmails = Utils.getMultiValuedClaim(userStoreManager, user,
                                 IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM);
@@ -797,9 +800,7 @@ public class UserSelfRegistrationManager {
                         throw new IdentityRecoveryServerException("Error occurred while obtaining existing claim " +
                                 "value for the user : " + user.getUserName(), e);
                     }
-                }
-                if (!RecoveryScenarios.EMAIL_VERIFICATION_ON_VERIFIED_LIST_UPDATE
-                        .equals(recoveryData.getRecoveryScenario())) {
+                } else {
                     userClaims.put(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM, pendingEmailClaimValue);
                 }
                 // Todo passes when email address is properly set here.
@@ -810,7 +811,8 @@ public class UserSelfRegistrationManager {
         if (RecoverySteps.VERIFY_MOBILE_NUMBER.equals(recoveryData.getRecoveryStep())) {
             String pendingMobileClaimValue = recoveryData.getRemainingSetIds();
             if (StringUtils.isNotBlank(pendingMobileClaimValue)) {
-                if (supportMultipleEmailsAndMobileNumbers) {
+                if (RecoveryScenarios.MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE.equals(
+                        recoveryData.getRecoveryScenario()) && supportMultipleEmailsAndMobileNumbers) {
                     try {
                         List<String> existingVerifiedMobileNumbersList = Utils.getMultiValuedClaim(userStoreManager,
                                 user, IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM);
@@ -836,9 +838,7 @@ public class UserSelfRegistrationManager {
                         throw new IdentityRecoveryServerException("Error occurred while obtaining existing claim " +
                                 "value for the user : " + user.getUserName(), e);
                     }
-                }
-                if (!RecoveryScenarios.MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE
-                        .equals(recoveryData.getRecoveryScenario())) {
+                } else {
                     userClaims.put(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM, pendingMobileClaimValue);
                 }
                 userClaims.put(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM, StringUtils.EMPTY);
@@ -1000,7 +1000,8 @@ public class UserSelfRegistrationManager {
             Verifying whether user is trying to add a mobile number to http://wso2.org/claims/verifedMobileNumbers
             claim.
             */
-            if (supportMultipleEmailsAndMobileNumbers) {
+            if (RecoveryScenarios.MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE.equals(
+                    recoveryData.getRecoveryScenario()) && supportMultipleEmailsAndMobileNumbers) {
                 try {
                     String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
                     List<String> existingVerifiedMobileNumbersList = Utils.getMultiValuedClaim(userStoreManager,
@@ -1027,9 +1028,7 @@ public class UserSelfRegistrationManager {
                     throw new IdentityRecoveryServerException("Error occurred while obtaining existing claim " +
                             "value for the user : " + user.getUserName(), e);
                 }
-            }
-            if (!RecoveryScenarios.MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE
-                    .equals(recoveryData.getRecoveryScenario())) {
+            } else {
                 userClaims.put(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM, pendingMobileNumberClaimValue);
             }
             userClaims.put(NotificationChannels.SMS_CHANNEL.getVerifiedClaimUrl(), Boolean.TRUE.toString());

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -768,7 +768,8 @@ public class UserSelfRegistrationManager {
         HashMap<String, String> userClaims = getClaimsListToUpdate(user, verifiedChannelType,
                 externallyVerifiedClaim, recoveryData.getRecoveryScenario().toString());
 
-        boolean supportMultipleEmailsAndMobileNumbers = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled();
+        boolean supportMultipleEmailsAndMobileNumbers =
+                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
 
         if (RecoverySteps.VERIFY_EMAIL.equals(recoveryData.getRecoveryStep())) {
@@ -990,7 +991,8 @@ public class UserSelfRegistrationManager {
         UserStoreManager userStoreManager = getUserStoreManager(user);
         HashMap<String, String> userClaims = new HashMap<>();
 
-        boolean supportMultipleEmailsAndMobileNumbers = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled();
+        boolean supportMultipleEmailsAndMobileNumbers =
+                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
 
         String pendingMobileNumberClaimValue = recoveryData.getRemainingSetIds();
         if (StringUtils.isNotBlank(pendingMobileNumberClaimValue)) {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -111,7 +111,6 @@ public class Utils {
 
     private static final Log AUDIT_LOG = CarbonConstants.AUDIT_LOG;
     private static final Log log = LogFactory.getLog(Utils.class);
-    public static final String EXCLUDED_USER_STORE_DOMAINS_CLAIM_PROPERTY_NAME = "ExcludedUserStoreDomains";
 
     //This is used to pass the arbitrary properties from self user manager to self user handler
     private static ThreadLocal<org.wso2.carbon.identity.recovery.model.Property[]> arbitraryProperties = new
@@ -1456,7 +1455,7 @@ public class Utils {
                                 Boolean.FALSE.toString()));
 
                 // Check if user store is not in excluded list.
-                String excludedUserStoreDomains = properties.get(EXCLUDED_USER_STORE_DOMAINS_CLAIM_PROPERTY_NAME);
+                String excludedUserStoreDomains = properties.get(ClaimConstants.EXCLUDED_USER_STORES_PROPERTY);
                 boolean isNotExcluded = StringUtils.isBlank(excludedUserStoreDomains) ||
                         !Arrays.asList(excludedUserStoreDomains.toUpperCase().split(","))
                                 .contains(userStoreDomain.toUpperCase());

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandlerTest.java
@@ -575,8 +575,8 @@ public class MobileNumberVerificationHandlerTest {
     private void mockUtilMethods(boolean mobileVerificationEnabled, boolean multiAttributeEnabled,
                                  boolean useVerifyClaimEnabled) {
 
-        mockedUtils.when(
-                Utils::isMultiEmailsAndMobileNumbersPerUserEnabled).thenReturn(multiAttributeEnabled);
+        mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
+                .thenReturn(multiAttributeEnabled);
         mockedUtils.when(Utils::isUseVerifyClaimEnabled).thenReturn(useVerifyClaimEnabled);
         mockedUtils.when(() -> Utils.getConnectorConfig(
                         eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_NUM_VERIFICATION_ON_UPDATE),

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandlerTest.java
@@ -218,8 +218,9 @@ public class UserEmailVerificationHandlerTest {
 
         userEmailVerificationHandler.handleEvent(event);
         Map<String, String> userClaims = getUserClaimsFromEvent(event);
-        Assert.assertTrue(StringUtils.contains(
-                userClaims.get(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM), NEW_EMAIL));
+        Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM), NEW_EMAIL);
+        // Multiple email addresses related claims should only be updated when they are present in the request.
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM));
 
         // Case 2 : Send email addresses claim with event.
         String emailsClaim = String.format("%s,%s", EXISTING_EMAIL_1, EXISTING_EMAIL_2);
@@ -231,8 +232,8 @@ public class UserEmailVerificationHandlerTest {
 
         userEmailVerificationHandler.handleEvent(event2);
         Map<String, String> userClaims2 = getUserClaimsFromEvent(event2);
-        Assert.assertTrue(StringUtils.contains(
-                userClaims2.get(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM), NEW_EMAIL));
+        Assert.assertEquals(userClaims2.get(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM), NEW_EMAIL);
+        Assert.assertEquals(userClaims2.get(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM), emailsClaim);
     }
 
     @Test(description = "Verification - Enabled, Multi attribute - Disabled")
@@ -306,7 +307,6 @@ public class UserEmailVerificationHandlerTest {
 
         /*
          Try to change the primary email, new Email is not in the existing verified email address list.
-         Expected: IdentityEventClientException should be thrown.
          */
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, null, NEW_EMAIL);
@@ -322,6 +322,8 @@ public class UserEmailVerificationHandlerTest {
         userEmailVerificationHandler.handleEvent(event);
         Map<String, String> userClaims = getUserClaimsFromEvent(event);
         Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM), NEW_EMAIL);
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM));
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM));
     }
 
     @Test(description = "Verification - Enabled, Multi attribute - Enabled, Change primary email which is already " +
@@ -347,6 +349,9 @@ public class UserEmailVerificationHandlerTest {
             mockedUtils.verify(() -> Utils.setThreadLocalToSkipSendingEmailVerificationOnUpdate(
                     eq(IdentityRecoveryConstants.SkipEmailVerificationOnUpdateStates
                             .SKIP_ON_ALREADY_VERIFIED_EMAIL_ADDRESSES.toString())));
+            Map<String, String> userClaims = getUserClaimsFromEvent(event);
+            Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM));
+            Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM));
     }
 
     @Test(description = "Verification - Enabled, Multi attribute - Enabled, Update verified list with new email")

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandlerTest.java
@@ -762,8 +762,8 @@ public class UserEmailVerificationHandlerTest {
     private void mockUtilMethods(boolean emailVerificationEnabled, boolean multiAttributeEnabled,
                                  boolean userVerifyClaimEnabled, boolean notificationOnEmailUpdate) {
 
-        mockedUtils.when(
-                Utils::isMultiEmailsAndMobileNumbersPerUserEnabled).thenReturn(multiAttributeEnabled);
+        mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
+                .thenReturn(multiAttributeEnabled);
         mockedUtils.when(Utils::isUseVerifyClaimEnabled).thenReturn(userVerifyClaimEnabled);
         mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION_ON_UPDATE,
                 emailVerificationEnabled);

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManagerTest.java
@@ -665,7 +665,6 @@ public class UserSelfRegistrationManagerTest {
 
         assertEquals(updatedVerificationPendingMobile, StringUtils.EMPTY);
         assertEquals(updatedPrimaryMobile, verificationPendingMobileNumber);
-        assertTrue(StringUtils.contains(updatedVerifiedMobileNumbers, verificationPendingMobileNumber));
 
         // Case 2: Multiple email and mobile per user is disabled.
         mockMultiAttributeEnabled(false);
@@ -749,7 +748,7 @@ public class UserSelfRegistrationManagerTest {
         String verificationPendingMobileNumber = "0700000000";
         User user = getUser();
         UserRecoveryData userRecoveryData = new UserRecoveryData(user, TEST_RECOVERY_DATA_STORE_SECRET,
-                RecoveryScenarios.MOBILE_VERIFICATION_ON_UPDATE, RecoverySteps.VERIFY_MOBILE_NUMBER);
+                RecoveryScenarios.MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE, RecoverySteps.VERIFY_MOBILE_NUMBER);
         userRecoveryData.setRemainingSetIds(verificationPendingMobileNumber);
 
         when(userRecoveryDataStore.load(eq(TEST_CODE))).thenReturn(userRecoveryData);
@@ -801,12 +800,12 @@ public class UserSelfRegistrationManagerTest {
         verify(userStoreManager, atLeastOnce()).setUserClaimValues(anyString(), claimsCaptor.capture(), isNull());
 
         Map<String, String> capturedClaims = claimsCaptor.getValue();
-        String updatedVerifiedEmailAddresses =
-                capturedClaims.get(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM);
+        String updatedEmailAddressClaim =
+                capturedClaims.get(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM);
         String verificationPendingEmailAddress =
                 capturedClaims.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM);
 
-        assertTrue(StringUtils.contains(updatedVerifiedEmailAddresses, verificationPendingEmail));
+        assertTrue(StringUtils.contains(updatedEmailAddressClaim, verificationPendingEmail));
         assertEquals(verificationPendingEmailAddress, StringUtils.EMPTY);
 
         // Case 2: Multiple email and mobile per user is disabled.
@@ -883,14 +882,11 @@ public class UserSelfRegistrationManagerTest {
         verify(userStoreManager, atLeastOnce()).setUserClaimValues(anyString(), claimsCaptor.capture(), isNull());
 
         Map<String, String> capturedClaims = claimsCaptor.getValue();
-        String updatedVerifiedMobileNumbers =
-                capturedClaims.get(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM);
         String verificationPendingMobileNumberClaim =
                 capturedClaims.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM);
         String updatedMobileNumberClaimValue =
                 capturedClaims.get(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM);
 
-        assertTrue(StringUtils.contains(updatedVerifiedMobileNumbers, verificationPendingMobileNumber));
         assertEquals(verificationPendingMobileNumberClaim, StringUtils.EMPTY);
         assertEquals(updatedMobileNumberClaimValue, verificationPendingMobileNumber);
 

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManagerTest.java
@@ -51,8 +51,8 @@ import org.wso2.carbon.identity.auth.attribute.handler.model.ValidationResult;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
-import org.wso2.carbon.identity.claim.metadata.mgt.model.AttributeMapping;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.consent.mgt.services.ConsentUtilityService;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -1585,24 +1585,18 @@ public class UserSelfRegistrationManagerTest {
                 .thenReturn(claimMetadataManagementService);
 
         List<LocalClaim> localClaims = new ArrayList<>();
+        Map<String, String> claimProperties = new HashMap<>();
+        claimProperties.put(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY, Boolean.TRUE.toString());
 
-        // Add claims with valid mappings.
         LocalClaim mobileNumbersClaim = new LocalClaim(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM);
-        mobileNumbersClaim.setMappedAttributes(
-                Arrays.asList(new AttributeMapping(TEST_USERSTORE_DOMAIN, "mobileNumbers")));
-
+        mobileNumbersClaim.setClaimProperties(claimProperties);
         LocalClaim verifiedMobileNumbersClaim = new LocalClaim(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM);
-        verifiedMobileNumbersClaim.setMappedAttributes(
-                Arrays.asList(new AttributeMapping(TEST_USERSTORE_DOMAIN, "verifiedMobileNumbers")));
-
+        verifiedMobileNumbersClaim.setClaimProperties(claimProperties);
         LocalClaim emailAddressesClaim = new LocalClaim(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM);
-        emailAddressesClaim.setMappedAttributes(
-                Arrays.asList(new AttributeMapping(TEST_USERSTORE_DOMAIN, "emailAddresses")));
-
+        emailAddressesClaim.setClaimProperties(claimProperties);
         LocalClaim verifiedEmailAddressesClaim =
                 new LocalClaim(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM);
-        verifiedEmailAddressesClaim.setMappedAttributes(
-                Arrays.asList(new AttributeMapping(TEST_USERSTORE_DOMAIN, "verifiedEmailAddresses")));
+        verifiedEmailAddressesClaim.setClaimProperties(claimProperties);
 
         localClaims.add(verifiedMobileNumbersClaim);
         localClaims.add(mobileNumbersClaim);

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/util/UtilsTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/util/UtilsTest.java
@@ -1396,7 +1396,7 @@ public class UtilsTest {
         // Case 4: When user store domain is excluded for feature related claims.
         Map<String, String> claimProperties4 = new HashMap<>();
         claimProperties4.put(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY, Boolean.TRUE.toString());
-        claimProperties4.put(Utils.EXCLUDED_USER_STORE_DOMAINS_CLAIM_PROPERTY_NAME, USER_STORE_DOMAIN);
+        claimProperties4.put(ClaimConstants.EXCLUDED_USER_STORES_PROPERTY, USER_STORE_DOMAIN);
         when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN)).thenReturn(
                 returnMultiEmailAndMobileRelatedLocalClaims(claimProperties4));
 

--- a/pom.xml
+++ b/pom.xml
@@ -700,7 +700,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.5.72</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.5.109</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request
- Toggle multi-email and mobile feature based on user store exclusion and support by default config.
- Updates claims for multiple emails and mobile numbers only when these specific claims are included in the request. This approach is taken to ensure that updates to primary email and mobile numbers are not blocked by user store limitations when handling newly introduced claims for multiple emails and mobile numbers.

Additional Context: LDAP does not provide default support for the newly introduced claims - emailAddresses, verifiedEmailAddresses, mobileNumbers, and verifiedMobileNumbers. This limitation creates an issue where attempts to update even basic primary email or mobile numbers can be blocked, as the system in some scenarios tries to update these unsupported multiple-value claims. To resolve this critical issue, the system will now only attempt to update these new claims if at least one of them is explicitly present in the update request, ensuring that essential primary email/mobile updates remain functional.

### Related Issues
- https://github.com/wso2/product-is/issues/19991

### Related PRs
- https://github.com/wso2/carbon-kernel/pull/4110