### PR TITLE
Fixing password recovery error format at validation failure initiated by pre update password action

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtil.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtil.java
@@ -46,7 +46,6 @@ import org.wso2.carbon.identity.recovery.endpoint.Exceptions.BadRequestException
 import org.wso2.carbon.identity.recovery.endpoint.Exceptions.InternalServerErrorException;
 import org.wso2.carbon.identity.recovery.endpoint.dto.ClaimDTO;
 import org.wso2.carbon.identity.recovery.endpoint.dto.ErrorDTO;
-import org.wso2.carbon.identity.recovery.endpoint.dto.LinkDTO;
 import org.wso2.carbon.identity.recovery.endpoint.dto.PropertyDTO;
 import org.wso2.carbon.identity.recovery.endpoint.dto.ReCaptchaResponseTokenDTO;
 import org.wso2.carbon.identity.recovery.endpoint.dto.UserClaimDTO;
@@ -70,12 +69,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.UUID;
 
 public class RecoveryUtil {
     private static final String USERNAME_CLAIM = "http://wso2.org/claims/username";
@@ -141,26 +138,6 @@ public class RecoveryUtil {
         ErrorDTO errorDTO = getErrorDTO(Constants.STATUS_INTERNAL_SERVER_ERROR_MESSAGE_DEFAULT, code,
                 Constants.STATUS_INTERNAL_SERVER_ERROR_DESCRIPTION_DEFAULT);
         return new InternalServerErrorException(errorDTO);
-    }
-
-
-    /**
-     * Handles a bad request by throwing a {@link BadRequestException} with the specified error details.
-     * If the {@code description} is blank, it delegates handling to {@link #handleBadRequest(String, String)}.
-     * Otherwise, it constructs an {@link ErrorDTO} and throws a {@link BadRequestException}.
-     *
-     * @param message     A brief message describing the error.
-     * @param description A detailed description of the error. If blank, the method delegates to another handler.
-     * @param code        The functional error code associated with the bad request.
-     * @throws BadRequestException Always thrown with the generated {@link ErrorDTO}.
-     */
-    public static void handleBadRequest(String message, String description, String code) throws BadRequestException {
-
-        if (StringUtils.isBlank(description)) {
-            handleBadRequest(message, code);
-        }
-        ErrorDTO errorDTO = getErrorDTO(message, code, description);
-        throw new BadRequestException(errorDTO);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtil.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtil.java
@@ -145,6 +145,25 @@ public class RecoveryUtil {
 
 
     /**
+     * Handles a bad request by throwing a {@link BadRequestException} with the specified error details.
+     * If the {@code description} is blank, it delegates handling to {@link #handleBadRequest(String, String)}.
+     * Otherwise, it constructs an {@link ErrorDTO} and throws a {@link BadRequestException}.
+     *
+     * @param message     A brief message describing the error.
+     * @param description A detailed description of the error. If blank, the method delegates to another handler.
+     * @param code        The functional error code associated with the bad request.
+     * @throws BadRequestException Always thrown with the generated {@link ErrorDTO}.
+     */
+    public static void handleBadRequest(String message, String description, String code) throws BadRequestException {
+
+        if (StringUtils.isBlank(description)) {
+            handleBadRequest(message, code);
+        }
+        ErrorDTO errorDTO = getErrorDTO(message, code, description);
+        throw new BadRequestException(errorDTO);
+    }
+
+    /**
      * Logs the error, builds a BadRequestException with specified details and throws it
      *
      * @param msg  error message

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/SetPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/SetPasswordApiServiceImpl.java
@@ -52,7 +52,7 @@ public class SetPasswordApiServiceImpl extends SetPasswordApiService {
                 return Response.status(Response.Status.BAD_REQUEST).entity(errorDTO).build();
             }
 
-            RecoveryUtil.handleBadRequest(e.getMessage(), e.getDescription(), e.getErrorCode());
+            RecoveryUtil.handleBadRequest(e.getMessage(), e.getErrorCode());
 
         } catch (IdentityRecoveryException e) {
             RecoveryUtil.handleInternalServerError(Constants.SERVER_ERROR, e.getErrorCode(), LOG, e);

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/SetPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/SetPasswordApiServiceImpl.java
@@ -9,11 +9,14 @@ import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.endpoint.Constants;
 import org.wso2.carbon.identity.recovery.endpoint.SetPasswordApiService;
 import org.wso2.carbon.identity.recovery.endpoint.Utils.RecoveryUtil;
+import org.wso2.carbon.identity.recovery.endpoint.dto.ErrorDTO;
 import org.wso2.carbon.identity.recovery.endpoint.dto.ResetPasswordRequestDTO;
 import org.wso2.carbon.identity.recovery.endpoint.dto.RetryErrorDTO;
 import org.wso2.carbon.identity.recovery.password.NotificationPasswordRecoveryManager;
 
 import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.recovery.endpoint.Utils.RecoveryUtil.getCorrelation;
 
 public class SetPasswordApiServiceImpl extends SetPasswordApiService {
 
@@ -44,11 +47,11 @@ public class SetPasswordApiServiceImpl extends SetPasswordApiService {
                 return Response.status(Response.Status.PRECONDITION_FAILED).entity(errorDTO).build();
             } else if (IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE.getCode()
                     .equals(e.getErrorCode())) {
-                RetryErrorDTO errorDTO = new RetryErrorDTO();
+                ErrorDTO errorDTO = new ErrorDTO();
                 errorDTO.setCode(e.getErrorCode());
                 errorDTO.setMessage(e.getMessage());
                 errorDTO.setDescription(e.getDescription());
-                errorDTO.setKey(resetPasswordRequest.getKey());
+                errorDTO.setRef(getCorrelation());
                 return Response.status(Response.Status.BAD_REQUEST).entity(errorDTO).build();
             }
 

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/SetPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/SetPasswordApiServiceImpl.java
@@ -42,6 +42,14 @@ public class SetPasswordApiServiceImpl extends SetPasswordApiService {
                 errorDTO.setDescription(e.getMessage());
                 errorDTO.setKey(resetPasswordRequest.getKey());
                 return Response.status(Response.Status.PRECONDITION_FAILED).entity(errorDTO).build();
+            } else if (IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE.getCode()
+                    .equals(e.getErrorCode())) {
+                RetryErrorDTO errorDTO = new RetryErrorDTO();
+                errorDTO.setCode(e.getErrorCode());
+                errorDTO.setMessage(e.getMessage());
+                errorDTO.setDescription(e.getDescription());
+                errorDTO.setKey(resetPasswordRequest.getKey());
+                return Response.status(Response.Status.BAD_REQUEST).entity(errorDTO).build();
             }
 
             RecoveryUtil.handleBadRequest(e.getMessage(), e.getDescription(), e.getErrorCode());

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/SetPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/SetPasswordApiServiceImpl.java
@@ -44,7 +44,7 @@ public class SetPasswordApiServiceImpl extends SetPasswordApiService {
                 return Response.status(Response.Status.PRECONDITION_FAILED).entity(errorDTO).build();
             }
 
-            RecoveryUtil.handleBadRequest(e.getMessage(), e.getErrorCode());
+            RecoveryUtil.handleBadRequest(e.getMessage(), e.getDescription(), e.getErrorCode());
 
         } catch (IdentityRecoveryException e) {
             RecoveryUtil.handleInternalServerError(Constants.SERVER_ERROR, e.getErrorCode(), LOG, e);

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtilsTest.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtilsTest.java
@@ -63,15 +63,16 @@ public class RecoveryUtilsTest {
     }
 
     @Test(description = "Test the password reset API error format.")
-    public void testHandleClientExceptionWithData() {
+    public void testHandleClientExceptionWithDescription() {
 
-        String data = "Invalid password format";
+        String description = "Invalid password format";
         String message = "invalid_value";
-        Throwable cause = new Throwable("Invalid password format");
+        Throwable cause = new Throwable(description);
 
         IdentityRecoveryClientException exception;
         try {
-            exception = Utils.handleClientException(ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE, data, message, cause);
+            exception = Utils.handleClientException(ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE, description, message,
+                    cause);
         } catch (IdentityRecoveryClientException e) {
             throw new RuntimeException(e);
         }
@@ -79,20 +80,20 @@ public class RecoveryUtilsTest {
         assertNotNull(exception);
         assertEquals(exception.getErrorCode(), ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE.getCode());
         assertEquals(exception.getMessage(), message);
-        assertEquals(exception.getDescription(), data);
+        assertEquals(exception.getDescription(), description);
         assertEquals(cause, exception.getCause());
     }
 
     @Test
-    public void testHandleClientExceptionWithoutData() {
+    public void testHandleClientExceptionWithoutDescription() {
 
-        String data = null;
         String message = "Test message";
         Throwable cause = new Throwable("Cause of the error");
 
         IdentityRecoveryClientException exception;
         try {
-            exception = Utils.handleClientException(ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE, data, message, cause);
+            exception =
+                    Utils.handleClientException(ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE, null, message, cause);
         } catch (IdentityRecoveryClientException e) {
             throw new RuntimeException(e);
         }
@@ -103,5 +104,4 @@ public class RecoveryUtilsTest {
         assertEquals(exception.getDescription(), ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE.getMessage());
         assertEquals(cause, exception.getCause());
     }
-
 }

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtilsTest.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtilsTest.java
@@ -19,7 +19,9 @@ package org.wso2.carbon.identity.recovery.endpoint.Utils;
 
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.captcha.util.CaptchaConstants;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
+import org.wso2.carbon.identity.recovery.util.Utils;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -31,6 +33,8 @@ import java.nio.file.Paths;
 import java.util.Properties;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE;
 
 /**
  * Unit tests for RecoveryUtils.java
@@ -57,4 +61,47 @@ public class RecoveryUtilsTest {
         assertEquals(properties, sampleProperties);
         assertEquals(properties.size(), sampleProperties.size());
     }
+
+    @Test(description = "Test the password reset API error format.")
+    public void testHandleClientExceptionWithData() {
+
+        String data = "Invalid password format";
+        String message = "invalid_value";
+        Throwable cause = new Throwable("Invalid password format");
+
+        IdentityRecoveryClientException exception;
+        try {
+            exception = Utils.handleClientException(ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE, data, message, cause);
+        } catch (IdentityRecoveryClientException e) {
+            throw new RuntimeException(e);
+        }
+
+        assertNotNull(exception);
+        assertEquals(exception.getErrorCode(), ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE.getCode());
+        assertEquals(exception.getMessage(), message);
+        assertEquals(exception.getDescription(), data);
+        assertEquals(cause, exception.getCause());
+    }
+
+    @Test
+    public void testHandleClientExceptionWithoutData() {
+
+        String data = null;
+        String message = "Test message";
+        Throwable cause = new Throwable("Cause of the error");
+
+        IdentityRecoveryClientException exception;
+        try {
+            exception = Utils.handleClientException(ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE, data, message, cause);
+        } catch (IdentityRecoveryClientException e) {
+            throw new RuntimeException(e);
+        }
+
+        assertNotNull(exception);
+        assertEquals(exception.getErrorCode(), ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE.getCode());
+        assertEquals(exception.getMessage(), message);
+        assertEquals(exception.getDescription(), ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE.getMessage());
+        assertEquals(cause, exception.getCause());
+    }
+
 }

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtilsTest.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtilsTest.java
@@ -71,8 +71,8 @@ public class RecoveryUtilsTest {
 
         IdentityRecoveryClientException exception;
         try {
-            exception = Utils.handleClientException(ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE, description, message,
-                    cause);
+            exception = Utils.handleClientException(ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE.getCode(), message,
+                    description, cause);
         } catch (IdentityRecoveryClientException e) {
             throw new RuntimeException(e);
         }
@@ -93,7 +93,8 @@ public class RecoveryUtilsTest {
         IdentityRecoveryClientException exception;
         try {
             exception =
-                    Utils.handleClientException(ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE, null, message, cause);
+                    Utils.handleClientException(ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE.getCode(), message, null,
+                            cause);
         } catch (IdentityRecoveryClientException e) {
             throw new RuntimeException(e);
         }
@@ -101,7 +102,7 @@ public class RecoveryUtilsTest {
         assertNotNull(exception);
         assertEquals(exception.getErrorCode(), ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE.getCode());
         assertEquals(exception.getMessage(), message);
-        assertEquals(exception.getDescription(), ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE.getMessage());
+        assertEquals(exception.getDescription(), null);
         assertEquals(cause, exception.getCause());
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryClientException.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryClientException.java
@@ -27,23 +27,28 @@ public class IdentityRecoveryClientException extends IdentityRecoveryException {
 
     private static final long serialVersionUID = -8248805950312129249L;
 
-    public IdentityRecoveryClientException(String errorDescription) {
-        super(errorDescription);
+    public IdentityRecoveryClientException(String message) {
+
+        super(message);
     }
 
-    public IdentityRecoveryClientException(String errorDescription, Throwable cause) {
-        super(errorDescription, cause);
+    public IdentityRecoveryClientException(String message, Throwable cause) {
+
+        super(message, cause);
     }
 
     public IdentityRecoveryClientException(String errorCode, String message) {
+
         super(errorCode, message);
     }
 
     public IdentityRecoveryClientException(String errorCode, String message, Throwable throwable) {
+
         super(errorCode, message, throwable);
     }
 
     public IdentityRecoveryClientException(String errorCode, String message, String description, Throwable throwable) {
+
         super(errorCode, message, throwable);
         this.description = description;
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryClientException.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryClientException.java
@@ -23,6 +23,8 @@ package org.wso2.carbon.identity.recovery;
  */
 public class IdentityRecoveryClientException extends IdentityRecoveryException {
 
+    String description;
+
     private static final long serialVersionUID = -8248805950312129249L;
 
     public IdentityRecoveryClientException(String errorDescription) {
@@ -41,4 +43,13 @@ public class IdentityRecoveryClientException extends IdentityRecoveryException {
         super(errorCode, message, throwable);
     }
 
+    public IdentityRecoveryClientException(String errorCode, String message, String description, Throwable throwable) {
+        super(errorCode, message, throwable);
+        this.description = description;
+    }
+
+    public String getDescription() {
+
+        return description;
+    }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -62,6 +62,7 @@ import org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.util.Utils;
 import org.wso2.carbon.identity.user.action.api.constant.UserActionError;
+import org.wso2.carbon.identity.user.action.api.exception.UserActionExecutionClientException;
 import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
@@ -1065,8 +1066,13 @@ public class NotificationPasswordRecoveryManager {
 
             if (cause instanceof UserStoreClientException && ((UserStoreClientException) cause).getErrorCode()
                     .equals(UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED)) {
+
+                String description = cause.getMessage();
+                if (cause instanceof UserActionExecutionClientException) {
+                    description = ((UserActionExecutionClientException) cause).getDescription();
+                }
                 throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages
-                        .ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE, cause.getMessage(), cause);
+                        .ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE, description, cause);
             }
             cause = cause.getCause();
         }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -1068,9 +1068,9 @@ public class NotificationPasswordRecoveryManager {
                             .equals(UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED)) {
 
                 throw Utils.handleClientException(
-                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE,
-                        ((UserActionExecutionClientException) cause).getDescription(),
-                        ((UserActionExecutionClientException) cause).getError(), cause);
+                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE.getCode(),
+                        ((UserActionExecutionClientException) cause).getError(),
+                        ((UserActionExecutionClientException) cause).getDescription(), cause);
             }
             cause = cause.getCause();
         }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -66,7 +66,6 @@ import org.wso2.carbon.identity.user.action.api.exception.UserActionExecutionCli
 import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
-import org.wso2.carbon.user.core.UserStoreClientException;
 import org.wso2.carbon.user.core.service.RealmService;
 
 import java.io.UnsupportedEncodingException;
@@ -1064,15 +1063,14 @@ public class NotificationPasswordRecoveryManager {
                         cause.getMessage(), e);
             }
 
