### PR TITLE
Add captcha handling flow execution listener

### DIFF
--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -98,6 +98,14 @@
             <artifactId>org.wso2.carbon.identity.event</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.user.registration.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.user.registration.engine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.datapublisher.authentication</groupId>
             <artifactId>org.wso2.carbon.identity.data.publisher.application.authentication</artifactId>
         </dependency>
@@ -203,6 +211,10 @@
                             org.wso2.securevault.*; version="${org.wso2.securevault.import.version.range}",
                             org.wso2.carbon.context; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.multi.attribute.login.mgt.*;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.user.registration.engine.*;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.user.registration.mgt.*;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                         </Import-Package>
                     </instructions>

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaComponent.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaComponent.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.ComponentContext;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticationDataPublisher;
+import org.wso2.carbon.identity.captcha.listener.CaptchaFlowExecutionListener;
 import org.wso2.carbon.identity.captcha.connector.CaptchaConnector;
 import org.wso2.carbon.identity.captcha.connector.recaptcha.EmailOTPCaptchaConnector;
 import org.wso2.carbon.identity.captcha.connector.recaptcha.GenericAuthenticatorReCaptchaConnector;
@@ -38,6 +39,7 @@ import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
 import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
+import org.wso2.carbon.identity.user.registration.engine.listener.FlowExecutionListener;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -101,6 +103,8 @@ public class CaptchaComponent {
                     failedLoginAttemptValidator, null);
             context.getBundleContext().registerService(AbstractEventHandler.class.getName(), new
                     FailLoginAttemptValidationHandler(), null);
