### PR TITLE
Make 'user onboard api core' service activation success log level to debug

### DIFF
--- a/components/org.wso2.carbon.identity.user.onboard.core.service/src/main/java/org/wso2/carbon/identity/user/onboard/core/service/internal/ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.user.onboard.core.service/src/main/java/org/wso2/carbon/identity/user/onboard/core/service/internal/ServiceComponent.java
@@ -44,7 +44,7 @@ public class ServiceComponent {
         try {
             componentContext.getBundleContext().registerService(UserOnboardCoreService.class.getName(),
                     new UserOnboardCoreServiceImpl(), null);
-            LOG.info("User onboard api core service component activated successfully.");
+            LOG.debug("User onboard api core service component activated successfully.");
         } catch (Throwable throwable) {
             LOG.error("Failed to activate the User onboard api core service component.", throwable);
         }


### PR DESCRIPTION
### Proposed changes in this pull request

$subject to avoid unnecessary logs to be printed during the product startup.