-            if (cause instanceof UserStoreClientException && ((UserStoreClientException) cause).getErrorCode()
-                    .equals(UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED)) {
+            if (cause instanceof UserActionExecutionClientException &&
+                    ((UserActionExecutionClientException) cause).getErrorCode()
+                            .equals(UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED)) {
 
-                String description = cause.getMessage();
-                if (cause instanceof UserActionExecutionClientException) {
-                    description = ((UserActionExecutionClientException) cause).getDescription();
-                }
-                throw Utils.handleClientException(IdentityRecoveryConstants.ErrorMessages
-                        .ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE, description, cause);
+                throw Utils.handleClientException(
+                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE,
+                        ((UserActionExecutionClientException) cause).getDescription(),
+                        ((UserActionExecutionClientException) cause).getError(), cause);
             }
             cause = cause.getCause();
         }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -441,6 +441,35 @@ public class Utils {
     }
 
     /**
+     * Handles client exceptions by creating an instance of {@link IdentityRecoveryClientException}
+     * with the specified error details.
+     * If the provided data is not blank, it is formatted into the error message; otherwise,
+     * the default error message is used.
+     *
+     * @param error   The predefined error message from {@link IdentityRecoveryConstants.ErrorMessages}.
+     * @param data    Additional data to be included in the error message (can be {@code null} or blank).
+     * @param message A brief message describing the error.
+     * @param e       The underlying cause of the exception.
+     * @return An instance of {@link IdentityRecoveryClientException} with the provided details.
+     * @throws IdentityRecoveryClientException If an error occurs while instantiating the exception.
+     */
+    public static IdentityRecoveryClientException handleClientException(IdentityRecoveryConstants.ErrorMessages error,
+                                                                        String data,
+                                                                        String message,
+                                                                        Throwable e)
+            throws IdentityRecoveryClientException {
+
+        String errorDescription;
+        if (StringUtils.isNotBlank(data)) {
+            errorDescription = String.format(error.getMessage(), data);
+        } else {
+            errorDescription = error.getMessage();
+        }
+
+        return IdentityException.error(IdentityRecoveryClientException.class, error.getCode(), message, errorDescription, e);
+    }
+
+    /**
      * Handle Client Exceptions.
      *
      * @param errorCode    Error code of the exception

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -446,35 +446,6 @@ public class Utils {
      * If the provided data is not blank, it is formatted into the error message; otherwise,
      * the default error message is used.
      *
-     * @param error   The predefined error message from {@link IdentityRecoveryConstants.ErrorMessages}.
-     * @param data    Additional data to be included in the error message (can be {@code null} or blank).
-     * @param message A brief message describing the error.
-     * @param e       The underlying cause of the exception.
-     * @return An instance of {@link IdentityRecoveryClientException} with the provided details.
-     * @throws IdentityRecoveryClientException If an error occurs while instantiating the exception.
-     */
-    public static IdentityRecoveryClientException handleClientException(IdentityRecoveryConstants.ErrorMessages error,
-                                                                        String data,
-                                                                        String message,
-                                                                        Throwable e)
-            throws IdentityRecoveryClientException {
-
-        String errorDescription;
-        if (StringUtils.isNotBlank(data)) {
-            errorDescription = String.format(error.getMessage(), data);
-        } else {
-            errorDescription = error.getMessage();
-        }
-
-        return IdentityException.error(IdentityRecoveryClientException.class, error.getCode(), message, errorDescription, e);
-    }
-
-    /**
-     * Handles client exceptions by creating an instance of {@link IdentityRecoveryClientException}
-     * with the specified error details.
-     * If the provided data is not blank, it is formatted into the error message; otherwise,
-     * the default error message is used.
-     *
      * @param code        The predefined error code.
      * @param message     A brief message describing the error.
      * @param description A detailed description of the error.

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -470,6 +470,26 @@ public class Utils {
     }
 
     /**
+     * Handles client exceptions by creating an instance of {@link IdentityRecoveryClientException}
+     * with the specified error details.
+     * If the provided data is not blank, it is formatted into the error message; otherwise,
+     * the default error message is used.
+     *
+     * @param code        The predefined error code.
+     * @param message     A brief message describing the error.
+     * @param description A detailed description of the error.
+     * @param e           The underlying cause of the exception.
+     * @return An instance of {@link IdentityRecoveryClientException} with the provided details.
+     * @throws IdentityRecoveryClientException If an error occurs while instantiating the exception.
+     */
+    public static IdentityRecoveryClientException handleClientException(String code, String message, String description,
+                                                                        Throwable e)
+            throws IdentityRecoveryClientException {
+
+        return IdentityException.error(IdentityRecoveryClientException.class, code, message, description, e);
+    }
+
+    /**
      * Handle Client Exceptions.
      *
      * @param errorCode    Error code of the exception

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManagerTest.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.RecoveryScenarios;
@@ -43,23 +44,32 @@ import org.wso2.carbon.identity.recovery.model.UserRecoveryData;
 import org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
 import org.wso2.carbon.identity.recovery.util.Utils;
+import org.wso2.carbon.identity.user.action.api.exception.UserActionExecutionClientException;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.UserStoreClientException;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.identity.event.event.Event;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.security.PrivilegedActionException;
 import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY;
 import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ConnectorConfig.PASSWORD_RECOVERY_SEND_OTP_IN_EMAIL;
 
@@ -79,6 +89,10 @@ public class NotificationPasswordRecoveryManagerTest {
     private static final String USER_STORE_DOMAIN = "PRIMARY";
     private static final String TRUE_STRING = "true";
     private static final int TENANT_ID = 1234;
+
+    public static final String PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED = "USER-ACTION-PRE-UPDATE-PASSWORD-60001";
+    public static final String EXTENSION_ERROR_MESSAGE = "invalid_password";
+    public static final String EXTENSION_ERROR_DESCRIPTION = "Invalid password format";
 
     @Mock
     private IdentityGovernanceService identityGovernanceService;
@@ -253,5 +267,62 @@ public class NotificationPasswordRecoveryManagerTest {
         organizationManagementUtilMockedStatic.close();
         jdbcRecoveryDataStoreMockedStatic.close();
 
+    }
+
+    @Test
+    public void testUpdateNewPassword_checkPasswordValidityIsTriggered() throws Exception {
+
+        NotificationPasswordRecoveryManager manager = NotificationPasswordRecoveryManager.getInstance();
+
+        User user = new User();
+        user.setTenantDomain("carbon.super");
+
+        UserRecoveryData recoveryData = mock(UserRecoveryData.class);
+        when(recoveryData.getUser()).thenReturn(user);
+
+        try (MockedStatic<IdentityTenantUtil> tenantUtilMock = mockStatic(IdentityTenantUtil.class)) {
+            tenantUtilMock.when(() -> IdentityTenantUtil.getTenantId("carbon.super")).thenReturn(-1234);
+
+            RealmService realmService = mock(RealmService.class);
+            UserRealm userRealm = mock(UserRealm.class);
+            UserStoreManager userStoreManager = mock(UserStoreManager.class);
+
+            when(realmService.getTenantUserRealm(-1234)).thenReturn(userRealm);
+            IdentityRecoveryServiceDataHolder.getInstance().setRealmService(realmService);
+
+            when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+            doThrow(buildUserStoreException()).when(userStoreManager).updateCredentialByAdmin(anyString(), anyString());
+
+            Method method = NotificationPasswordRecoveryManager.class.getDeclaredMethod(
+                    "updateNewPassword", User.class, String.class, String.class, UserRecoveryData.class, boolean.class);
+            method.setAccessible(true);
+
+            try {
+                method.invoke(manager, user, "Password@123!", "user1", recoveryData, false);
+                fail("Expected an IdentityRecoveryClientException was not thrown");
+            } catch (InvocationTargetException ex) {
+                Throwable actual = ex.getCause();
+
+                assertTrue(actual instanceof IdentityRecoveryClientException);
+                IdentityRecoveryClientException identityRecoveryClientException =
+                        (IdentityRecoveryClientException) actual;
+
+                assertEquals(identityRecoveryClientException.getErrorCode(),
+                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE.getCode());
+                assertEquals(identityRecoveryClientException.getMessage(), EXTENSION_ERROR_MESSAGE);
+                assertEquals(identityRecoveryClientException.getDescription(), EXTENSION_ERROR_DESCRIPTION);
+            }
+        }
+    }
+
+    private UserStoreException buildUserStoreException() {
+
+        UserActionExecutionClientException userActionExecutionClientException =
+                new UserActionExecutionClientException(PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED,
+                        EXTENSION_ERROR_MESSAGE, EXTENSION_ERROR_DESCRIPTION);
+        InvocationTargetException invocationTargetException =
+                new InvocationTargetException(userActionExecutionClientException);
+        PrivilegedActionException privilegedActionException = new PrivilegedActionException(invocationTargetException);
+        return new UserStoreClientException(privilegedActionException);
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManagerTest.java
@@ -90,9 +90,9 @@ public class NotificationPasswordRecoveryManagerTest {
     private static final String TRUE_STRING = "true";
     private static final int TENANT_ID = 1234;
 
-    public static final String PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED = "USER-ACTION-PRE-UPDATE-PASSWORD-60001";
-    public static final String EXTENSION_ERROR_MESSAGE = "invalid_password";
-    public static final String EXTENSION_ERROR_DESCRIPTION = "Invalid password format";
+    private static final String PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED = "USER-ACTION-PRE-UPDATE-PASSWORD-60001";
+    private static final String EXTENSION_ERROR_MESSAGE = "invalid_password";
+    private static final String EXTENSION_ERROR_DESCRIPTION = "Invalid password format";
 
     @Mock
     private IdentityGovernanceService identityGovernanceService;
@@ -270,7 +270,7 @@ public class NotificationPasswordRecoveryManagerTest {
     }
 
     @Test
-    public void testUpdateNewPassword_checkPasswordValidityIsTriggered() throws Exception {
+    public void testUpdateNewPasswordCheckPasswordValidityIsTriggered() throws Exception {
 
         NotificationPasswordRecoveryManager manager = NotificationPasswordRecoveryManager.getInstance();
 
@@ -291,7 +291,8 @@ public class NotificationPasswordRecoveryManagerTest {
             IdentityRecoveryServiceDataHolder.getInstance().setRealmService(realmService);
 
             when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
-            doThrow(buildUserStoreException()).when(userStoreManager).updateCredentialByAdmin(anyString(), anyString());
+            doThrow(buildExceptionForPreUpdatePasswordActionFailure()).when(userStoreManager)
+                    .updateCredentialByAdmin(anyString(), anyString());
 
             Method method = NotificationPasswordRecoveryManager.class.getDeclaredMethod("updateNewPassword", User.class,
                     String.class, String.class, UserRecoveryData.class, boolean.class);
@@ -315,7 +316,7 @@ public class NotificationPasswordRecoveryManagerTest {
         }
     }
 
-    private UserStoreException buildUserStoreException() {
+    private UserStoreException buildExceptionForPreUpdatePasswordActionFailure() {
 
         UserActionExecutionClientException userActionExecutionClientException =
                 new UserActionExecutionClientException(PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED,

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManagerTest.java
@@ -270,7 +270,7 @@ public class NotificationPasswordRecoveryManagerTest {
     }
 
     @Test
-    public void testUpdateNewPasswordCheckPasswordValidityIsTriggered() throws Exception {
+    public void testExceptionThrownAtPreUpdatePasswordValidationFailure() throws Exception {
 
         NotificationPasswordRecoveryManager manager = NotificationPasswordRecoveryManager.getInstance();
 

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManagerTest.java
@@ -293,8 +293,8 @@ public class NotificationPasswordRecoveryManagerTest {
             when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
             doThrow(buildUserStoreException()).when(userStoreManager).updateCredentialByAdmin(anyString(), anyString());
 
-            Method method = NotificationPasswordRecoveryManager.class.getDeclaredMethod(
-                    "updateNewPassword", User.class, String.class, String.class, UserRecoveryData.class, boolean.class);
+            Method method = NotificationPasswordRecoveryManager.class.getDeclaredMethod("updateNewPassword", User.class,
+                    String.class, String.class, UserRecoveryData.class, boolean.class);
             method.setAccessible(true);
 
             try {


### PR DESCRIPTION
Improving the 400 bad request error for password reset flow

This PR should not merge without the version bump of below.

- https://github.com/wso2/carbon-identity-framework/pull/6665

Prent issue:
- https://github.com/wso2/product-is/issues/23729

Framework version bump
- https://github.com/wso2-extensions/identity-governance/pull/937