+            context.getBundleContext().registerService(FlowExecutionListener.class, new CaptchaFlowExecutionListener(),
+                    null);
             if (log.isDebugEnabled()) {
                 log.debug("Captcha Component is activated");
             }

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/listener/CaptchaFlowExecutionListener.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/listener/CaptchaFlowExecutionListener.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.captcha.listener;
+
+import org.wso2.carbon.identity.captcha.exception.CaptchaClientException;
+import org.wso2.carbon.identity.captcha.exception.CaptchaException;
+import org.wso2.carbon.identity.captcha.util.CaptchaUtil;
+import org.wso2.carbon.identity.user.registration.engine.Constants.ErrorMessages;
+import org.wso2.carbon.identity.user.registration.engine.exception.RegistrationEngineClientException;
+import org.wso2.carbon.identity.user.registration.engine.exception.RegistrationEngineException;
+import org.wso2.carbon.identity.user.registration.engine.exception.RegistrationEngineServerException;
+import org.wso2.carbon.identity.user.registration.engine.listener.AbstractFlowExecutionListener;
+import org.wso2.carbon.identity.user.registration.engine.model.RegistrationContext;
+import org.wso2.carbon.identity.user.registration.engine.model.RegistrationStep;
+import org.wso2.carbon.identity.user.registration.mgt.Constants;
+import org.wso2.carbon.identity.user.registration.mgt.model.ComponentDTO;
+
+import java.util.Map;
+
+/**
+ * Listener to handle captcha validation.
+ */
+public class CaptchaFlowExecutionListener extends AbstractFlowExecutionListener {
+
+    public static final String CAPTCHA_ENABLED = "captchaEnabled";
+    public static final String CAPTCHA_RESPONSE = "captchaResponse";
+    public static final String CAPTCHA_KEY = "captchaKey";
+    public static final String CAPTCHA_URL = "captchaURL";
+    private static final String CAPTCHA_GOVERNANCE_CONFIG_KEY = "sso.login.recaptcha.enable";
+
+    @Override
+    public int getDefaultOrderId() {
+
+        return 3;
+    }
+
+    @Override
+    public int getExecutionOrderId() {
+
+        return 3;
+    }
+
+    @Override
+    public boolean isEnabled() {
+
+        return true;
+    }
+
+    @Override
+    public boolean doPostInitiate(RegistrationStep step, RegistrationContext registrationContext)
+            throws RegistrationEngineException {
+
+        if (isReCaptchaDisabled(registrationContext.getTenantDomain())) {
+            return true;
+        }
+        addCaptchaKeys(step, registrationContext);
+        return true;
+    }
+
+    @Override
+    public boolean doPreContinue(RegistrationContext registrationContext) throws RegistrationEngineException {
+
+        if (isReCaptchaDisabled(registrationContext.getTenantDomain())) {
+            return true;
+        }
+        validateCaptcha(registrationContext);
+        return true;
+    }
+
+    @Override
+    public boolean doPostContinue(RegistrationStep step, RegistrationContext registrationContext)
+            throws RegistrationEngineException {
+
+        if (isReCaptchaDisabled(registrationContext.getTenantDomain())) {
+            return true;
+        }
+        addCaptchaKeys(step, registrationContext);
+        return true;
+    }
+
+    private boolean isReCaptchaDisabled(String tenantDomain) {
+
+        return !CaptchaUtil.isReCaptchaEnabledForFlow(CAPTCHA_GOVERNANCE_CONFIG_KEY, tenantDomain);
+    }
+
+    private void addCaptchaKeys(RegistrationStep step, RegistrationContext context) {
+
+        if (step.getData().getComponents() == null) {
+            return;
+        }
+
+        for (ComponentDTO componentDTO : step.getData().getComponents()) {
+            if (componentDTO.getType().equals(Constants.ComponentTypes.CAPTCHA)) {
+                /*  Currently, we are only supporting reCaptcha. When generic captcha support is added,
+                this needs to be updated. */
+                componentDTO.addConfig(CAPTCHA_KEY, CaptchaUtil.reCaptchaSiteKey());
+                componentDTO.addConfig(CAPTCHA_URL, CaptchaUtil.reCaptchaAPIURL());
+                context.setProperty(CAPTCHA_ENABLED, true);
+                step.getData().addAdditionalData(CAPTCHA_ENABLED, String.valueOf(true));
+                context.getCurrentStepInputs().forEach(
+                        (key, value) -> value.add(CAPTCHA_RESPONSE)
+                );
+                context.getCurrentRequiredInputs().forEach(
+                        (key, value) -> value.add(CAPTCHA_RESPONSE)
+                );
+                return;
+            }
+        }
+    }
+
+    private void validateCaptcha(RegistrationContext registrationContext) throws RegistrationEngineException {
+
+        Map<String, Object> properties = registrationContext.getProperties();
+        Map<String, String> userInputData = registrationContext.getUserInputData();
+
+        // Check if captcha is enabled for the current step.
+        if (!Boolean.TRUE.equals(properties.get(CAPTCHA_ENABLED))) {
+            return;
+        }
+
+        registrationContext.setProperty(CAPTCHA_ENABLED, false);
+        String captchaResponse = userInputData.get(CAPTCHA_RESPONSE);
+        String flowId = registrationContext.getContextIdentifier();
+        if (captchaResponse == null || captchaResponse.isEmpty()) {
+            throw getRegistrationEngineClientException(flowId);
+        }
+
+        try {
+            if (!CaptchaUtil.isValidCaptcha(captchaResponse)) {
+                throw getRegistrationEngineClientException(flowId);
+            }
+        } catch (CaptchaClientException e) {
+            throw getRegistrationEngineClientException(flowId);
+        } catch (CaptchaException e) {
+            throw getRegistrationEngineServerException(flowId);
+        }
+    }
+
+    private static RegistrationEngineServerException getRegistrationEngineServerException(String flowId) {
+
+        return new RegistrationEngineServerException(
+                ErrorMessages.ERROR_CODE_CAPTCHA_VERIFICATION_FAILURE.getCode(),
+                ErrorMessages.ERROR_CODE_CAPTCHA_VERIFICATION_FAILURE.getMessage(),
+                String.format(ErrorMessages.ERROR_CODE_CAPTCHA_VERIFICATION_FAILURE.getDescription(), flowId)
+        );
+    }
+
+    private static RegistrationEngineClientException getRegistrationEngineClientException(String flowId) {
+
+        return new RegistrationEngineClientException(ErrorMessages.ERROR_CODE_INVALID_CAPTCHA.getCode(),
+                ErrorMessages.ERROR_CODE_INVALID_CAPTCHA.getMessage(),
+                String.format(ErrorMessages.ERROR_CODE_INVALID_CAPTCHA.getDescription(), flowId));
+    }
+}

