### PR TITLE
Skip the identity claims resolved from the user store when the identity claims are stored in the identity db

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
@@ -292,6 +292,16 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
             claimMap = new HashMap<>();
         }
 
+        if (!isHybridDataStoreEnable) {
+            /*
+            If hybrid data store is disabled, we need to use the identity claim value only from the identity data store.
+            Hence, we need to remove the identity claim values from the claimMap to avoid use of values from user store
+            for identity claims.
+             */
+            claimMap.entrySet().removeIf(
+                    entry -> entry.getKey().contains(UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI_PREFIX));
+        }
+
         // check if there are identity claims
         boolean containsIdentityClaims = false;
         for (String claim : claims) {


### PR DESCRIPTION
#### Related Issues
- https://github.com/wso2/product-is/issues/23076

### Proposed changes in this pull request

This issue has occurred due to a regression introduced from removing the logic as here [1], done as part of the improvement[2]. In that issue, the identity claims are removed from the pre-listener of user claim retrieval when the identity claims are stored in the identity db (As those claims are not required to be search in the user store as those claims won't exist).

But the removed part of that PR is a needed logic. When there are user store level claims which are configured as map attributes of identity claims,  it can cause to get reflected them as identity claims though the real identity claims are stored in the identity-db. 

Hence before fetching the identity claims from the identity-db, we can clear all the identity claims from the claims derived so far as those claim are not relevant.

[1] - https://github.com/wso2-extensions/identity-governance/pull/827/files#diff-839560d3e49da20a1f7245182def048fe1673a3fb7ebdf2bb8ead4cd6812199dL246-L255

[2] - https://github.com/wso2/product-is/issues/20490