### PR TITLE
Persist lastPasswordUpdateTime regardless of password expiry config

### DIFF
--- a/components/org.wso2.carbon.identity.password.expiry/src/main/java/org/wso2/carbon/identity/password/expiry/PasswordChangeHandler.java
+++ b/components/org.wso2.carbon.identity.password.expiry/src/main/java/org/wso2/carbon/identity/password/expiry/PasswordChangeHandler.java
@@ -55,17 +55,16 @@ public class PasswordChangeHandler extends AbstractEventHandler {
         String tenantDomain = (String) event.getEventProperties()
                 .get(IdentityEventConstants.EventProperty.TENANT_DOMAIN);
 
-        try {
-            if (!PasswordPolicyUtils.isPasswordExpiryEnabled(tenantDomain)) {
-                return;
-            }
-        } catch (PostAuthenticationFailedException e) {
-            throw new IdentityEventException(e.getMessage(), e);
-        }
-
         //password grant handler - password expiry validation
         if (PasswordPolicyConstants.PASSWORD_GRANT_POST_AUTHENTICATION_EVENT.equals(eventName)) {
-            handlePasswordExpiryInPasswordGrantType(event, username, tenantDomain);
+            try {
+                if (!PasswordPolicyUtils.isPasswordExpiryEnabled(tenantDomain)) {
+                    return;
+                }
+                handlePasswordExpiryInPasswordGrantType(event, username, tenantDomain);
+            } catch (PostAuthenticationFailedException e) {
+                throw new IdentityEventException("Error during password expiry processing: " + e.getMessage(), e);
+            }
             return;
         }
 


### PR DESCRIPTION
### Proposed changes in this pull request
This PR ensures that the system records the last password update time for a user irrespective of whether the password expiry feature is enabled. Previously, the lastPasswordUpdateTime persisted only when the password expiry configuration was active
