### PR TITLE
Update the default channel enabling for password recovery.

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceServiceImpl.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceServiceImpl.java
@@ -381,12 +381,13 @@ public class IdentityGovernanceServiceImpl implements IdentityGovernanceService 
             boolean emailOtpPasswordRecoveryProperty = Boolean.parseBoolean(emailOtpForPasswordRecoveryProp);
 
             if (recoveryNotificationPasswordProperty) {
+                // Connector is enabled and if channels are not explicitly enabled/disabled, email link and sms otp
+                // will be enabled in default.
                 configurationDetails.put(EMAIL_LINK_PASSWORD_RECOVERY_PROPERTY,
                         String.valueOf(emailLinkPasswordRecoveryProperty ||
                                 StringUtils.isBlank(emailLinkForPasswordRecoveryProp)));
                 configurationDetails.put(EMAIL_OTP_PASSWORD_RECOVERY_PROPERTY,
-                        String.valueOf(emailOtpPasswordRecoveryProperty ||
-                                StringUtils.isBlank(emailOtpForPasswordRecoveryProp)));
+                        String.valueOf(emailOtpPasswordRecoveryProperty));
                 configurationDetails.put(SMS_OTP_PASSWORD_RECOVERY_PROPERTY,
                         String.valueOf(smsOtpPasswordRecoveryProperty ||
                                 StringUtils.isBlank(smsOtpForPasswordRecoveryProp)));

--- a/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/IdentityGovernanceServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/IdentityGovernanceServiceImplTest.java
@@ -248,7 +248,7 @@ public class IdentityGovernanceServiceImplTest {
         Map<String, String> passwordConfigs7 = getPasswordRecoveryConfigs(true, null, null, null);
         IdentityProviderProperty[] passwordIdentityProps7 = getPasswordRecoveryIdentityProviderProperties(false, false
                 , false, false);
-        Map<String, String> passwordExpected7 = getPasswordRecoveryExpectedPropertyValues(true, true, true, true);
+        Map<String, String> passwordExpected7 = getPasswordRecoveryExpectedPropertyValues(true, true, false, true);
 
         // Disabling the password recovery config. Precondition: email link and sms otp are true.
         Map<String, String> passwordConfigs8 = getPasswordRecoveryConfigs(false, null, null, null);

--- a/pom.xml
+++ b/pom.xml
@@ -700,7 +700,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.8.63</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.84</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request
- This will be changing the behaviour of default channel enabling logic when user only enables the "Recovery.Notification.Password.Enable".
- This [PR](https://github.com/wso2/product-is/issues/23444) has introduced enabling all the channels when user tries only enable the password recovery.
- Now only the email link and sms OTP will enabled unless user enable/disable the channels.

### Related issues
- https://github.com/wso2/product-is/issues/23444

### Related PRs
- https://github.com/wso2-extensions/identity-governance/pull/929