### PR TITLE
Change execution order to ensure the account is locked in case of a notification sending failure

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
@@ -122,33 +122,6 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
         if (IdentityEventConstants.Event.POST_ADD_USER.equals(event.getEventName())) {
             UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
 
-            if (isAccountLockOnCreation || isEnableConfirmationOnCreation) {
-                HashMap<String, String> userClaims = new HashMap<>();
-                if (isAccountLockOnCreation) {
-                    // Need to lock user account.
-                    userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
-                    userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_REASON_CLAIM,
-                            IdentityMgtConstants.LockedReason.PENDING_SELF_REGISTRATION.toString());
-                }
-                if (Utils.isAccountStateClaimExisting(tenantDomain)) {
-                    userClaims.put(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI,
-                            IdentityRecoveryConstants.PENDING_SELF_REGISTRATION);
-                }
-                try {
-                    userStoreManager.setUserClaimValues(user.getUserName(), userClaims, null);
-                    if (log.isDebugEnabled()) {
-                        if (isAccountLockOnCreation) {
-                            log.debug("Locked user account: " + user.getUserName());
-                        }
-                        if (isEnableConfirmationOnCreation) {
-                            log.debug("Send verification notification for user account: " + user.getUserName());
-                        }
-                    }
-                } catch (UserStoreException e) {
-                    throw new IdentityEventException("Error while lock user account :" + user.getUserName(), e);
-                }
-            }
-
             try {
                 // Get the user preferred notification channel.
                 String preferredChannel = resolveNotificationChannel(eventProperties, userName, tenantDomain,
@@ -160,6 +133,34 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
                         preferredChannel, eventProperties);
                 if (notificationChannelVerified) {
                     return;
+                }
+
+                // If account lock on creation is enabled, lock the account by persisting the account lock claim.
+                if (isAccountLockOnCreation || isEnableConfirmationOnCreation) {
+                    HashMap<String, String> userClaims = new HashMap<>();
+                    if (isAccountLockOnCreation) {
+                        // Need to lock user account.
+                        userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
+                        userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_REASON_CLAIM,
+                                IdentityMgtConstants.LockedReason.PENDING_SELF_REGISTRATION.toString());
+                    }
+                    if (Utils.isAccountStateClaimExisting(tenantDomain)) {
+                        userClaims.put(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI,
+                                IdentityRecoveryConstants.PENDING_SELF_REGISTRATION);
+                    }
+                    try {
+                        userStoreManager.setUserClaimValues(user.getUserName(), userClaims, null);
+                        if (log.isDebugEnabled()) {
+                            if (isAccountLockOnCreation) {
+                                log.debug("Locked user account: " + user.getUserName());
+                            }
+                            if (isEnableConfirmationOnCreation) {
+                                log.debug("Send verification notification for user account: " + user.getUserName());
+                            }
+                        }
+                    } catch (UserStoreException e) {
+                        throw new IdentityEventException("Error while lock user account :" + user.getUserName(), e);
+                    }
                 }
 
                 boolean isSelfRegistrationConfirmationNotify = Boolean.parseBoolean(Utils.getSignUpConfigs

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
@@ -122,6 +122,33 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
         if (IdentityEventConstants.Event.POST_ADD_USER.equals(event.getEventName())) {
             UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
 
+            if (isAccountLockOnCreation || isEnableConfirmationOnCreation) {
+                HashMap<String, String> userClaims = new HashMap<>();
+                if (isAccountLockOnCreation) {
+                    // Need to lock user account.
+                    userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
+                    userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_REASON_CLAIM,
+                            IdentityMgtConstants.LockedReason.PENDING_SELF_REGISTRATION.toString());
+                }
+                if (Utils.isAccountStateClaimExisting(tenantDomain)) {
+                    userClaims.put(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI,
+                            IdentityRecoveryConstants.PENDING_SELF_REGISTRATION);
+                }
+                try {
+                    userStoreManager.setUserClaimValues(user.getUserName(), userClaims, null);
+                    if (log.isDebugEnabled()) {
+                        if (isAccountLockOnCreation) {
+                            log.debug("Locked user account: " + user.getUserName());
+                        }
+                        if (isEnableConfirmationOnCreation) {
+                            log.debug("Send verification notification for user account: " + user.getUserName());
+                        }
+                    }
+                } catch (UserStoreException e) {
+                    throw new IdentityEventException("Error while lock user account :" + user.getUserName(), e);
+                }
+            }
+
             try {
                 // Get the user preferred notification channel.
                 String preferredChannel = resolveNotificationChannel(eventProperties, userName, tenantDomain,
@@ -166,33 +193,6 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
             } catch (IdentityRecoveryException e) {
                 throw new IdentityEventException("Error while sending self sign up notification ", e);
             }
-            if (isAccountLockOnCreation || isEnableConfirmationOnCreation) {
-                HashMap<String, String> userClaims = new HashMap<>();
-                if (isAccountLockOnCreation) {
-                    // Need to lock user account.
-                    userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
-                    userClaims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_REASON_CLAIM,
-                            IdentityMgtConstants.LockedReason.PENDING_SELF_REGISTRATION.toString());
-                }
-                if (Utils.isAccountStateClaimExisting(tenantDomain)) {
-                    userClaims.put(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI,
-                            IdentityRecoveryConstants.PENDING_SELF_REGISTRATION);
-                }
-                try {
-                    userStoreManager.setUserClaimValues(user.getUserName(), userClaims, null);
-                    if (log.isDebugEnabled()) {
-                        if (isAccountLockOnCreation) {
-                            log.debug("Locked user account: " + user.getUserName());
-                        }
-                        if (isEnableConfirmationOnCreation) {
-                            log.debug("Send verification notification for user account: " + user.getUserName());
-                        }
-                    }
-                } catch (UserStoreException e) {
-                    throw new IdentityEventException("Error while lock user account :" + user.getUserName(), e);
-                }
-            }
-
         }
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

This PR resolves an issue in the self-registration flow where user accounts would remain unlocked if the account confirmation notification failed to send. When account confirmation is enabled, the user's account should be locked until they verify it. However, if a server error occurs during notification delivery (e.g., missing account confirmation email template), the account remains unlocked, leading to unintended behavior.

### Changes Made

- Adjusted the order of execution to ensure that the user account lock and account state claims are persisted before triggering the notification for account confirmation. Guaranteed that the user account is locked immediately upon successful registration, irrespective of the success or failure of notification delivery.

> Note: This behavior isn't reproduced in case of a email server failure. ATM this can be reproduced by removing the account confirmation email template.

### Issue

https://github.com/wso2/product-is/issues/21290
