### PR TITLE
Run suspension task from master-node.

### DIFF
--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/AccountValidatorThread.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/AccountValidatorThread.java
@@ -90,7 +90,7 @@ public class AccountValidatorThread implements Runnable {
         }
 
         // Run the task only from master node in cluster setup.
-        if (isClusterModeEnabled() && !isHazelcastMasterNode()) {
+        if (isMasterNodeExclusiveExecutionEnabled() && !isHazelcastMasterNode()) {
             return;
         }
 
@@ -174,13 +174,13 @@ public class AccountValidatorThread implements Runnable {
     }
 
     /**
-     * Check whether suspension task runs in cluster or not.
+     * Check whether suspension task configured to run only in master node or not.
      *
      * @return true or false based on the deployment config.
      */
-    private boolean isClusterModeEnabled() {
+    private boolean isMasterNodeExclusiveExecutionEnabled() {
 
-        String clusterModeEnabledValue = IdentityUtil.getProperty(NotificationConstants.EXECUTE_TASK_IN_SINGLE_NODE);
+        String clusterModeEnabledValue = IdentityUtil.getProperty(NotificationConstants.EXECUTE_TASK_IN_MASTER_NODE);
         return StringUtils.isNotBlank(clusterModeEnabledValue) ? Boolean.parseBoolean(clusterModeEnabledValue) : false;
     }
 

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/AccountValidatorThread.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/AccountValidatorThread.java
@@ -180,7 +180,7 @@ public class AccountValidatorThread implements Runnable {
      */
     private boolean isClusterModeEnabled() {
 
-        String clusterModeEnabledValue = IdentityUtil.getProperty(NotificationConstants.RUN_TASK_IN_CLUSTER_MODE);
+        String clusterModeEnabledValue = IdentityUtil.getProperty(NotificationConstants.EXECUTE_TASK_IN_SINGLE_NODE);
         return StringUtils.isNotBlank(clusterModeEnabledValue) ? Boolean.parseBoolean(clusterModeEnabledValue) : false;
     }
 

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/AccountValidatorThread.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/AccountValidatorThread.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.identity.account.suspension.notification.task;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -86,6 +87,11 @@ public class AccountValidatorThread implements Runnable {
 
         if (log.isDebugEnabled()) {
             log.debug("Handling idle account suspension task for tenant: " + tenantDomain);
+        }
+
+        // Run the task only from master node in cluster setup.
+        if (isClusterModeEnabled() && !isHazelcastMasterNode()) {
+            return;
         }
 
         Property[] identityProperties;
@@ -165,6 +171,27 @@ public class AccountValidatorThread implements Runnable {
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }
+    }
+
+    /**
+     * Check whether suspension task runs in cluster or not.
+     *
+     * @return true or false based on the deployment config.
+     */
+    private boolean isClusterModeEnabled() {
+
+        String clusterModeEnabledValue = IdentityUtil.getProperty(NotificationConstants.RUN_TASK_IN_CLUSTER_MODE);
+        return StringUtils.isNotBlank(clusterModeEnabledValue) ? Boolean.parseBoolean(clusterModeEnabledValue) : false;
+    }
+
+    /**
+     * Check whether current node is master node in the Hazelcast cluster.
+     *
+     * @return true or false based on the Hazelcast cluster.
+     */
+    private boolean isHazelcastMasterNode() {
+
+        return NotificationTaskDataHolder.getInstance().getClusteringAgent().isCoordinator();
     }
 
     /**

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/internal/NotificationTaskDataHolder.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/internal/NotificationTaskDataHolder.java
@@ -16,6 +16,7 @@
 
 package org.wso2.carbon.identity.account.suspension.notification.task.internal;
 
+import org.apache.axis2.clustering.ClusteringAgent;
 import org.osgi.framework.BundleContext;
 import org.wso2.carbon.identity.account.suspension.notification.task.NotificationReceiversRetrievalFactory;
 import org.wso2.carbon.identity.account.suspension.notification.task.util.NotificationConstants;
@@ -43,6 +44,7 @@ public class NotificationTaskDataHolder {
     private String notificationTriggerTime;
     private String schedulerDelay;
     private String notificationSendingThreadPoolSize = "1";
+    private ClusteringAgent clusteringAgent;
 
     public int getNotificationSendingThreadPoolSize() {
         return Integer.parseInt(notificationSendingThreadPoolSize);
@@ -111,5 +113,15 @@ public class NotificationTaskDataHolder {
 
     public RealmService getRealmService() {
         return realmService;
+    }
+
+    public ClusteringAgent getClusteringAgent() {
+
+        return clusteringAgent;
+    }
+
+    public void setClusteringAgent(ClusteringAgent clusteringAgent) {
+
+        this.clusteringAgent = clusteringAgent;
     }
 }

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/internal/NotificationTaskServiceComponent.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/internal/NotificationTaskServiceComponent.java
@@ -164,6 +164,7 @@ public class NotificationTaskServiceComponent {
             policy = ReferencePolicy.DYNAMIC,
             unbind = "unsetClusteringAgent")
     protected void setClusteringAgent(ConfigurationContextService configurationContextService) {
+
         NotificationTaskDataHolder.getInstance().setClusteringAgent(
                 configurationContextService.getServerConfigContext().getAxisConfiguration().getClusteringAgent());
     }

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/internal/NotificationTaskServiceComponent.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/internal/NotificationTaskServiceComponent.java
@@ -36,6 +36,7 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.utils.ConfigurationContextService;
 
 /**
  * Notification scheduler. Check for users who requires a notification for relogin
@@ -155,6 +156,20 @@ public class NotificationTaskServiceComponent {
         if (log.isDebugEnabled()) {
             log.debug("RealmService is unset in the Application Authentication Framework bundle");
         }
+    }
+
+    @Reference(
+            name = "config.context.service",
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetClusteringAgent")
+    protected void setClusteringAgent(ConfigurationContextService configurationContextService) {
+        NotificationTaskDataHolder.getInstance().setClusteringAgent(
+                configurationContextService.getServerConfigContext().getAxisConfiguration().getClusteringAgent());
+    }
+
+    protected void unsetClusteringAgent(ConfigurationContextService configurationContextService) {
+        NotificationTaskDataHolder.getInstance().setClusteringAgent(null);
     }
 }
 

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationConstants.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationConstants.java
@@ -27,7 +27,7 @@ public class NotificationConstants {
     public static final String SUSPENSION_NOTIFICATION_TRIGGER_TIME= "suspension.notification.trigger.time";
     public static final String SUSPENSION_NOTIFICATION_DELAYS="suspension.notification.delays";
     public static final String USE_IDENTITY_CLAIM_FOR_LAST_LOGIN_TIME = "AccountSuspension.UseIdentityClaims";
-    public static final String EXECUTE_TASK_IN_SINGLE_NODE = "AccountSuspension.ExecuteTaskOnSingleNode";
+    public static final String EXECUTE_TASK_IN_MASTER_NODE = "AccountSuspension.ExecuteTaskOnMasterNode";
     public static final String TRIGGER_TIME_FORMAT = "HH:mm:ss";
     public static final long SCHEDULER_DELAY = 24; // In hours
     public static final String SUSPENSION_NOTIFICATION_THREAD_POOL_SIZE = "suspension.notification.thread.pool.size";

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationConstants.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationConstants.java
@@ -27,7 +27,7 @@ public class NotificationConstants {
     public static final String SUSPENSION_NOTIFICATION_TRIGGER_TIME= "suspension.notification.trigger.time";
     public static final String SUSPENSION_NOTIFICATION_DELAYS="suspension.notification.delays";
     public static final String USE_IDENTITY_CLAIM_FOR_LAST_LOGIN_TIME = "AccountSuspension.UseIdentityClaims";
-    public static final String RUN_TASK_IN_CLUSTER_MODE = "AccountSuspension.RunTaskInClusterMode";
+    public static final String EXECUTE_TASK_IN_SINGLE_NODE = "AccountSuspension.ExecuteTaskOnSingleNode";
     public static final String TRIGGER_TIME_FORMAT = "HH:mm:ss";
     public static final long SCHEDULER_DELAY = 24; // In hours
     public static final String SUSPENSION_NOTIFICATION_THREAD_POOL_SIZE = "suspension.notification.thread.pool.size";

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationConstants.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationConstants.java
@@ -27,6 +27,7 @@ public class NotificationConstants {
     public static final String SUSPENSION_NOTIFICATION_TRIGGER_TIME= "suspension.notification.trigger.time";
     public static final String SUSPENSION_NOTIFICATION_DELAYS="suspension.notification.delays";
     public static final String USE_IDENTITY_CLAIM_FOR_LAST_LOGIN_TIME = "AccountSuspension.UseIdentityClaims";
+    public static final String RUN_TASK_IN_CLUSTER_MODE = "AccountSuspension.RunTaskInClusterMode";
     public static final String TRIGGER_TIME_FORMAT = "HH:mm:ss";
     public static final long SCHEDULER_DELAY = 24; // In hours
     public static final String SUSPENSION_NOTIFICATION_THREAD_POOL_SIZE = "suspension.notification.thread.pool.size";


### PR DESCRIPTION
### Proposed changes in this pull request

Run the suspension task from master node in cluster setup up.

Issue: https://github.com/wso2/product-is/issues/9829

Need to add the following config to enable this feature
```
[identity_mgt_account_suspension]
execute_task_on_master_node = true
```

### When should this PR be merged

Depended on config PR

https://github.com/wso2/carbon-identity-framework/pull/6201

