### PR TITLE
Improving error message format generated at V2 Recovery API flow on validation failure during SMS OTP recovery flow triggered by pre-update password action

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/password/PasswordRecoveryManagerImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/password/PasswordRecoveryManagerImpl.java
@@ -443,6 +443,13 @@ public class PasswordRecoveryManagerImpl implements PasswordRecoveryManager {
             exception.setErrorCode(Utils.prependOperationScenarioToErrorCode(exception.getErrorCode(),
                     IdentityRecoveryConstants.PASSWORD_RECOVERY_SCENARIO));
         }
+
+        if (IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE.getCode()
+                .equals(exception.getErrorCode())) {
+            return Utils.handleClientException(exception.getErrorCode(), exception.getMessage(),
+                    exception.getDescription(), exception);
+        }
+
         return Utils.handleClientException(exception.getErrorCode(), exception.getMessage(), null);
     }
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -451,11 +451,9 @@ public class Utils {
      * @param description A detailed description of the error.
      * @param e           The underlying cause of the exception.
      * @return An instance of {@link IdentityRecoveryClientException} with the provided details.
-     * @throws IdentityRecoveryClientException If an error occurs while instantiating the exception.
      */
     public static IdentityRecoveryClientException handleClientException(String code, String message, String description,
-                                                                        Throwable e)
-            throws IdentityRecoveryClientException {
+                                                                        Throwable e) {
 
         return IdentityException.error(IdentityRecoveryClientException.class, code, message, description, e);
     }


### PR DESCRIPTION
Improving error message format generated at V2 Recovery API flow on validation failure during SMS OTP recovery flow triggered by pre-update password action.

Parent issue:

- https://github.com/wso2/product-is/issues/23768