### PR TITLE
Unlock user accounts during admin-initiated password resets based on lock reason and support reinitiating the ask password flow

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2016-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.user.endpoint.ResendCodeApiService;
 import org.wso2.carbon.identity.user.endpoint.dto.ErrorDTO;
 import org.wso2.carbon.identity.user.endpoint.dto.PropertyDTO;
 import org.wso2.carbon.identity.user.endpoint.dto.ResendCodeRequestDTO;
+import org.wso2.carbon.identity.user.endpoint.dto.UserDTO;
 import org.wso2.carbon.identity.user.endpoint.util.Utils;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
@@ -44,7 +45,10 @@ import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
 import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.user.endpoint.util.Utils.getUserClaim;
 
 /**
  * This class contains the implementation of Resend Code API Service.
@@ -127,11 +131,24 @@ public class ResendCodeApiServiceImpl extends ResendCodeApiService {
                                                               ResendCodeRequestDTO resendCodeRequestDTO) {
 
         UserRecoveryData userRecoveryData = Utils.getUserRecoveryData(resendCodeRequestDTO, recoveryScenario);
+        ResendConfirmationManager resendConfirmationManager;
+
         if (userRecoveryData == null) {
+            // If the recovery scenario is ASK_PASSWORD and the user's account state is pending ask password,
+            // reinitiate "Ask password" flow even though recovery data is absent.
+            if (RecoveryScenarios.ASK_PASSWORD.toString().equals(recoveryScenario)
+                    && isUserInPendingAskPasswordState(resendCodeRequestDTO.getUser())) {
+                resendConfirmationManager = Utils.getResendConfirmationManager();
+                notificationResponseBean = setNotificationResponseBean(resendConfirmationManager,
+                        RecoveryScenarios.ASK_PASSWORD.toString(),
+                        RecoverySteps.UPDATE_PASSWORD.toString(),
+                        IdentityRecoveryConstants.NOTIFICATION_TYPE_RESEND_ASK_PASSWORD,
+                        resendCodeRequestDTO);
+            }
             return notificationResponseBean;
         }
 
-        ResendConfirmationManager resendConfirmationManager = Utils.getResendConfirmationManager();
+        resendConfirmationManager = Utils.getResendConfirmationManager();
         if (RecoveryScenarios.ASK_PASSWORD.toString().equals(recoveryScenario) &&
                 RecoveryScenarios.ASK_PASSWORD.equals(userRecoveryData.getRecoveryScenario()) &&
                 RecoverySteps.UPDATE_PASSWORD.equals(userRecoveryData.getRecoveryStep())) {
@@ -270,4 +287,19 @@ public class ResendCodeApiServiceImpl extends ResendCodeApiService {
         return tenantDomain;
     }
 
+    /**
+     * Determines if a user's account is in a state where they need to set a password
+     * through the ask password flow.
+     *
+     * @param user User object containing user information.
+     * @return true if the user is in pending ask password state, false otherwise.
+     */
+    private boolean isUserInPendingAskPasswordState(UserDTO user) {
+        
+        String accountState = getUserClaim(user, IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI, LOG);
+        if (StringUtils.isBlank(accountState)) {
+            return false;
+        }
+        return IdentityRecoveryConstants.PENDING_ASK_PASSWORD.equals(accountState);
+    }
 }

