### PR TITLE
Skip passwordExpiryEventListener in authentication flow

### DIFF
--- a/components/org.wso2.carbon.identity.password.expiry/src/main/java/org/wso2/carbon/identity/password/expiry/listener/PasswordExpiryEventListener.java
+++ b/components/org.wso2.carbon.identity.password.expiry/src/main/java/org/wso2/carbon/identity/password/expiry/listener/PasswordExpiryEventListener.java
@@ -75,8 +75,8 @@ public class PasswordExpiryEventListener extends AbstractIdentityUserOperationEv
         try {
             String userTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
             String domainQualifiedUserName =
-                    ((AbstractUserStoreManager) userStoreManager).getUser(
-                            null, username).getDomainQualifiedUsername();
+                    ((AbstractUserStoreManager) userStoreManager).getUser(null, username)
+                            .getDomainQualifiedUsername();
             Optional<Long> passwordExpiryTime =
                     PasswordPolicyUtils.getUserPasswordExpiryTime(userTenantDomain, domainQualifiedUserName);
             passwordExpiryTime.ifPresent(expiryTime -> claimMap.put(PasswordPolicyConstants.PASSWORD_EXPIRY_TIME_CLAIM,

--- a/components/org.wso2.carbon.identity.password.expiry/src/main/java/org/wso2/carbon/identity/password/expiry/listener/PasswordExpiryEventListener.java
+++ b/components/org.wso2.carbon.identity.password.expiry/src/main/java/org/wso2/carbon/identity/password/expiry/listener/PasswordExpiryEventListener.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.password.expiry.models.PasswordExpiryRule;
 import org.wso2.carbon.identity.password.expiry.util.PasswordPolicyUtils;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.model.UserClaimSearchEntry;
 
 import java.util.Arrays;
@@ -73,8 +74,11 @@ public class PasswordExpiryEventListener extends AbstractIdentityUserOperationEv
 
         try {
             String userTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+            String domainQualifiedUserName =
+                    ((AbstractUserStoreManager) userStoreManager).getUser(
+                            null, username).getDomainQualifiedUsername();
             Optional<Long> passwordExpiryTime =
-                    PasswordPolicyUtils.getUserPasswordExpiryTime(userTenantDomain, username);
+                    PasswordPolicyUtils.getUserPasswordExpiryTime(userTenantDomain, domainQualifiedUserName);
             passwordExpiryTime.ifPresent(expiryTime -> claimMap.put(PasswordPolicyConstants.PASSWORD_EXPIRY_TIME_CLAIM,
                     String.valueOf(expiryTime)));
         } catch (ExpiredPasswordIdentificationException e) {

--- a/components/org.wso2.carbon.identity.password.expiry/src/main/java/org/wso2/carbon/identity/password/expiry/listener/PasswordExpiryEventListener.java
+++ b/components/org.wso2.carbon.identity.password.expiry/src/main/java/org/wso2/carbon/identity/password/expiry/listener/PasswordExpiryEventListener.java
@@ -60,7 +60,13 @@ public class PasswordExpiryEventListener extends AbstractIdentityUserOperationEv
                                                   Map<String, String> claimMap, UserStoreManager userStoreManager)
             throws UserStoreException {
 
-        if (!isEnable() || !Arrays.asList(claims).contains(PasswordPolicyConstants.PASSWORD_EXPIRY_TIME_CLAIM)) {
+        /*
+         * The passwordExpiryTime is a dynamically calculated value. It is only computed and added to the claims map
+         * if explicitly requested by the user via the claims list. This computation is also skipped during the
+         * authentication flow to avoid unnecessary processing.
+         */
+        if (!isEnable() || !Arrays.asList(claims).contains(PasswordPolicyConstants.PASSWORD_EXPIRY_TIME_CLAIM) ||
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername() == null) {
             return true;
         }
         log.debug("post get user claim values with id is called in PasswordExpiryEventListener");

--- a/components/org.wso2.carbon.identity.password.expiry/src/main/java/org/wso2/carbon/identity/password/expiry/util/PasswordPolicyUtils.java
+++ b/components/org.wso2.carbon.identity.password.expiry/src/main/java/org/wso2/carbon/identity/password/expiry/util/PasswordPolicyUtils.java
@@ -265,8 +265,8 @@ public class PasswordPolicyUtils {
                     List<String> roleIdsOfGroups = getRoleIdsOfGroups(new ArrayList<>(userGroupIds), tenantDomain);
 
                     List<RoleBasicInfo> userRoles = getUserRoles(tenantDomain, userId);
-                    Set<String> userRoleIds =
-                            userRoles.stream().map(RoleBasicInfo::getId).collect(Collectors.toSet());
+                    Set<String> userRoleIds = userRoles.stream().map(RoleBasicInfo::getId).filter(Objects::nonNull)
+                                    .collect(Collectors.toSet());
                     userRoleIds.addAll(roleIdsOfGroups);
                     fetchedUserAttributes.put(PasswordExpiryRuleAttributeEnum.ROLES, userRoleIds);
                     break;


### PR DESCRIPTION
### Proposed changes in this pull request
- Skip passwordExpiryEventListener in authentication flow
- Pass domain qualified username.


### Related Issues
 - https://github.com/wso2/product-is/issues/22177