### PR TITLE
Refactor error message from the pre update password action failure in recovery apis

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -330,7 +330,7 @@ public class IdentityRecoveryConstants {
         ERROR_CODE_NO_HASHING_ALGO_FOR_CODE("20065", "Error while hashing the code."),
         ERROR_CODE_MULTIPLE_CLAIMS_WITH_MULTI_ATTRIBUTE_URI("20066", "Multiple claims not allowed " +
                 "when user identifier claim is used."),
-        ERROR_CODE_INVALID_PASSWORD("20067", "Error while validating the password. %s"),
+        ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE("20067", "%s"),
 
         ERROR_CODE_ERROR_RETRIVING_CLAIM("18004", "Error when retrieving the locale claim of user '%s' of '%s' domain."),
         ERROR_CODE_RECOVERY_DATA_NOT_FOUND_FOR_USER("18005", "Recovery data not found."),

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -79,7 +79,6 @@ import java.util.Map;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AUDIT_FAILED;
 import static org.wso2.carbon.registry.core.RegistryConstants.PATH_SEPARATOR;
-import static org.wso2.carbon.user.core.UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME;
 
 /**
  * Manager class which can be used to recover passwords using a notification.
@@ -1063,7 +1062,7 @@ public class NotificationPasswordRecoveryManager {
             if (cause instanceof UserStoreClientException && ((UserStoreClientException) cause).getErrorCode()
                     .equals(UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED)) {
                 throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages
-                        .ERROR_CODE_INVALID_PASSWORD, cause.getMessage(), cause);
+                        .ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE, cause.getMessage(), cause);
             }
             cause = cause.getCause();
         }


### PR DESCRIPTION
### Proposed changes in this pull request

- Previously a default error message was appended in the front for the client errors coming from the pre update password action. With this PR, that default message will be removed and only the message coming from the downstream component will be returned from the API.

#### Previous behaviour
<img width="604" alt="image" src="https://github.com/user-attachments/assets/5e999e6e-83c3-49b4-bf18-f571befefbad" />

#### New behaviour
<img width="675" alt="image" src="https://github.com/user-attachments/assets/d044f3c9-353e-49a9-a32c-00b6e954aa3d" />

### Related Issue
- https://github.com/wso2/product-is/issues/23080
