### PR TITLE
Address multiple users exist in different user stores when recovering username

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/UserAccountRecoveryManager.java
@@ -138,7 +138,7 @@ public class UserAccountRecoveryManager {
             NotificationChannelDTO[] notificationChannelDTOS = null;
 
             for (org.wso2.carbon.user.core.common.User resultedUser : resultedUserList) {
-                username = resultedUser.getUsername();
+                username = resultedUser.getDomainQualifiedUsername();
                 User user = Utils.buildUser(username, tenantDomain);
 
                 try {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/username/UsernameRecoveryManagerImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/username/UsernameRecoveryManagerImpl.java
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020, WSO2 LLC. (http://www.wso2.org)
+ * Copyright (c) 2020-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -15,6 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.wso2.carbon.identity.recovery.internal.service.impl.username;
 
 import org.apache.commons.collections.MapUtils;

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/username/UsernameRecoveryManagerImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/username/UsernameRecoveryManagerImpl.java
@@ -355,11 +355,14 @@ public class UsernameRecoveryManagerImpl implements UsernameRecoveryManager {
 
         String combinedUsernames = user.getUserName();
         String[] usernames = combinedUsernames.split(",");
+        int userIndex = 0;
         for (String username : usernames) {
+            String userStoreDomain = user.getUserStoreDomain().split(",")[userIndex];
+            userIndex++;
             HashMap<String, Object> properties = new HashMap<>();
             properties.put(IdentityEventConstants.EventProperty.USER_NAME, username);
             properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, user.getTenantDomain());
-            properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, user.getUserStoreDomain());
+            properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, userStoreDomain);
             properties.put(IdentityEventConstants.EventProperty.NOTIFICATION_CHANNEL, notificationChannel);
             if (metaProperties != null) {
                 for (String key : metaProperties.keySet()) {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/username/UsernameRecoveryManagerImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/username/UsernameRecoveryManagerImpl.java
@@ -355,13 +355,22 @@ public class UsernameRecoveryManagerImpl implements UsernameRecoveryManager {
 
         String combinedUsernames = user.getUserName();
         String[] usernames = combinedUsernames.split(",");
+        String[] userStoreDomains = null;
+        if (user.getUserStoreDomain() != null) {
+            userStoreDomains = user.getUserStoreDomain().split(",");
+        }
+
         int userIndex = 0;
         for (String username : usernames) {
-            String userStoreDomain = user.getUserStoreDomain().split(",")[userIndex];
-            userIndex++;
             HashMap<String, Object> properties = new HashMap<>();
             properties.put(IdentityEventConstants.EventProperty.USER_NAME, username);
             properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, user.getTenantDomain());
+
+            String userStoreDomain = user.getUserStoreDomain();
+            if (userStoreDomains != null && userStoreDomains.length > userIndex) {
+                userStoreDomain = userStoreDomains[userIndex];
+            }
+            userIndex++;
             properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, userStoreDomain);
             properties.put(IdentityEventConstants.EventProperty.NOTIFICATION_CHANNEL, notificationChannel);
             if (metaProperties != null) {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1066,10 +1066,25 @@ public class Utils {
      */
     public static User buildUser(String username, String tenantDomain) {
 
+        String[] parts = username.split(",");
         User user = new User();
-        user.setUserName(UserCoreUtil.removeDomainFromName(username));
         user.setTenantDomain(tenantDomain);
-        user.setUserStoreDomain(IdentityUtil.extractDomainFromName(username));
+
+        for (String part : parts) {
+            String domainFreeName = UserCoreUtil.removeDomainFromName(part);
+            if (user.getUserName() != null) {
+                user.setUserName(user.getUserName() + "," + domainFreeName);
+            } else {
+                user.setUserName(domainFreeName);
+            }
+
+            String userStoreDomain = IdentityUtil.extractDomainFromName(part);
+            if (user.getUserStoreDomain() != null) {
+                user.setUserStoreDomain(user.getUserStoreDomain() + "," + userStoreDomain);
+            } else {
+                user.setUserStoreDomain(userStoreDomain);
+            }
+        }
         return user;
     }
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1066,11 +1066,13 @@ public class Utils {
      */
     public static User buildUser(String username, String tenantDomain) {
 
-        String[] parts = username.split(",");
+        /* The User Account Recovery process can identify multiple users that match the specified conditions.
+            In such cases, the usernames are represented as a comma-separated list. */
+        String[] usernameSegments = username.split(",");
         User user = new User();
         user.setTenantDomain(tenantDomain);
 
-        for (String part : parts) {
+        for (String part : usernameSegments) {
             String domainFreeName = UserCoreUtil.removeDomainFromName(part);
             if (user.getUserName() != null) {
                 user.setUserName(user.getUserName() + "," + domainFreeName);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2016-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except


### PR DESCRIPTION
### Proposed changes in this pull request


#### Related Issues
- https://github.com/wso2/product-is/issues/22169

As the default email template is configured as below, receive multiple emails with domain qualified usernames.
```
<b>{{userstore-domain}}/{{user-name}}</b>
```
<img width="649" alt="Screenshot 2025-01-10 at 14 43 15" src="https://github.com/user-attachments/assets/9090a393-52ed-4694-b51e-9ca23346c9ca" />

<img width="640" alt="Screenshot 2025-01-10 at 14 43 29" src="https://github.com/user-attachments/assets/2e5c3a3f-1933-4525-8ba1-9fa4f3d0848d" />
