### PR TITLE
Drop standard port in default callback URL value

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/LiteRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/LiteRegistrationConfigImpl.java
@@ -225,7 +225,7 @@ public class LiteRegistrationConfigImpl implements IdentityConnectorConfig {
                 IdentityRecoveryConstants.ConnectorConfig.LITE_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME);
         String verificationSMSOTPRegexProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.LITE_REGISTRATION_SMS_OTP_REGEX);
-        String selfRegistrationCallbackRegexProperty = IdentityUtil.getProperty(
+        String selfRegistrationCallbackRegexProperty = IdentityUtil.getPropertyWithoutStandardPort(
                 IdentityRecoveryConstants.ConnectorConfig.LITE_REGISTRATION_CALLBACK_REGEX);
         String selfRegistrationResendVerificationOnUserExistenceProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.LITE_REGISTRATION_RESEND_VERIFICATION_ON_USER_EXISTENCE);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImpl.java
@@ -303,7 +303,7 @@ public class RecoveryConfigImpl implements IdentityConnectorConfig {
                 PASSWORD_RECOVERY_RECAPTCHA_ENABLE);
         String userNameRecoveryReCaptcha = IdentityUtil.getProperty(IdentityRecoveryConstants.ConnectorConfig.
                 USERNAME_RECOVERY_RECAPTCHA_ENABLE);
-        String recoveryCallbackRegexProperty = IdentityUtil.getProperty(
+        String recoveryCallbackRegexProperty = IdentityUtil.getPropertyWithoutStandardPort(
                 IdentityRecoveryConstants.ConnectorConfig.RECOVERY_CALLBACK_REGEX);
         String adminPasswordResetAutoLoginProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.ENABLE_AUTO_LGOIN_AFTER_PASSWORD_RESET);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImpl.java
@@ -265,7 +265,7 @@ public class SelfRegistrationConfigImpl implements IdentityConnectorConfig {
                 IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SMSOTP_VERIFICATION_CODE_EXPIRY_TIME);
         String verificationSMSOTPRegexProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SMS_OTP_REGEX);
-        String selfRegistrationCallbackRegexProperty = IdentityUtil.getProperty(
+        String selfRegistrationCallbackRegexProperty = IdentityUtil.getPropertyWithoutStandardPort(
                 IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_CALLBACK_REGEX);
         String selfSignUpConfirmationNotificationProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_NOTIFY_ACCOUNT_CONFIRMATION);

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/RecoveryConfigImplTest.java
@@ -352,6 +352,8 @@ public class RecoveryConfigImplTest {
         String testPropertyValue = "testValue";
         try(MockedStatic<IdentityUtil> identityUtilMockedStatic = Mockito.mockStatic(IdentityUtil.class)) {
             identityUtilMockedStatic.when(() -> IdentityUtil.getProperty(property)).thenReturn(testPropertyValue);
+            identityUtilMockedStatic.when(() ->
+                    IdentityUtil.getPropertyWithoutStandardPort(property)).thenReturn(testPropertyValue);
 
             Properties properties = recoveryConfigImpl.getDefaultPropertyValues(tenantDomain);
             assertEquals(testPropertyValue, properties.getProperty(property));

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/SelfRegistrationConfigImplTest.java
@@ -327,7 +327,7 @@ public class SelfRegistrationConfigImplTest {
         mockedIdentityUtil.when(() -> IdentityUtil.getProperty(
                         IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SMS_OTP_REGEX))
                 .thenReturn(testVerificationSMSOTPRegex);
-        mockedIdentityUtil.when(() -> IdentityUtil.getProperty(
+        mockedIdentityUtil.when(() -> IdentityUtil.getPropertyWithoutStandardPort(
                         IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_CALLBACK_REGEX))
                 .thenReturn(selfRegistrationCallbackRegex);
         mockedIdentityUtil.when(() -> IdentityUtil.getProperty(

--- a/pom.xml
+++ b/pom.xml
@@ -700,7 +700,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.8.53</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.63</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -700,7 +700,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.7.267</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.53</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
## Important

This has to be merged after https://github.com/wso2/carbon-identity-framework/pull/6600 as the relevant framework version needs to be updated.

## Purpose

Drops the standard ports, namely 443 for https and 80 for http, in the following default callback URL regex values.

- LiteRegistration.CallbackRegex
- SelfRegistration.CallbackRegex
- Recovery.CallbackRegex

## Related Issues

- https://github.com/wso2/product-is/issues/23196

## Related PRs

- https://github.com/wso2/carbon-identity-framework/pull/6600