--- a/components/org.wso2.carbon.identity.captcha/src/test/java/org/wso2/carbon/identity/captcha/listener/CaptchaFlowExecutionListenerTest.java
+++ b/components/org.wso2.carbon.identity.captcha/src/test/java/org/wso2/carbon/identity/captcha/listener/CaptchaFlowExecutionListenerTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.captcha.listener;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.captcha.exception.CaptchaException;
+import org.wso2.carbon.identity.captcha.util.CaptchaUtil;
+import org.wso2.carbon.identity.user.registration.engine.exception.RegistrationEngineClientException;
+import org.wso2.carbon.identity.user.registration.engine.exception.RegistrationEngineException;
+import org.wso2.carbon.identity.user.registration.engine.exception.RegistrationEngineServerException;
+import org.wso2.carbon.identity.user.registration.engine.model.RegistrationContext;
+import org.wso2.carbon.identity.user.registration.engine.model.RegistrationStep;
+import org.wso2.carbon.identity.user.registration.mgt.Constants;
+import org.wso2.carbon.identity.user.registration.mgt.model.ComponentDTO;
+import org.wso2.carbon.identity.user.registration.mgt.model.DataDTO;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.wso2.carbon.identity.captcha.listener.CaptchaFlowExecutionListener.CAPTCHA_ENABLED;
+import static org.wso2.carbon.identity.captcha.listener.CaptchaFlowExecutionListener.CAPTCHA_KEY;
+import static org.wso2.carbon.identity.captcha.listener.CaptchaFlowExecutionListener.CAPTCHA_RESPONSE;
+
+/**
+ * Unit test for {@link CaptchaFlowExecutionListener}.
+ */
+public class CaptchaFlowExecutionListenerTest {
+
+    private static CaptchaFlowExecutionListener captchaFlowExecutionListener;
+
+    @BeforeMethod
+    public void setUp() {
+
+        captchaFlowExecutionListener = new CaptchaFlowExecutionListener();
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+    }
+
+    @Test
+    public void testDoPostInitiate() throws RegistrationEngineException {
+
+        RegistrationStep registrationStep = getRegistrationStep();
+        RegistrationContext registrationContext = getRegistrationContext();
+        try (MockedStatic<CaptchaUtil> captchaUtilMockedStatic = Mockito.mockStatic(CaptchaUtil.class)) {
+            captchaUtilMockedStatic.when(CaptchaUtil::reCaptchaSiteKey).thenReturn("captchaKeyValue");
+            captchaUtilMockedStatic.when(()-> CaptchaUtil.isReCaptchaEnabledForFlow(anyString(), anyString()))
+                    .thenReturn(true);
+            captchaFlowExecutionListener.doPostInitiate(registrationStep, registrationContext);
+            Assert.assertTrue(registrationStep.getData().getComponents().get(0).getConfigs().containsKey(CAPTCHA_KEY));
+            Assert.assertTrue(registrationContext.getCurrentStepInputs().get("action1").contains(CAPTCHA_RESPONSE));
+            Assert.assertTrue(registrationContext.getCurrentRequiredInputs().get("action1").contains(CAPTCHA_RESPONSE));
+            Assert.assertTrue((boolean) registrationContext.getProperty(CAPTCHA_ENABLED));
+        }
+    }
+
+    @Test(expectedExceptions = RegistrationEngineClientException.class)
+    public void testDoPreContinueMissingCaptchaResponse() throws RegistrationEngineException {
+
+        RegistrationContext registrationContext = getRegistrationContext();
+        registrationContext.setProperty(CAPTCHA_ENABLED, true);
+        registrationContext.getUserInputData().put(CAPTCHA_RESPONSE, "");
+        try (MockedStatic<CaptchaUtil> captchaUtilMockedStatic = Mockito.mockStatic(CaptchaUtil.class)) {
+            captchaUtilMockedStatic.when(()-> CaptchaUtil.isReCaptchaEnabledForFlow(anyString(), anyString()))
+                    .thenReturn(true);
+            captchaFlowExecutionListener.doPreContinue(registrationContext);
+        }
+    }
+
+    @Test(expectedExceptions = RegistrationEngineClientException.class)
+    public void testDoPreContinueInvalidCaptcha() throws RegistrationEngineException {
+
+        RegistrationContext registrationContext = getRegistrationContext();
+        registrationContext.setProperty(CAPTCHA_ENABLED, true);
+        registrationContext.getUserInputData().put(CAPTCHA_RESPONSE, "");
+        try (MockedStatic<CaptchaUtil> captchaUtilMockedStatic = Mockito.mockStatic(CaptchaUtil.class)) {
+            captchaUtilMockedStatic.when(() -> CaptchaUtil.isValidCaptcha(anyString())).thenReturn(false);
+            captchaUtilMockedStatic.when(()-> CaptchaUtil.isReCaptchaEnabledForFlow(anyString(), anyString()))
+                    .thenReturn(true);
+            captchaFlowExecutionListener.doPreContinue(registrationContext);
+        }
+    }
+
+    @Test
+    public void testDoPostContinue() throws RegistrationEngineException {
+
+        RegistrationStep registrationStep = getRegistrationStep();
+        RegistrationContext registrationContext = getRegistrationContext();
+        try (MockedStatic<CaptchaUtil> captchaUtilMockedStatic = Mockito.mockStatic(CaptchaUtil.class)) {
+            captchaUtilMockedStatic.when(CaptchaUtil::reCaptchaSiteKey).thenReturn("captchaKeyValue");
+            captchaUtilMockedStatic.when(()-> CaptchaUtil.isReCaptchaEnabledForFlow(anyString(), anyString()))
+                    .thenReturn(true);
+            captchaFlowExecutionListener.doPostContinue(registrationStep, registrationContext);
+            Assert.assertTrue(registrationStep.getData().getComponents().get(0).getConfigs().containsKey(CAPTCHA_KEY));
+            Assert.assertTrue(registrationContext.getCurrentStepInputs().get("action1").contains(CAPTCHA_RESPONSE));
+            Assert.assertTrue(registrationContext.getCurrentRequiredInputs().get("action1").contains(CAPTCHA_RESPONSE));
+            Assert.assertTrue((boolean) registrationContext.getProperty(CAPTCHA_ENABLED));
+        }
+    }
+
+    @Test
+    public void testDoPostInitiateCaptchaDisabled() throws RegistrationEngineException {
+
+        RegistrationStep step = getRegistrationStep();
+        RegistrationContext context = getRegistrationContext();
+
+        try (MockedStatic<CaptchaUtil> captchaUtil = Mockito.mockStatic(CaptchaUtil.class)) {
+            captchaUtil.when(()-> CaptchaUtil.isReCaptchaEnabledForFlow(anyString(), anyString())).thenReturn(false);
+            captchaFlowExecutionListener.doPostInitiate(step, context);
+            Assert.assertFalse(step.getData().getComponents().get(0).getConfigs().containsKey(CAPTCHA_KEY));
+            Assert.assertFalse(context.getCurrentStepInputs().get("action1").contains(CAPTCHA_RESPONSE));
+            Assert.assertFalse(context.getCurrentRequiredInputs().get("action1").contains(CAPTCHA_RESPONSE));
+            Assert.assertNull(context.getProperty(CAPTCHA_ENABLED));
+        }
+    }
+
+    @Test
+    public void testDoPostInitiateNullComponents() throws RegistrationEngineException {
+
+        RegistrationStep step = new RegistrationStep.Builder()
+                .stepType(Constants.StepTypes.VIEW)
+                .flowId("flowId")
+                .data(new DataDTO.Builder().components(null).build())
+                .build();
+        RegistrationContext context = getRegistrationContext();
+
+        try (MockedStatic<CaptchaUtil> captchaUtil = Mockito.mockStatic(CaptchaUtil.class)) {
+
+            captchaUtil.when(()-> CaptchaUtil.isReCaptchaEnabledForFlow(anyString(), anyString())).thenReturn(true);
+            captchaFlowExecutionListener.doPostInitiate(step, context);
+            Assert.assertNull(context.getProperty(CAPTCHA_ENABLED));
+            Assert.assertFalse(context.getCurrentStepInputs().get("action1").contains(CAPTCHA_RESPONSE));
+            Assert.assertFalse(context.getCurrentRequiredInputs().get("action1").contains(CAPTCHA_RESPONSE));
+        }
+    }
+
+    @Test
+    public void testDoPostInitiateNonCaptchaComponent() throws RegistrationEngineException {
+
+        ComponentDTO nonCaptchaComponent = new ComponentDTO.Builder()
+                .id("input_1")
+                .type("TEXT_INPUT")
+                .variant("GENERIC")
+                .build();
+        RegistrationStep step = new RegistrationStep.Builder()
+                .stepType(Constants.StepTypes.VIEW)
+                .flowId("flowId")
+                .data(new DataDTO.Builder().components(Collections.singletonList(nonCaptchaComponent)).build())
+                .build();
+        RegistrationContext context = getRegistrationContext();
+
+        try (MockedStatic<CaptchaUtil> captchaUtil = Mockito.mockStatic(CaptchaUtil.class)) {
+
+            captchaUtil.when(()-> CaptchaUtil.isReCaptchaEnabledForFlow(anyString(), anyString())).thenReturn(true);
+            captchaFlowExecutionListener.doPostInitiate(step, context);
+            Assert.assertFalse(step.getData().getComponents().get(0).getConfigs().containsKey(CAPTCHA_KEY));
+            Assert.assertFalse(context.getCurrentStepInputs().get("action1").contains(CAPTCHA_RESPONSE));
+            Assert.assertFalse(context.getCurrentRequiredInputs().get("action1").contains(CAPTCHA_RESPONSE));
+            Assert.assertNull(context.getProperty(CAPTCHA_ENABLED));
+        }
+    }
+
+    @Test
+    public void testDoPreContinueCaptchaDisabled() throws RegistrationEngineException {
+
+        RegistrationContext context = getRegistrationContext();
+        try (MockedStatic<CaptchaUtil> captchaUtil = Mockito.mockStatic(CaptchaUtil.class)) {
+            captchaUtil.when(() -> CaptchaUtil.isReCaptchaEnabledForFlow(anyString(), anyString()))
+                    .thenReturn(false);
+            context.setProperty(CAPTCHA_ENABLED, false);
+            captchaFlowExecutionListener.doPreContinue(context);
+            // No exception means success; make sure captcha remains disabled.
+            Assert.assertEquals(context.getProperty(CAPTCHA_ENABLED), false);
+        }
+    }
+
+    @Test(expectedExceptions = RegistrationEngineServerException.class)
+    public void testDoPreContinueCaptchaThrowsServerException() throws RegistrationEngineException {
+
+        RegistrationContext context = getRegistrationContext();
+        context.setProperty(CAPTCHA_ENABLED, true);
+        context.getUserInputData().put(CAPTCHA_RESPONSE, "someResponse");
+
+        try (MockedStatic<CaptchaUtil> captchaUtil = Mockito.mockStatic(CaptchaUtil.class)) {
+            captchaUtil.when(() -> CaptchaUtil.isValidCaptcha(anyString()))
+                    .thenThrow(new CaptchaException("Internal error"));
+            captchaUtil.when(()-> CaptchaUtil.isReCaptchaEnabledForFlow(anyString(), anyString())).thenReturn(true);
+            captchaFlowExecutionListener.doPreContinue(context);
+        }
+    }
+
+    private RegistrationContext getRegistrationContext() {
+
+        RegistrationContext registrationContext = new RegistrationContext();
+        registrationContext.setTenantDomain("test.com");
+        registrationContext.setContextIdentifier("contextId");
+        registrationContext.getCurrentRequiredInputs().put("action1", new HashSet<>());
+        registrationContext.getCurrentStepInputs().put("action1", new HashSet<>());
+        return registrationContext;
+    }
+
+    private RegistrationStep getRegistrationStep() {
+
+        ComponentDTO componentDTO = new ComponentDTO.Builder()
+                .id("captcha_f12v")
+                .type("CAPTCHA")
+                .variant("RECAPTCHA_V2")
+                .build();
+        return new RegistrationStep.Builder()
+                .stepType(Constants.StepTypes.VIEW)
+                .flowId("flowId")
+                .data(new DataDTO.Builder()
+                        .components(Collections.singletonList(componentDTO))
+                        .additionalData(new HashMap<>())
+                        .build()).build();
+    }
+}

--- a/components/org.wso2.carbon.identity.captcha/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.captcha/src/test/resources/testng.xml
@@ -23,4 +23,9 @@
             <class name="org.wso2.carbon.identity.captcha.util.CaptchaUtilTest"/>
         </classes>
     </test>
+    <test name="Captcha-Listener-Tests" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.carbon.identity.captcha.listener.CaptchaFlowExecutionListenerTest"/>
+        </classes>
+    </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -496,6 +496,16 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.user.registration.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.user.registration.engine</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.governance</groupId>
                 <artifactId>org.wso2.carbon.identity.multi.attribute.login.service</artifactId>
                 <version>${project.version}</version>
@@ -700,7 +710,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.8.99</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.104</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request

Introduce FlowExecutionListener to handle captcha. Purpose of this listener,

- Inject captchaKey to the stepDTO on `postInitiate`, `postContinue`
- Update registrationContext to indicate the captcha requirement for current step
- Update inputs of the current step inputs to include `captchaReesponse`
- Validate captcha response on `preContinue`

### Issue

https://github.com/wso2/product-is/issues/23756