### PR TITLE
Add new recovery scenario for offline user invite

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/RecoveryScenarios.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/RecoveryScenarios.java
@@ -36,7 +36,8 @@ public enum RecoveryScenarios {
     MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE,
     LITE_SIGN_UP,
     TENANT_ADMIN_ASK_PASSWORD,
-    PASSWORD_EXPIRY;
+    PASSWORD_EXPIRY,
+    ADMIN_INVITE_SET_PASSWORD_OFFLINE;
 
     /**
      * Get recovery scenario which matches the given scenario name.
@@ -52,7 +53,7 @@ public enum RecoveryScenarios {
                 ASK_PASSWORD, ADMIN_FORCED_PASSWORD_RESET_VIA_EMAIL_LINK, ADMIN_FORCED_PASSWORD_RESET_VIA_OTP,
                 LITE_SIGN_UP, TENANT_ADMIN_ASK_PASSWORD, EMAIL_VERIFICATION_ON_UPDATE, MOBILE_VERIFICATION_ON_UPDATE,
                 PASSWORD_EXPIRY, EMAIL_VERIFICATION_ON_VERIFIED_LIST_UPDATE,
-                MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE
+                MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE, ADMIN_INVITE_SET_PASSWORD_OFFLINE
         };
         if (StringUtils.isNotEmpty(scenarioName)) {
             for (RecoveryScenarios scenario : scenarios) {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -1414,6 +1414,7 @@ public class NotificationPasswordRecoveryManager {
                 IdentityContext.getThreadLocalIdentityContext().setFlow(flow);
                 break;
             case ASK_PASSWORD:
+            case ADMIN_INVITE_SET_PASSWORD_OFFLINE:
                 flow = new Flow.Builder()
                         .name(Flow.Name.USER_REGISTRATION_INVITE_WITH_PASSWORD)
                         .initiatingPersona(Flow.InitiatingPersona.ADMIN)

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/store/JDBCRecoveryDataStoreTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/store/JDBCRecoveryDataStoreTest.java
@@ -182,6 +182,7 @@ public class JDBCRecoveryDataStoreTest {
                 { RecoveryScenarios.LITE_SIGN_UP, RecoverySteps.VALIDATE_CHALLENGE_QUESTION },
                 { RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_OTP, RecoverySteps.UPDATE_PASSWORD },
                 { RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_EMAIL_LINK, RecoverySteps.UPDATE_PASSWORD },
+                { RecoveryScenarios.ADMIN_INVITE_SET_PASSWORD_OFFLINE, RecoverySteps.UPDATE_PASSWORD }
         };
     }
 

--- a/components/org.wso2.carbon.identity.user.onboard.core.service/src/main/java/org/wso2/carbon/identity/user/onboard/core/service/password/ResetLinkGenerator.java
+++ b/components/org.wso2.carbon.identity.user.onboard.core.service/src/main/java/org/wso2/carbon/identity/user/onboard/core/service/password/ResetLinkGenerator.java
@@ -105,9 +105,9 @@ public class ResetLinkGenerator {
         UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
         userRecoveryDataStore.invalidate(user);
         String secretKey = Utils.generateSecretKey(notificationChannel, user.getTenantDomain(),
-                RecoveryScenarios.NOTIFICATION_BASED_PW_RECOVERY.name());
+                RecoveryScenarios.ADMIN_INVITE_SET_PASSWORD_OFFLINE.name());
         UserRecoveryData recoveryDataDO = new UserRecoveryData(user, secretKey,
-                RecoveryScenarios.NOTIFICATION_BASED_PW_RECOVERY, RecoverySteps.UPDATE_PASSWORD);
+                RecoveryScenarios.ADMIN_INVITE_SET_PASSWORD_OFFLINE, RecoverySteps.UPDATE_PASSWORD);
 
         // Store the notified channel in the recovery object for future reference.
         recoveryDataDO.setRemainingSetIds(notificationChannel);


### PR DESCRIPTION
### Proposed changes in this pull request

1. Previously `NOTIFICATION_BASED_PW_RECOVERY` was used as the recovery scenario for offline user invite flow. But the `NOTIFICATION_BASED_PW_RECOVERY` used in password recovery flows as well. 
Due to that reason it's unable to distinguish offline user invite flow and a user password recovery flow using the User Recovery Data. 
2. Hence this PR will introduce new recovery scenario(`ADMIN_INVITE_SET_PASSWORD_OFFLINE`) for the offline user invite flow.

### Related Issue
- https://github.com/wso2/product-is/issues/22638