### PR TITLE
Fix self registration email OTP not sending to OTP template.

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -48,7 +48,8 @@ public class IdentityRecoveryConstants {
     public static final String NOTIFICATION_TYPE_ADMIN_FORCED_PASSWORD_RESET_WITH_OTP = "adminforcedpasswordresetwithotp";
     public static final String NOTIFICATION_TYPE_RESEND_ADMIN_FORCED_PASSWORD_RESET_WITH_OTP =
             "resendAdminForcedPasswordResetWithOTP";
-    public static final String NOTIFICATION_TYPE_ACCOUNT_CONFIRM = "accountconfirmation";
+    public static final String NOTIFICATION_TYPE_ACCOUNT_CONFIRM_EMAIL_LINK = "accountconfirmation";
+    public static final String NOTIFICATION_TYPE_ACCOUNT_CONFIRM_EMAIL_OTP = "EmailOTPVerification";
     public static final String NOTIFICATION_TYPE_RESEND_ACCOUNT_CONFIRM = "resendaccountconfirmation";
     public static final String NOTIFICATION_TYPE_EMAIL_CONFIRM = "emailconfirm";
     public static final String NOTIFICATION_TYPE_LITE_USER_EMAIL_CONFIRM = "liteUserEmailConfirmation";
@@ -78,6 +79,7 @@ public class IdentityRecoveryConstants {
     public static final String INITIATED_PLATFORM = "initiated-platform";
     public static final String CAMPAIGN = "campaign";
     public static final String CONFIRMATION_CODE = "confirmation-code";
+    public static final String OTP_CODE = "OTPCode";
     public static final String OTP_TOKEN = "otpToken";
     public static final String OTP_TOKEN_STRING = "otpTokenString";
     public static final String VERIFICATION_PENDING_EMAIL = "verification-pending-email";

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandlerTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.recovery.handler;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
+import org.wso2.carbon.identity.recovery.RecoveryScenarios;
+import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
+import org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStore;
+import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
+import org.wso2.carbon.identity.recovery.util.Utils;
+import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.core.UserStoreManager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+import static org.testng.Assert.assertEquals;
+import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION;
+import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP;
+import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SEND_OTP_IN_EMAIL;
+import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE;
+import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.NOTIFICATION_TYPE_ACCOUNT_CONFIRM_EMAIL_LINK;
+import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.NOTIFICATION_TYPE_ACCOUNT_CONFIRM_EMAIL_OTP;
+import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.SELF_SIGNUP_ROLE;
+
+public class UserSelfRegistrationHandlerTest {
+
+    private static final String POST_ADD_USER = "POST_ADD_USER";
+    private static final String TENANT_DOMAIN = "carbon.super";
+    private static final String DOMAIN_NAME = "TEST";
+    private static final String TENANT_DOMAIN_KEY = "tenant-domain";
+    private static final String USER_STORE_KEY = "userStoreManager";
+    private static final String USER_STORE_DOMAIN_KEY = "userstore-domain";
+    private static final String ROLE_LIST_KEY = "ROLE_LIST";
+    private static final String NOTIFICATION_CHANNEL_KEY = "notification-channel";
+    private static final String TEMPLATE_TYPE_KEY = "TEMPLATE_TYPE";
+    private static final String EMAIL = "EMAIL";
+    private static final String EVENT_NAME = "TRIGGER_NOTIFICATION";
+    private static final String CONNECTOR_NAME = "SelfRegistration";
+    private static final String TRUE_STRING = "true";
+
+    @Mock
+    private UserStoreManager userStoreManager;
+
+    @Mock
+    private RealmConfiguration realmConfiguration;
+
+    @Mock
+    private UserRecoveryDataStore userRecoveryDataStore;
+
+    @Mock
+    private IdentityRecoveryServiceDataHolder identityRecoveryServiceDataHolder;
+
+    @Mock
+    private IdentityEventService identityEventService;
+
+    private MockedStatic<Utils> utilsMockedStatic;
+
+    private MockedStatic<JDBCRecoveryDataStore> jdbcRecoveryDataStoreMockedStatic;
+
+    private MockedStatic<IdentityRecoveryServiceDataHolder> identityRecoveryServiceDataHolderMockedStatic;
+
+    @BeforeMethod
+    public void init() {
+
+        openMocks(this);
+        utilsMockedStatic = mockStatic(Utils.class);
+        jdbcRecoveryDataStoreMockedStatic = mockStatic(JDBCRecoveryDataStore.class);
+        identityRecoveryServiceDataHolderMockedStatic = mockStatic(IdentityRecoveryServiceDataHolder.class);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        utilsMockedStatic.close();
+        jdbcRecoveryDataStoreMockedStatic.close();
+        identityRecoveryServiceDataHolderMockedStatic.close();
+    }
+
+    @Test(dataProvider = "userRegistrationConfig")
+    public void testUserRegistrationEmailTemplates(boolean isEmailOtpEnabled, String expectedEmailTemplate)
+            throws IdentityEventException, IdentityRecoveryException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(TENANT_DOMAIN_KEY, TENANT_DOMAIN);
+        eventProperties.put(USER_STORE_KEY, userStoreManager);
+        eventProperties.put(ROLE_LIST_KEY, new String[]{SELF_SIGNUP_ROLE});
+        Event event = new Event(POST_ADD_USER, eventProperties);
+
+        when(userStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
+        when(realmConfiguration.getUserStoreProperty(anyString())).thenReturn(DOMAIN_NAME);
+        jdbcRecoveryDataStoreMockedStatic.when(JDBCRecoveryDataStore::getInstance).thenReturn(userRecoveryDataStore);
+        doNothing().when(userRecoveryDataStore).invalidate(any(User.class));
+        utilsMockedStatic.when(() -> Utils.getConnectorConfig(ENABLE_SELF_SIGNUP, TENANT_DOMAIN)).
+                thenReturn(TRUE_STRING);
+        if (isEmailOtpEnabled) {
+            utilsMockedStatic.when(() -> Utils.getConnectorConfig(SELF_REGISTRATION_SEND_OTP_IN_EMAIL, TENANT_DOMAIN)).
+                    thenReturn(TRUE_STRING);
+        }
+        utilsMockedStatic.when(() -> Utils.getConnectorConfig(SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE, TENANT_DOMAIN)).
+                thenReturn(TRUE_STRING);
+        utilsMockedStatic.when(() -> Utils.getConnectorConfig(ACCOUNT_LOCK_ON_CREATION, TENANT_DOMAIN)).
+                thenReturn(TRUE_STRING);
+        utilsMockedStatic.when(() -> Utils.generateSecretKey(EMAIL, RecoveryScenarios.SELF_SIGN_UP.name(),
+                TENANT_DOMAIN, CONNECTOR_NAME)).thenReturn("12345");
+        identityRecoveryServiceDataHolderMockedStatic.when(IdentityRecoveryServiceDataHolder::getInstance).
+                thenReturn(identityRecoveryServiceDataHolder);
+        when(identityRecoveryServiceDataHolder.getIdentityEventService()).thenReturn(identityEventService);
+
+        UserSelfRegistrationHandler userSelfRegistrationHandler = new UserSelfRegistrationHandler();
+        userSelfRegistrationHandler.handleEvent(event);
+
+        // Capturing the event value for asserting.
+        ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+        verify(identityEventService).handleEvent(captor.capture());
+        Event capturedEvent = captor.getValue();
+        Map<String, Object> capturedEventEventProperties = capturedEvent.getEventProperties();
+        assertEquals(capturedEvent.getEventName(), EVENT_NAME);
+        assertEquals(capturedEventEventProperties.get(TENANT_DOMAIN_KEY), TENANT_DOMAIN);
+        assertEquals(capturedEventEventProperties.get(USER_STORE_DOMAIN_KEY), DOMAIN_NAME);
+        assertEquals(capturedEventEventProperties.get(NOTIFICATION_CHANNEL_KEY), EMAIL);
+        assertEquals(capturedEventEventProperties.get(TEMPLATE_TYPE_KEY), expectedEmailTemplate);
+    }
+
+    @DataProvider(name = "userRegistrationConfig")
+    private Object[][] buildUserRegistrationConfigs() {
+
+        return new Object[][]{
+                {false, NOTIFICATION_TYPE_ACCOUNT_CONFIRM_EMAIL_LINK},
+                {true, NOTIFICATION_TYPE_ACCOUNT_CONFIRM_EMAIL_OTP}
+        };
+    }
+
+}

--- a/components/org.wso2.carbon.identity.recovery/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.recovery/src/test/resources/testng.xml
@@ -30,6 +30,7 @@
             <class name="org.wso2.carbon.identity.recovery.internal.service.impl.username.UsernameRecoveryManagerImplTest"/>
             <class name="org.wso2.carbon.identity.recovery.util.UtilsTest"/>
             <class name="org.wso2.carbon.identity.recovery.handler.UserEmailVerificationHandlerTest" />
+            <class name="org.wso2.carbon.identity.recovery.handler.UserSelfRegistrationHandlerTest"/>
             <class name="org.wso2.carbon.identity.recovery.confirmation.ResendConfirmationManagerTest" />
             <class name="org.wso2.carbon.identity.recovery.handler.MobileNumberVerificationHandlerTest" />
             <class name="org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStoreTest" />


### PR DESCRIPTION
### Purpose
- $subject

### Description
- Now user registration handler will pick the email template conditionally by checking the config `SelfRegistration.OTP.SendOTPInEmail`.

### Related issues
- https://github.com/wso2/product-is/issues/23694 

