### PR TITLE
Bump apache commons io version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -681,7 +681,7 @@
         <com.google.code.gson.osgi.version.range>[2.3.1,3.0.0)</com.google.code.gson.osgi.version.range>
         <commons-codec.version>1.14.0.wso2v1</commons-codec.version>
         <commons-codec.wso2.osgi.version.range>[1.4.0,2.0.0)</commons-codec.wso2.osgi.version.range>
-        <commons-io.wso2.version>2.4.0.wso2v1</commons-io.wso2.version>
+        <commons-io.wso2.version>2.17.0.wso2v1</commons-io.wso2.version>
         <commons.io.wso2.osgi.version.range>[2.4.0,3.0.0)</commons.io.wso2.osgi.version.range>
         <commons-logging.osgi.version.range>[1.2.0,2.0.0)</commons-logging.osgi.version.range>
         <commons-lang.osgi.version.range>[2.6.0, 3.0.0)</commons-lang.osgi.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request

The commons-io version is bumped to `2.17.0.wso2v1` by this effort. https://github.com/wso2/orbit/pull/1145
Hence the apache commons-io version of the project is bumped to `2.17.0.wso2v1` as dependent components get the library as transitive dependency.
