### PR TITLE
Error code for duplicate claim value error in self registration

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2016-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -117,6 +117,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AUDIT_SUCCESS;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.Configs.USERNAME;
 import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.ErrorMessages.ERROR_GETTING_EXISTING_CONFIGURATIONS;
+import static org.wso2.carbon.identity.mgt.constants.SelfRegistrationStatusCodes.ERROR_CODE_DUPLICATE_CLAIM_VALUE;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_EMAIL_DOMAIN_NOT_MAPPED_TO_ORGANIZATION;
 import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_MULTIPLE_REGISTRATION_OPTIONS;
 import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.SIGNUP_PROPERTY_REGISTRATION_OPTION;
@@ -247,8 +248,15 @@ public class UserSelfRegistrationManager {
                 Throwable cause = e;
                 while (cause != null) {
                     if (cause instanceof PolicyViolationException) {
+                        if (((PolicyViolationException) cause).getErrorCode() != null &&
+                                ERROR_CODE_DUPLICATE_CLAIM_VALUE.equals(
+                                        ((PolicyViolationException) cause).getErrorCode())) {
+                            throw IdentityException.error(IdentityRecoveryClientException.class,
+                                    ERROR_CODE_DUPLICATE_CLAIM_VALUE, cause.getMessage(), e);
+                        }
                         throw IdentityException.error(IdentityRecoveryClientException.class,
-                                IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_POLICY_VIOLATION.getCode(), cause.getMessage(), e);
+                                IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_POLICY_VIOLATION.getCode(),
+                                cause.getMessage(), e);
                     }
                     cause = cause.getCause();
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -700,7 +700,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.7.266</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.267</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -700,7 +700,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.7.148</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.266</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Purpose
When one or more attributes are configured as unique, and we attempt to register via the Self-Register API (https://localhost:9443/api/identity/user/v1.0/me) with a claim value already in use by another user (e.g., Mobile Number), the system responds with the following error:

{
    "code": "20035",
    "message": "Bad Request", 
    "description": "The value defined for Mobile is already in use by different user!",
    "traceId": "92c0ae8e-da20-46a8-a181-81e27033c472"
}

The error code 20035 is currently defined for password policy violations.

### Implementation 
This PR fix the issue by adding a new error code, ERROR_CODE_DUPLICATE_CLAIM_VALUE = "60007", introduced in SelfRegistrationStatusCodes and here it check whether the PolicyViolationException contains this error code and throw the error with it.

### Related Issue 
- https://github.com/wso2/product-is/issues/22515

### Merge After
- https://github.com/wso2/carbon-identity-framework/pull/6477