### PR TITLE
Handle UserStoreClient Exceptions thrown from the Pre Update Password Action Execution

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -129,6 +129,10 @@
             <artifactId>org.wso2.carbon.identity.input.validation.mgt</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.user.action</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.governance</groupId>
             <artifactId>org.wso2.carbon.identity.multi.attribute.login.service</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -329,6 +329,7 @@ public class IdentityRecoveryConstants {
         ERROR_CODE_NO_HASHING_ALGO_FOR_CODE("20065", "Error while hashing the code."),
         ERROR_CODE_MULTIPLE_CLAIMS_WITH_MULTI_ATTRIBUTE_URI("20066", "Multiple claims not allowed " +
                 "when user identifier claim is used."),
+        ERROR_CODE_INVALID_PASSWORD("20067", "Error while validating the password. %s"),
 
         ERROR_CODE_ERROR_RETRIVING_CLAIM("18004", "Error when retrieving the locale claim of user '%s' of '%s' domain."),
         ERROR_CODE_RECOVERY_DATA_NOT_FOUND_FOR_USER("18005", "Recovery data not found."),

--- a/pom.xml
+++ b/pom.xml
@@ -496,6 +496,11 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.user.action</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.governance</groupId>
                 <artifactId>org.wso2.carbon.identity.multi.attribute.login.service</artifactId>
                 <version>${project.version}</version>
@@ -700,7 +705,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.7.114</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.144-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -705,7 +705,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.7.144-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.148</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request

1. Previously UserstoreClientExceptions are considered as server errors and handled accordingly.
2. But with the Pre Update password extension, we need to throw a client error from the recovery apis.
3. Since UserstoreClientExceptions were treated as server errors before, we added an extra validation by checking the error code thrown from the pre update password action component just to be precise on the error scenario.
4. Hence adding the pre update password action dependency to the repository.

### Related Issue:
- https://github.com/wso2/product-is/issues/22351