--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImpl.java
@@ -308,8 +308,9 @@ public class ResendCodeApiServiceImpl extends ResendCodeApiService {
      * @return true if the user is in pending ask password state, false otherwise.
      */
     private boolean isUserInPendingAskPasswordState(UserDTO user) {
-        
-        String accountState = getUserClaim(user, IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI, LOG);
+
+        String domainQualifiedUsername = UserCoreUtil.addDomainToName(user.getUsername(), user.getRealm());
+        String accountState = Utils.getAccountState(domainQualifiedUsername, user.getTenantDomain());
         if (StringUtils.isBlank(accountState)) {
             return false;
         }

--- a/components/org.wso2.carbon.identity.api.user.governance/src/test/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/test/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImplTest.java
@@ -156,7 +156,7 @@ public class ResendCodeApiServiceImplTest {
         ResendCodeRequestDTO requestDTO = createResendCodeRequestDTO(RecoveryScenarios.ASK_PASSWORD.name());
 
         mockedUtils.when(() -> Utils.getUserRecoveryData(any(), anyString())).thenReturn(null);
-        mockedUtils.when(() -> Utils.getUserClaim(any(UserDTO.class), anyString(), any()))
+        mockedUtils.when(() -> Utils.getAccountState(anyString(), anyString()))
                 .thenReturn(IdentityRecoveryConstants.PENDING_ASK_PASSWORD);
         mockedUtils.when(Utils::getResendConfirmationManager).thenReturn(resendConfirmationManager);
 
@@ -188,7 +188,7 @@ public class ResendCodeApiServiceImplTest {
         ResendCodeRequestDTO requestDTO = createResendCodeRequestDTO(RecoveryScenarios.ASK_PASSWORD.name());
 
         mockedUtils.when(() -> Utils.getUserRecoveryData(any(), anyString())).thenReturn(null);
-        mockedUtils.when(() -> Utils.getUserClaim(any(UserDTO.class), anyString(), any()))
+        mockedUtils.when(() -> Utils.getAccountState(anyString(), anyString()))
                 .thenReturn(IdentityRecoveryConstants.PENDING_SELF_REGISTRATION);
         mockedUtils.when(Utils::getResendConfirmationManager).thenReturn(resendConfirmationManager);
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
@@ -493,7 +493,7 @@ public class ResendConfirmationManager {
         String storedNotificationChannel = StringUtils.EMPTY;
         if (userRecoveryData == null &&
                 RecoveryScenarios.ASK_PASSWORD.equals(RecoveryScenarios.getRecoveryScenario(recoveryScenario)) &&
-                Utils.isUserInPendingAskPasswordState(user)) {
+                isUserInPendingAskPasswordState(user)) {
                 storedNotificationChannel = NotificationChannels.EMAIL_CHANNEL.getChannelType();
         } else if (!RecoveryScenarios.LITE_SIGN_UP.toString().equals(recoveryScenario)) {
             // Validate the previous confirmation code with the data retrieved by the user recovery information.
@@ -766,5 +766,21 @@ public class ResendConfirmationManager {
                     identityRecoveryClientException.getMessage());
         }
 
+    }
+
+    /**
+     * Determines if a user's account is in a state where they need to set a password
+     * through the ask password flow.
+     *
+     * @param user User object containing user information
+     * @return true if the user is in pending ask password state, false otherwise
+     */
+    private boolean isUserInPendingAskPasswordState(User user) {
+
+        String accountState = Utils.getAccountStateForUserNameWithoutUserDomain(user);
+        if (StringUtils.isBlank(accountState)) {
+            return false;
+        }
+        return IdentityRecoveryConstants.PENDING_ASK_PASSWORD.equals(accountState);
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017-2025, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -491,7 +491,11 @@ public class ResendConfirmationManager {
                 RecoveryScenarios.getRecoveryScenario(recoveryScenario));
 
         String storedNotificationChannel = StringUtils.EMPTY;
-        if (!RecoveryScenarios.LITE_SIGN_UP.toString().equals(recoveryScenario)) {
+        if (userRecoveryData == null &&
+                RecoveryScenarios.ASK_PASSWORD.equals(RecoveryScenarios.getRecoveryScenario(recoveryScenario)) &&
+                Utils.isUserInPendingAskPasswordState(user)) {
+                storedNotificationChannel = NotificationChannels.EMAIL_CHANNEL.getChannelType();
+        } else if (!RecoveryScenarios.LITE_SIGN_UP.toString().equals(recoveryScenario)) {
             // Validate the previous confirmation code with the data retrieved by the user recovery information.
             validateWithOldConfirmationCode(code, recoveryScenario, recoveryStep, userRecoveryData);
             // Get the notification channel details stored in the remainingSetIds.

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AdminForcedPasswordResetHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AdminForcedPasswordResetHandler.java
@@ -1,17 +1,19 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations und
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.recovery.handler;

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1909,42 +1909,6 @@ public class Utils {
     }
 
     /**
-     * Retrieve values of multiple claims for a given user from the user store.
-     *
-     * @param user   User object containing user information.
-     * @param claims Array of claim URIs to retrieve for the user.
-     * @return Map of claim URIs to their corresponding values.
-     * @throws IdentityRecoveryServerException If an error occurs while retrieving the claim values.
-     */
-    public static Map<String, String> getUserClaimValues(User user, String[] claims)
-            throws IdentityRecoveryServerException {
-
-        String userStoreDomain = user.getUserStoreDomain();
-        RealmService realmService = IdentityRecoveryServiceDataHolder.getInstance().getRealmService();
-        try {
-            org.wso2.carbon.user.api.UserRealm userRealm =
-                    realmService.getTenantUserRealm(IdentityTenantUtil.getTenantId(user.getTenantDomain()));
-            UserStoreManager userStoreManager = userRealm.getUserStoreManager();
-
-            if (userStoreManager == null) {
-                throw new IdentityRecoveryServerException(String.format("userStoreManager is null for user: " +
-                        "%s in tenant domain : %s", maskIfRequired(user.getUserName()), user.getTenantDomain()));
-            }
-            if (StringUtils.isNotBlank(userStoreDomain) && !PRIMARY_DEFAULT_DOMAIN_NAME.equals(userStoreDomain)) {
-                userStoreManager =
-                        ((AbstractUserStoreManager) userStoreManager).getSecondaryUserStoreManager(userStoreDomain);
-            }
-
-            return userStoreManager.getUserClaimValues(user.getUserName(), claims, null);
-
-        } catch (UserStoreException e) {
-            String error = String.format("Error occurred while retrieving claim values for user: " +
-                    "%s in tenant domain : %s", maskIfRequired(user.getUserName()), user.getTenantDomain());
-            throw new IdentityRecoveryServerException(error, e);
-        }
-    }
-
-    /**
      * Retrieves the existing multi-valued claims for a given claim URI.
      *
      * @param userStoreManager User store manager.
@@ -1968,26 +1932,5 @@ public class Utils {
             throw new IdentityEventException("Error retrieving claim " + claimURI +
                     " for user: " + user.toFullQualifiedUsername(), e);
         }
-    }
-
-    /**
-     * Determines if a user's account is in a state where they need to set a password
-     * through the ask password flow.
-     *
-     * @param user User object containing user information
-     * @return true if the user is in pending ask password state, false otherwise
-     */
-    public static boolean isUserInPendingAskPasswordState(User user) throws IdentityRecoveryServerException {
-
-        String accountState = null;
-        Map<String, String> claimValueMap =
-                getUserClaimValues(user, new String[]{IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI});
-        if (claimValueMap != null && claimValueMap.containsKey(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI)) {
-            accountState = claimValueMap.get(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI);
-        }
-        if (StringUtils.isBlank(accountState)) {
-            return false;
-        }
-        return IdentityRecoveryConstants.PENDING_ASK_PASSWORD.equals(accountState);
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1874,6 +1874,7 @@ public class Utils {
 
     /**
      * Retrieve user claim of the user.
+     * Note : This method cannot be used to retrieve identity claim values of the user.
      *
      * @param user      User from whom the claim needs to be retrieved.
      * @param userClaim Claim URI of the user.
@@ -1908,6 +1909,42 @@ public class Utils {
     }
 
     /**
+     * Retrieve values of multiple claims for a given user from the user store.
+     *
+     * @param user   User object containing user information.
+     * @param claims Array of claim URIs to retrieve for the user.
+     * @return Map of claim URIs to their corresponding values.
+     * @throws IdentityRecoveryServerException If an error occurs while retrieving the claim values.
+     */
+    public static Map<String, String> getUserClaimValues(User user, String[] claims)
+            throws IdentityRecoveryServerException {
+
+        String userStoreDomain = user.getUserStoreDomain();
+        RealmService realmService = IdentityRecoveryServiceDataHolder.getInstance().getRealmService();
+        try {
+            org.wso2.carbon.user.api.UserRealm userRealm =
+                    realmService.getTenantUserRealm(IdentityTenantUtil.getTenantId(user.getTenantDomain()));
+            UserStoreManager userStoreManager = userRealm.getUserStoreManager();
+
+            if (userStoreManager == null) {
+                throw new IdentityRecoveryServerException(String.format("userStoreManager is null for user: " +
+                        "%s in tenant domain : %s", maskIfRequired(user.getUserName()), user.getTenantDomain()));
+            }
+            if (StringUtils.isNotBlank(userStoreDomain) && !PRIMARY_DEFAULT_DOMAIN_NAME.equals(userStoreDomain)) {
+                userStoreManager =
+                        ((AbstractUserStoreManager) userStoreManager).getSecondaryUserStoreManager(userStoreDomain);
+            }
+
+            return userStoreManager.getUserClaimValues(user.getUserName(), claims, null);
+
+        } catch (UserStoreException e) {
+            String error = String.format("Error occurred while retrieving claim values for user: " +
+                    "%s in tenant domain : %s", maskIfRequired(user.getUserName()), user.getTenantDomain());
+            throw new IdentityRecoveryServerException(error, e);
+        }
+    }
+
+    /**
      * Retrieves the existing multi-valued claims for a given claim URI.
      *
      * @param userStoreManager User store manager.
@@ -1931,5 +1968,26 @@ public class Utils {
             throw new IdentityEventException("Error retrieving claim " + claimURI +
                     " for user: " + user.toFullQualifiedUsername(), e);
         }
+    }
+
+    /**
+     * Determines if a user's account is in a state where they need to set a password
+     * through the ask password flow.
+     *
+     * @param user User object containing user information
+     * @return true if the user is in pending ask password state, false otherwise
+     */
+    public static boolean isUserInPendingAskPasswordState(User user) throws IdentityRecoveryServerException {
+
+        String accountState = null;
+        Map<String, String> claimValueMap =
+                getUserClaimValues(user, new String[]{IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI});
+        if (claimValueMap != null && claimValueMap.containsKey(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI)) {
+            accountState = claimValueMap.get(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI);
+        }
+        if (StringUtils.isBlank(accountState)) {
+            return false;
+        }
+        return IdentityRecoveryConstants.PENDING_ASK_PASSWORD.equals(accountState);
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/AdminForcedPasswordResetHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/AdminForcedPasswordResetHandlerTest.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.recovery.handler;
+
+import org.apache.commons.lang.StringUtils;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.governance.IdentityMgtConstants;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
+import org.wso2.carbon.identity.recovery.RecoveryScenarios;
+import org.wso2.carbon.identity.recovery.RecoverySteps;
+import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
+import org.wso2.carbon.identity.recovery.model.UserRecoveryData;
+import org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStore;
+import org.wso2.carbon.identity.recovery.store.UserRecoveryDataStore;
+import org.wso2.carbon.identity.recovery.util.Utils;
+import org.wso2.carbon.user.api.ClaimManager;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.config.RealmConfiguration;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.tenant.TenantManager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+/**
+ * Unit tests for AdminForcedPasswordResetHandler.
+ */
+public class AdminForcedPasswordResetHandlerTest {
+
+    private static final String TEST_USERNAME = "testUser";
+    private static final String MASKED_TEST_USERNAME = "t******r";
+    private static final String TEST_TENANT_DOMAIN = "carbon.super";
+    private static final String TEST_USER_STORE_DOMAIN = "PRIMARY";
+    private static final int TEST_TENANT_ID = 1;
+    private static final String TEST_DUMMY_CODE = "dummy-code";
+    private static final RecoverySteps UPDATE_PASSWORD_RECOVERY_STEP = RecoverySteps.UPDATE_PASSWORD;
+    private static final String EXPECTED_ACCOUNT_LOCK_ERROR_MESSAGE_PATTERN =
+            "Error while handling account unlock on admin password update for user: t\\*\\*\\*\\*\\*\\*r";
+
+    @Mock
+    private UserStoreManager userStoreManager;
+
+    @Mock
+    private RealmConfiguration realmConfiguration;
+
+    @Mock
+    private ClaimManager claimManager;
+
+    @Mock
+    private RealmService realmService;
+
+    @Mock
+    private UserRealm userRealm;
+
+    @Mock
+    private TenantManager tenantManager;
+
+    @Mock
+    private UserRecoveryDataStore userRecoveryDataStore;
+
+    @Mock
+    private IdentityEventService identityEventService;
+
+    @Mock
+    private IdentityRecoveryServiceDataHolder serviceDataHolder;
+
+    private AdminForcedPasswordResetHandler adminForcedPasswordResetHandler;
+    private MockedStatic<Utils> mockedUtils;
+    private MockedStatic<JDBCRecoveryDataStore> mockedJDBCRecoveryDataStore;
+    private MockedStatic<IdentityRecoveryServiceDataHolder> mockedIdentityRecoveryServiceDataHolder;
+    private MockedStatic<IdentityTenantUtil> mockedIdentityTenantUtil;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        MockitoAnnotations.openMocks(this);
+        adminForcedPasswordResetHandler = new AdminForcedPasswordResetHandler();
+
+        mockedUtils = mockStatic(Utils.class);
+        mockedJDBCRecoveryDataStore = mockStatic(JDBCRecoveryDataStore.class);
+        mockedIdentityRecoveryServiceDataHolder = mockStatic(IdentityRecoveryServiceDataHolder.class);
+        mockedIdentityTenantUtil = mockStatic(IdentityTenantUtil.class);
+
+        mockedJDBCRecoveryDataStore.when(JDBCRecoveryDataStore::getInstance).thenReturn(userRecoveryDataStore);
+        mockedIdentityRecoveryServiceDataHolder.when(IdentityRecoveryServiceDataHolder::getInstance)
+                .thenReturn(serviceDataHolder);
+        mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(TEST_TENANT_ID);
+
+        when(serviceDataHolder.getRealmService()).thenReturn(realmService);
+        when(serviceDataHolder.getIdentityEventService()).thenReturn(identityEventService);
+        when(realmService.getTenantManager()).thenReturn(tenantManager);
+        when(tenantManager.getTenantId(TEST_TENANT_DOMAIN)).thenReturn(TEST_TENANT_ID);
+        when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
+        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+        when(userRealm.getClaimManager()).thenReturn(claimManager);
+        when(userStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
+        when(realmConfiguration.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME))
+                .thenReturn(TEST_USER_STORE_DOMAIN);
+        mockedUtils.when(() -> Utils.maskIfRequired(any())).thenReturn(MASKED_TEST_USERNAME);
+
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        mockedUtils.close();
+        mockedJDBCRecoveryDataStore.close();
+        mockedIdentityRecoveryServiceDataHolder.close();
+        mockedIdentityTenantUtil.close();
+    }
+
+    @Test
+    public void testGetNames() {
+
+        assertEquals(adminForcedPasswordResetHandler.getName(), "adminForcedPasswordReset");
+        assertEquals(adminForcedPasswordResetHandler.getFriendlyName(), "Admin Forced Password Reset");
+    }
+
+    @Test(description = "Test handleEvent() with POST_UPDATE_CREDENTIAL_BY_ADMIN event where no recovery data exists" +
+            "and account is in unlocked state.")
+    public void testHandlePostUpdateCredentialByAdminWithUnlockedAccount() throws Exception {
+
+        Map<String, String> claims = new HashMap<>();
+        claims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.FALSE.toString());
+
+        Event event = createEvent(IdentityEventConstants.Event.POST_UPDATE_CREDENTIAL_BY_ADMIN);
+        mockUserClaims(claims, true);
+
+        when(userRecoveryDataStore.loadWithoutCodeExpiryValidation(any(User.class))).thenReturn(null);
+        
+        // Test the method.
+        adminForcedPasswordResetHandler.handleEvent(event);
+
+        // Verify claims were not updated since account is already unlocked.
+        verify(userStoreManager, never()).setUserClaimValues(eq(TEST_USERNAME), any(), any());
+        // Verify that invalidation was not called.
+        verify(userRecoveryDataStore, never()).invalidate(any(User.class));
+    }
+
+    @DataProvider(name = "askPasswordDataProvider")
+    public Object[][] getAskPasswordDataProvider() {
+
+        return new Object[][] {
+                {null, true},
+                {null, false},
+                {mockRecoveryData(RecoveryScenarios.ASK_PASSWORD), true},
+                {mockRecoveryData(RecoveryScenarios.ASK_PASSWORD), false}
+        };
+    }
+
+    @Test(description = "Test handleEvent() with POST_UPDATE_CREDENTIAL_BY_ADMIN event where the account is locked" +
+            "due to pending ask password.", dataProvider = "askPasswordDataProvider")
+    public void testHandlePostUpdateCredentialByAdminWithPendingAskPasswordLockedAccount
+            (UserRecoveryData recoveryData, boolean accountStateExists) throws Exception {
+
+        Map<String, String> claims = new HashMap<>();
+        claims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
+        claims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_REASON_CLAIM,
+                IdentityMgtConstants.LockedReason.PENDING_ASK_PASSWORD.toString());
+
+        Event event = createEvent(IdentityEventConstants.Event.POST_UPDATE_CREDENTIAL_BY_ADMIN);
+        mockUserClaims(claims, accountStateExists);
+
+        when(userRecoveryDataStore.loadWithoutCodeExpiryValidation(any(User.class))).thenReturn(recoveryData);
+
+        // Test the method.
+        adminForcedPasswordResetHandler.handleEvent(event);
+
+        // Verify claims were updated.
+        verifyClaimUpdates(accountStateExists);
+        if (recoveryData == null) {
+            // Verify that invalidation was not called.
+            verify(userRecoveryDataStore, never()).invalidate(any(User.class));
+        } else {
+            // Verify that invalidation was called.
+            verify(userRecoveryDataStore, times(1)).invalidate(any(User.class));
+        }
+    }
+
+    @DataProvider(name = "forcedPasswordRestDataProvider")
+    public Object[][] getForcedPasswordResetDataProvider() {
+
+        return new Object[][] {
+                {null, true},
+                {null, false},
+                {mockRecoveryData(RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_EMAIL_LINK), true},
+                {mockRecoveryData(RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_EMAIL_LINK), false},
+                {mockRecoveryData(RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_OTP), true},
+                {mockRecoveryData(RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_OTP), false}
+        };
+    }
+
+    @Test(description = "Test handleEvent() with POST_UPDATE_CREDENTIAL_BY_ADMIN event where the account is locked" +
+            "due to pending forced password reset.", dataProvider = "forcedPasswordRestDataProvider")
+    public void testHandlePostUpdateCredentialByAdminWithPendingForcedPasswordResetLockedAccount
+            (UserRecoveryData recoveryData, boolean accountStateExists) throws Exception {
+
+        Map<String, String> claims = new HashMap<>();
+        claims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
+        claims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_REASON_CLAIM,
+                IdentityMgtConstants.LockedReason.PENDING_ADMIN_FORCED_USER_PASSWORD_RESET.toString());
+
+        Event event = createEvent(IdentityEventConstants.Event.POST_UPDATE_CREDENTIAL_BY_ADMIN);
+        mockUserClaims(claims, accountStateExists);
+
+        when(userRecoveryDataStore.loadWithoutCodeExpiryValidation(any(User.class))).thenReturn(recoveryData);
+
+        // Test the method.
+        adminForcedPasswordResetHandler.handleEvent(event);
+
+        // Verify claims were updated.
+        verifyClaimUpdates(accountStateExists);
+        if (recoveryData == null) {
+            // Verify that invalidation was not called.
+            verify(userRecoveryDataStore, never()).invalidate(any(User.class));
+        } else {
+            // Verify that invalidation was called.
+            verify(userRecoveryDataStore, times(1)).invalidate(any(User.class));
+        }
+    }
+
+    @DataProvider(name = "accountStateExistsDataProvider")
+    public Object[][] getAccountStateExistsDataProvider() {
+
+        return new Object[][] {
+                {true},
+                {false},
+        };
+    }
+
+    @Test(description = "Test handleEvent() with POST_UPDATE_CREDENTIAL_BY_ADMIN event where the account is locked" +
+            "due to maximum attempts exceed.", dataProvider = "accountStateExistsDataProvider")
+    public void testHandlePostUpdateCredentialByAdminWithPendingForcedPasswordResetLockedAccount
+            (boolean accountStateExists) throws Exception {
+
+        Map<String, String> claims = new HashMap<>();
+        claims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
+        claims.put(IdentityRecoveryConstants.ACCOUNT_LOCKED_REASON_CLAIM,
+                IdentityMgtConstants.LockedReason.MAX_ATTEMPTS_EXCEEDED.toString());
+
+        Event event = createEvent(IdentityEventConstants.Event.POST_UPDATE_CREDENTIAL_BY_ADMIN);
+        mockUserClaims(claims, accountStateExists);
+
+        when(userRecoveryDataStore.loadWithoutCodeExpiryValidation(any(User.class))).thenReturn(null);
+
+        // Test the method.
+        adminForcedPasswordResetHandler.handleEvent(event);
+
+        // Verify claims were not updated since account is already unlocked.
+        verify(userStoreManager, never()).setUserClaimValues(eq(TEST_USERNAME), any(), any());
+        // Verify that invalidation was not called.
+        verify(userRecoveryDataStore, never()).invalidate(any(User.class));
+    }
+
+    @Test(description = "Test handleEvent() with POST_UPDATE_CREDENTIAL_BY_ADMIN event when getUserClaimValues " +
+            "throws exception",
+            expectedExceptions = {IdentityEventException.class},
+            expectedExceptionsMessageRegExp = EXPECTED_ACCOUNT_LOCK_ERROR_MESSAGE_PATTERN)
+    public void testHandlePostUpdateCredentialByAdminWithUserStoreException() throws Exception {
+
+        Event event = createEvent(IdentityEventConstants.Event.POST_UPDATE_CREDENTIAL_BY_ADMIN);
+        mockedUtils.when(() -> Utils.isAccountStateClaimExisting(TEST_TENANT_DOMAIN)).thenReturn(true);
+
+        UserStoreException userStoreException = new UserStoreException("Error retrieving user claims");
+        when(userStoreManager.getUserClaimValues(eq(TEST_USERNAME), any(), any())).thenThrow(userStoreException);
+        
+        // Test the method, which should throw IdentityEventException.
+        adminForcedPasswordResetHandler.handleEvent(event);
+    }
+
+    private Event createEvent(String eventName) {
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.USER_NAME, TEST_USERNAME);
+        eventProperties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, TEST_USER_STORE_DOMAIN);
+        eventProperties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, TEST_TENANT_DOMAIN);
+        eventProperties.put(IdentityEventConstants.EventProperty.USER_STORE_MANAGER, userStoreManager);
+        return new Event(eventName, eventProperties);
+    }
+
+    private void mockUserClaims(Map<String, String> claims, boolean accountStateExists) throws UserStoreException {
+
+        mockedUtils.when(() -> Utils.isAccountStateClaimExisting(TEST_TENANT_DOMAIN)).thenReturn(accountStateExists);
+        when(userStoreManager.getUserClaimValues(eq(TEST_USERNAME), any(), any())).thenReturn(claims);
+    }
+
+    private void verifyClaimUpdates(boolean accountStateExists) throws UserStoreException {
+
+        ArgumentCaptor<Map<String, String>> claimsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(userStoreManager, times(1)).setUserClaimValues(eq(TEST_USERNAME),
+                claimsCaptor.capture(), eq(null));
+
+        Map<String, String> updatedClaims = claimsCaptor.getValue();
+        if (accountStateExists) {
+            assertEquals(updatedClaims.get(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI),
+                    IdentityRecoveryConstants.ACCOUNT_STATE_UNLOCKED, "Account state should be set to UNLOCKED");
+        } else {
+            assertNull(updatedClaims.get(IdentityRecoveryConstants.ACCOUNT_STATE_CLAIM_URI),
+                    "Account state claim should not be set when not available");
+        }
+        assertEquals(updatedClaims.get(IdentityRecoveryConstants.ACCOUNT_LOCKED_CLAIM),
+                Boolean.FALSE.toString(), "Account locked claim should be set to false");
+        assertEquals(updatedClaims.get(IdentityRecoveryConstants.ACCOUNT_LOCKED_REASON_CLAIM),
+                StringUtils.EMPTY, "Account locked reason should be empty");
+    }
+
+    private UserRecoveryData mockRecoveryData(RecoveryScenarios recoveryScenario) {
+        
+        User user = new User();
+        user.setUserName(TEST_USERNAME);
+        user.setTenantDomain(TEST_TENANT_DOMAIN);
+        user.setUserStoreDomain(TEST_USER_STORE_DOMAIN);
+
+        return new UserRecoveryData(user, TEST_DUMMY_CODE, recoveryScenario, UPDATE_PASSWORD_RECOVERY_STEP);
+    }
+}

--- a/components/org.wso2.carbon.identity.recovery/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.recovery/src/test/resources/testng.xml
@@ -29,6 +29,7 @@
             <class name="org.wso2.carbon.identity.recovery.internal.service.impl.UserAccountRecoveryManagerTest"/>
             <class name="org.wso2.carbon.identity.recovery.internal.service.impl.username.UsernameRecoveryManagerImplTest"/>
             <class name="org.wso2.carbon.identity.recovery.util.UtilsTest"/>
+            <class name="org.wso2.carbon.identity.recovery.handler.AdminForcedPasswordResetHandlerTest"/>
             <class name="org.wso2.carbon.identity.recovery.handler.UserEmailVerificationHandlerTest" />
             <class name="org.wso2.carbon.identity.recovery.handler.UserSelfRegistrationHandlerTest"/>
             <class name="org.wso2.carbon.identity.recovery.confirmation.ResendConfirmationManagerTest" />


### PR DESCRIPTION
### Proposed changes in this pull request

- This PR replicates the state changes observed when a user updates their password during the ask password and password reset flows to administrator-initiated password updates. It introduces the following improvements:
    - Automatically unlock the user account upon an administrator's password update if it was locked due to pending password update scenarios, such as `PENDING_ASK_PASSWORD` or `PENDING_ADMIN_FORCED_USER_PASSWORD_RESET`.
 
    - Set the account state to `UNLOCKED` upon an administrator's password update when the account is in a pending ask password (`PENDING_AP`) state while remaining unlocked.
        - Note: This scenario is important for cases where account locking is disabled via the console during user invitations for setting up password.
- Further it add capabilities for the admin to reinitiate ask password flow even if the recovery data is missing in the DB.

![Untitled-2025-04-03-1724](https://github.com/user-attachments/assets/836d6e17-64b1-48e7-bf03-8063026c3a4a)
![Untitled-2025-04-03-1725](https://github.com/user-attachments/assets/afc88064-127f-4667-ae17-5a99fb786de8)
![Untitled-2025-04-03-1723](https://github.com/user-attachments/assets/a28f00bf-95c2-4a97-b192-7c801cbe2fd6)

