### PR TITLE
Add Notification Template Retrieval Methods with Resolve Param Support

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/notification/NotificationTemplateManager.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/notification/NotificationTemplateManager.java
@@ -119,12 +119,15 @@ public interface NotificationTemplateManager {
     }
 
     /**
+     * @deprecated Use {@link #getAllNotificationTemplates(String, String, boolean)} instead.
+     * <p>
      * Get all available notification template types in the tenant for a given notification channel.
      *
      * @param notificationChannel Notification channel (Eg: SMS, EMAIL).
      * @param tenantDomain        Tenant domain.
      * @throws NotificationTemplateManagerException If an error occurred while getting the notification template types.
      */
+    @Deprecated
     default List<NotificationTemplate> getAllNotificationTemplates(String notificationChannel, String tenantDomain)
             throws NotificationTemplateManagerException {
 
@@ -179,6 +182,8 @@ public interface NotificationTemplateManager {
     }
 
     /**
+     * @deprecated Use {@link #getNotificationTemplatesOfType(String, String, String, String, boolean)} instead.
+     * <p>
      * Get all notification templates of the given type.
      *
      * @param notificationChannel Notification channel (Eg: SMS, EMAIL).
@@ -188,6 +193,7 @@ public interface NotificationTemplateManager {
      * @return List of notification templates.
      * @throws NotificationTemplateManagerException If an error occurred while getting the notification templates.
      */
+    @Deprecated
     default List<NotificationTemplate> getNotificationTemplatesOfType(String notificationChannel,
                                               String templateDisplayName, String tenantDomain, String applicationUuid)
             throws NotificationTemplateManagerException {
@@ -249,6 +255,8 @@ public interface NotificationTemplateManager {
     }
 
     /**
+     * @deprecated Use {@link #getNotificationTemplate(String, String, String, String, String, boolean)} instead.
+     * <p>
      * Return the notification template from the tenant registry which matches the given channel and template name.
      *
      * @param notificationChannel Notification Channel Name (Eg: SMS or EMAIL).
@@ -259,6 +267,7 @@ public interface NotificationTemplateManager {
      * @return Return {@link org.wso2.carbon.identity.governance.model.NotificationTemplate} object.
      * @throws NotificationTemplateManagerException If an error occurred while getting the notification template.
      */
+    @Deprecated
     default NotificationTemplate getNotificationTemplate(String notificationChannel, String templateType, String locale,
                                                          String tenantDomain, String applicationUuid)
             throws NotificationTemplateManagerException {

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/notification/NotificationTemplateManager.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/notification/NotificationTemplateManager.java
@@ -132,6 +132,37 @@ public interface NotificationTemplateManager {
     }
 
     /**
+     * Retrieves all notification templates for a given notification channel and tenant domain.
+     * <p>
+     * This method fetches notification templates based on the specified notification channel
+     * (e.g., email, SMS) and tenant domain. The behavior of template retrieval depends on the
+     * {@code resolve} parameter:
+     * <ul>
+     *     <li><b>Resolved templates (resolve = true):</b> Retrieves templates resolved through the
+     *     ancestor organization hierarchy, returning templates that are applicable across the tenant's
+     *     organizational structure.</li>
+     *     <li><b>Current organization's templates (resolve = false):</b> Retrieves templates strictly defined
+     *     within the current organization, without considering organizational hierarchy.</li>
+     * </ul>
+     *
+     * @param notificationChannel the type of notification channel for which templates are retrieved
+     *                            (e.g., "EMAIL", "SMS").
+     * @param tenantDomain        the tenant domain of the organization for which templates are retrieved.
+     * @param resolve             a flag to indicate whether to retrieve resolved templates
+     *                            ({@code true}) or templates specific to the current organization
+     *                            ({@code false}).
+     * @return a list of {@link NotificationTemplate} templates matching the specified criteria.
+     * @throws NotificationTemplateManagerException if an error occurs while retrieving the templates.
+     */
+    default List<NotificationTemplate> getAllNotificationTemplates(String notificationChannel, String tenantDomain,
+                                                                   boolean resolve)
+            throws NotificationTemplateManagerException {
+
+        throw new UnsupportedOperationException(
+                "getAllNotificationTemplates method is not implemented in " + this.getClass());
+    }
+
+    /**
      * Get all notification templates of the given type.
      *
      * @param notificationChannel Notification channel (Eg: SMS, EMAIL).
@@ -162,6 +193,42 @@ public interface NotificationTemplateManager {
             throws NotificationTemplateManagerException {
 
         throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * Retrieves notification templates of a specific type for a given notification channel and tenant domain.
+     * <p>
+     * This method fetches notification templates based on the specified notification channel
+     * (e.g., email, SMS), template display name, tenant domain, and application UUID. The behavior
+     * of template retrieval depends on the {@code resolve} parameter:
+     * <ul>
+     *     <li><b>Resolved templates (resolve = true):</b> Retrieves templates resolved through the
+     *     ancestor organization hierarchy, ensuring that templates applicable across the organizational
+     *     structure are returned.</li>
+     *     <li><b>Current org's or app's templates (resolve = false):</b> Retrieves templates specific to the
+     *     current organization or application, without considering the organization hierarchy.</li>
+     * </ul>
+     *
+     * @param notificationChannel the type of notification channel for which templates are retrieved
+     *                            (e.g., "EMAIL", "SMS").
+     * @param templateDisplayName the display name of the notification template type (e.g., "Welcome Email").
+     * @param tenantDomain        the tenant domain of the organization for which templates are retrieved.
+     * @param applicationUuid     the UUID of the application associated with the notification templates.
+     * @param resolve             a flag to indicate whether to retrieve resolved templates
+     *                            ({@code true}) or templates specific to the current organization or application
+     *                            ({@code false}).
+     *
+     * @return a list of {@link NotificationTemplate} templates matching the specified criteria.
+     *
+     * @throws NotificationTemplateManagerException if an error occurs while retrieving the templates.
+     */
+    default List<NotificationTemplate> getNotificationTemplatesOfType(String notificationChannel,
+                                                                      String templateDisplayName, String tenantDomain,
+                                                                      String applicationUuid, boolean resolve)
+            throws NotificationTemplateManagerException {
+
+        throw new UnsupportedOperationException(
+                "getNotificationTemplatesOfType method is not implemented in " + this.getClass());
     }
 
     /**
@@ -197,6 +264,39 @@ public interface NotificationTemplateManager {
             throws NotificationTemplateManagerException {
 
         throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * Retrieves a specific notification template for a given notification channel, template type,
+     * locale, tenant domain, and application UUID.
+     * <p>
+     * This method fetches a notification template based on the specified criteria. The behavior
+     * depends on the {@code resolve} parameter:
+     * <ul>
+     *     <li><b>Resolved template (resolve = true):</b> Retrieves the template resolved through the
+     *     ancestor organization hierarchy.</li>
+     *     <li><b>Current org's or app's template  (resolve = false):</b> Retrieves the template specific to
+     *     the current organization or application only.</li>
+     * </ul>
+     *
+     * @param notificationChannel the notification channel (e.g., "EMAIL", "SMS").
+     * @param templateType        the type of the notification template (e.g., "Welcome Email").
+     * @param locale              the locale of the notification template (e.g., "en_US").
+     * @param tenantDomain        the tenant domain of the organization from which the template is retrieved.
+     * @param applicationUuid     the UUID of the application associated with the template.
+     * @param resolve             a flag indicating whether to retrieve resolved template
+     *                            ({@code true}) or template specific to the current organization or application
+     *                            ({@code false}).
+     * @return the {@link NotificationTemplate} template matching the specified criteria.
+     * @throws NotificationTemplateManagerException if an error occurs while retrieving the template
+     *                                              or if no template is found in the specified or default locale.
+     */
+    default NotificationTemplate getNotificationTemplate(String notificationChannel, String templateType, String locale,
+                                                         String tenantDomain, String applicationUuid, boolean resolve)
+            throws NotificationTemplateManagerException {
+
+        throw new UnsupportedOperationException(
+                "getNotificationTemplate method is not implemented in " + this.getClass());
     }
 
     /**

--- a/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/listener/NotificationTemplateManagerTest.java
+++ b/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/listener/NotificationTemplateManagerTest.java
@@ -1,11 +1,33 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.governance.listener;
 
 import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.governance.exceptions.notiification.NotificationTemplateManagerException;
 import org.wso2.carbon.identity.governance.model.NotificationTemplate;
 import org.wso2.carbon.identity.governance.service.notification.NotificationTemplateManager;
 
+/**
+ * Unit tests for NotificationTemplateManager.
+ */
 public class NotificationTemplateManagerTest {
 
     private NotificationTemplateManager notificationTemplateManager;
@@ -20,6 +42,15 @@ public class NotificationTemplateManagerTest {
     public void setUp() {
         notificationTemplateManager = new NotificationTemplateManager() {
             // No implementation needed, using default methods which throw UnsupportedOperationException
+        };
+    }
+
+    @DataProvider(name = "resolveDataProvider")
+    public Object[][] resolveDataProvider() {
+
+        return new Object[][]{
+                {true},
+                {false}
         };
     }
 
@@ -66,6 +97,13 @@ public class NotificationTemplateManagerTest {
         notificationTemplateManager.getAllNotificationTemplates(notificationChannel, tenantDomain);
     }
 
+    @Test(dataProvider = "resolveDataProvider", expectedExceptions = UnsupportedOperationException.class)
+    public void testGetAllNotificationTemplatesWithResolve(boolean resolve)
+            throws NotificationTemplateManagerException {
+
+        notificationTemplateManager.getAllNotificationTemplates(notificationChannel, tenantDomain, resolve);
+    }
+
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testGetNotificationTemplatesOfType() throws NotificationTemplateManagerException {
 
@@ -80,6 +118,14 @@ public class NotificationTemplateManagerTest {
                 tenantDomain, applicationUuid);
     }
 
+    @Test(dataProvider = "resolveDataProvider", expectedExceptions = UnsupportedOperationException.class)
+    public void testGetNotificationTemplatesOfTypeWithApplicationIdWithResolve(boolean resolve)
+            throws NotificationTemplateManagerException {
+
+        notificationTemplateManager.getNotificationTemplatesOfType(notificationChannel, displayName,
+                tenantDomain, applicationUuid, resolve);
+    }
+
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testGetNotificationTemplate() throws NotificationTemplateManagerException {
 
@@ -91,6 +137,14 @@ public class NotificationTemplateManagerTest {
 
         notificationTemplateManager.getNotificationTemplate(notificationChannel, displayName, locale, tenantDomain,
                 applicationUuid);
+    }
+
+    @Test(dataProvider = "resolveDataProvider", expectedExceptions = UnsupportedOperationException.class)
+    public void testGetNotificationTemplateWithApplicationIdWithResolve(boolean resolve)
+            throws NotificationTemplateManagerException {
+
+        notificationTemplateManager.getNotificationTemplate(notificationChannel, displayName, locale, tenantDomain,
+                applicationUuid, resolve);
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)


### PR DESCRIPTION
### Purpose
- The following methods are added to `NotificationTemplateManager`.
    -  `getAllNotificationTemplates(String, String, boolean)`
    - `getNotificationTemplatesOfType(String, String, String, String, boolean)` 
    - `getNotificationTemplate(String, String, String, String, String, boolean)`

### Related Issues
- https://github.com/wso2/product-is/issues/21214