### PR TITLE
Associate emailVerified and phoneVerified claims only with the respective primary value

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -119,6 +119,7 @@ public class IdentityRecoveryConstants {
     public static final String VERIFY_EMAIL_CLIAM = "http://wso2.org/claims/identity/verifyEmail";
     public static final String EMAIL_VERIFIED_CLAIM = "http://wso2.org/claims/identity/emailVerified";
     public static final String VERIFY_MOBILE_CLAIM = "http://wso2.org/claims/identity/verifyMobile";
+    public static final String MOBILE_VERIFIED_CLAIM = "http://wso2.org/claims/identity/phoneVerified";
     public static final String EMAIL_ADDRESS_PENDING_VALUE_CLAIM =
             "http://wso2.org/claims/identity/emailaddress.pendingValue";
     public static final String MOBILE_NUMBER_PENDING_VALUE_CLAIM =

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
@@ -369,6 +369,13 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
                 mobileNumber = getVerificationPendingMobileNumber(exisitingVerifiedNumbersList,
                         updatedVerifiedNumbersList);
                 updatedVerifiedNumbersList.remove(mobileNumber);
+            } else {
+                /*
+                 * When both primary mobile number and verified mobile numbers are provided, give the primary‑mobile
+                 * number change the precedence; leave the updated verified‑mobile numbers list exactly as it exists
+                 * in the user store.
+                 */
+                updatedVerifiedNumbersList = exisitingVerifiedNumbersList;
             }
 
             /*
@@ -413,13 +420,6 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
                     IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates
                             .SKIP_ON_ALREADY_VERIFIED_MOBILE_NUMBERS.toString());
             claims.put(IdentityRecoveryConstants.MOBILE_VERIFIED_CLAIM, Boolean.TRUE.toString());
-
-            // If the existing primary mobile is not verified do not add it to the verified mobile numbers list.
-            if (shouldUpdateMultiMobilesRelatedClaims && !isPrimaryMobileVerified(userStoreManager, user)) {
-                updatedVerifiedNumbersList.remove(existingMobileNumber);
-                claims.put(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM,
-                        StringUtils.join(updatedVerifiedNumbersList, multiAttributeSeparator));
-            }
             invalidatePendingMobileVerification(user, userStoreManager, claims);
             return;
         }
@@ -460,7 +460,6 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
                         maskIfRequired(mobileNumber), maskIfRequired(username), user.getTenantDomain(),
                         user.getUserStoreDomain()));
             }
-            Utils.unsetThreadLocalIsOnlyVerifiedMobileNumbersUpdated();
         }
         /*
         When 'UseVerifyClaim' is enabled, the verification should happen only if the 'verifyMobile'

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
@@ -61,6 +61,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.wso2.carbon.identity.recovery.util.Utils.maskIfRequired;
+
 /**
  * This event handler is used to send a verification SMS when a claim update event to update the mobile number
  * is triggered.
@@ -101,7 +103,7 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
             if (IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM.equals(claim)) {
                 if (log.isDebugEnabled()) {
                     log.debug(String.format("Primary mobile claim removed for user '%s'. Removing " +
-                            "corresponding 'phoneVerified' claim.", user.getUserName()));
+                            "corresponding 'phoneVerified' claim.", maskIfRequired(user.getUserName())));
                 }
                 setUserClaim(IdentityRecoveryConstants.MOBILE_VERIFIED_CLAIM, StringUtils.EMPTY, userStoreManager,
                         user);
@@ -426,8 +428,8 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
                 if (log.isDebugEnabled()) {
                     log.debug(String.format("The mobile number to be updated: %s is same as the existing mobile " +
                                     "number for user: %s in domain: %s and user store: %s. Hence an SMS OTP " +
-                                    "verification will not be triggered.", mobileNumber, username,
-                            user.getTenantDomain(), user.getUserStoreDomain()));
+                                    "verification will not be triggered.", maskIfRequired(mobileNumber),
+                            maskIfRequired(username), user.getTenantDomain(), user.getUserStoreDomain()));
                 }
                 Utils.setThreadLocalToSkipSendingSmsOtpVerificationOnUpdate(IdentityRecoveryConstants
                         .SkipMobileNumberVerificationOnUpdateStates.SKIP_ON_EXISTING_MOBILE_NUM.toString());
@@ -446,7 +448,8 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
                 log.debug(String.format("The mobile number to be updated: %s is same as the existing mobile " +
                                 "number for user: %s in domain: %s and user store: %s. Yet the mobile number is not " +
                                 "verified. Hence an SMS OTP verification will be triggered.",
-                        mobileNumber, username, user.getTenantDomain(), user.getUserStoreDomain()));
+                        maskIfRequired(mobileNumber), maskIfRequired(username), user.getTenantDomain(),
+                        user.getUserStoreDomain()));
             }
             Utils.unsetThreadLocalIsOnlyVerifiedMobileNumbersUpdated();
         }
@@ -697,7 +700,9 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
         try {
             userStoreManager.setUserClaimValues(user.getUserName(), userClaims, null);
         } catch (UserStoreException e) {
-            throw new IdentityEventException("Error while setting user claim value :" + user.getUserName(), e);
+            throw new IdentityEventException(
+                    String.format("Error while setting user claim value for user: %s",
+                            maskIfRequired(user.getUserName())), e);
         }
     }
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
@@ -337,6 +337,15 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
 
         String mobileNumber = claims.get(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM);
 
+        /*
+         * If the `mobile` claim (the primary number) is emptied — indicating its removal — the`phoneVerified` claim
+         * (which flags verification) should also be cleared so the user profile does not display a deleted number
+         * as verified.
+         */
+        if (StringUtils.EMPTY.equals(mobileNumber)) {
+            claims.put(IdentityRecoveryConstants.MOBILE_VERIFIED_CLAIM, StringUtils.EMPTY);
+        }
+
         List<String> updatedVerifiedNumbersList = new ArrayList<>();
         List<String> updatedAllNumbersList;
 
@@ -418,10 +427,10 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
         if (StringUtils.equals(mobileNumber, existingMobileNumber)) {
 
             if (supportMultipleMobileNumbers && shouldUpdateMultiMobilesRelatedClaims &&
-                    !updatedVerifiedNumbersList.contains(existingMobileNumber)) {
-                updatedVerifiedNumbersList.add(existingMobileNumber);
+                    !updatedAllNumbersList.contains(existingMobileNumber)) {
+                updatedAllNumbersList.add(existingMobileNumber);
                 claims.put(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM,
-                String.join(multiAttributeSeparator, updatedVerifiedNumbersList));
+                        String.join(multiAttributeSeparator, updatedAllNumbersList));
             }
 
             if (isPrimaryMobileVerified(userStoreManager, user)) {
@@ -436,10 +445,10 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
                 invalidatePendingMobileVerification(user, userStoreManager, claims);
 
                 if (supportMultipleMobileNumbers && shouldUpdateMultiMobilesRelatedClaims &&
-                        !updatedAllNumbersList.contains(existingMobileNumber)) {
-                    updatedAllNumbersList.add(existingMobileNumber);
+                        !updatedVerifiedNumbersList.contains(existingMobileNumber)) {
+                    updatedVerifiedNumbersList.add(existingMobileNumber);
                     claims.put(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM,
-                            String.join(multiAttributeSeparator, updatedAllNumbersList));
+                            String.join(multiAttributeSeparator, updatedVerifiedNumbersList));
                 }
                 return;
             }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -582,6 +582,16 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
 
         String emailAddress = claims.get(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM);
+
+        /*
+         * If the `emailaddress` claim (the primary email) is emptied — indicating its removal — the`emailVerified`
+         * claim (which flags verification) should also be cleared so the user profile does not display a deleted
+         * email as verified.
+         */
+        if (StringUtils.EMPTY.equals(emailAddress)) {
+            claims.put(IdentityRecoveryConstants.EMAIL_VERIFIED_CLAIM, StringUtils.EMPTY);
+        }
+
         List<String> updatedVerifiedEmailAddresses = new ArrayList<>();
         List<String> updatedAllEmailAddresses;
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -65,6 +65,7 @@ import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ErrorMessages
         .ERROR_CODE_VERIFICATION_EMAIL_NOT_FOUND;
+import static org.wso2.carbon.identity.recovery.util.Utils.maskIfRequired;
 
 public class UserEmailVerificationHandler extends AbstractEventHandler {
 
@@ -103,7 +104,7 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
             if (IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM.equals(claim)) {
                 if (log.isDebugEnabled()) {
                     log.debug(String.format("Primary email address claim removed for user '%s'. Removing " +
-                            "corresponding 'emailVerified' claim.", user.getUserName()));
+                            "corresponding 'emailVerified' claim.", maskIfRequired(user.getUserName())));
                 }
                 setUserClaim(IdentityRecoveryConstants.EMAIL_VERIFIED_CLAIM, StringUtils.EMPTY, userStoreManager, user);
             }
@@ -647,8 +648,9 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
         if (supportMultipleEmails && updatedVerifiedEmailAddresses.contains(emailAddress)) {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("The email address to be updated: %s is already verified and contains" +
-                        " in the verified email addresses list. Hence an email verification will not be " +
-                        "triggered.", emailAddress));
+                        " in the verified email addresses list for user: %s in domain %s. Hence an email " +
+                        "verification will not be triggered.", maskIfRequired(emailAddress),
+                        maskIfRequired(user.getUserName()), user.getTenantDomain()));
             }
             Utils.setThreadLocalToSkipSendingEmailVerificationOnUpdate(IdentityRecoveryConstants
                     .SkipEmailVerificationOnUpdateStates.SKIP_ON_ALREADY_VERIFIED_EMAIL_ADDRESSES.toString());
@@ -676,7 +678,8 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
                 if (log.isDebugEnabled()) {
                     log.debug(String.format("The email address to be updated: %s is same as the existing email " +
                             "address for user: %s in domain %s. Hence an email verification will not be " +
-                            "triggered.", emailAddress, user.getUserName(), user.getTenantDomain()));
+                            "triggered.", maskIfRequired(emailAddress), maskIfRequired(user.getUserName()),
+                            user.getTenantDomain()));
                 }
                 Utils.setThreadLocalToSkipSendingEmailVerificationOnUpdate(IdentityRecoveryConstants
                         .SkipEmailVerificationOnUpdateStates.SKIP_ON_EXISTING_EMAIL.toString());
@@ -694,8 +697,8 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("The email address to be updated: %s is same as the existing email " +
                         "address for user: %s in domain %s. Yet the email is not verified. " +
-                        "Hence an email verification will be triggered.", emailAddress,
-                        user.getUserName(), user.getTenantDomain()));
+                        "Hence an email verification will be triggered.", maskIfRequired(emailAddress),
+                        maskIfRequired(user.getUserName()), user.getTenantDomain()));
             }
             Utils.unsetThreadLocalIsOnlyVerifiedEmailAddressesUpdated();
         }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -1041,8 +1041,8 @@ public class UserSelfRegistrationManager {
                 }
             } else {
                 userClaims.put(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM, pendingMobileNumberClaimValue);
+                userClaims.put(NotificationChannels.SMS_CHANNEL.getVerifiedClaimUrl(), Boolean.TRUE.toString());
             }
-            userClaims.put(NotificationChannels.SMS_CHANNEL.getVerifiedClaimUrl(), Boolean.TRUE.toString());
             userClaims.put(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM, StringUtils.EMPTY);
             Utils.setThreadLocalToSkipSendingSmsOtpVerificationOnUpdate(IdentityRecoveryConstants
                     .SkipMobileNumberVerificationOnUpdateStates.SKIP_ON_CONFIRM.toString());

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -1220,6 +1220,18 @@ public class UserSelfRegistrationManager {
     }
 
     /**
+     * Check whether verification claim needs to be set based on the recovery scenario.
+     *
+     * @param recoveryScenario The recovery scenario to check.
+     * @return true if verification claim should be set, false otherwise.
+     */
+    private boolean shouldSetVerificationClaim(String recoveryScenario) {
+
+        return !(RecoveryScenarios.EMAIL_VERIFICATION_ON_VERIFIED_LIST_UPDATE.toString().equals(recoveryScenario) ||
+                RecoveryScenarios.MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE.toString().equals(recoveryScenario));
+    }
+
+    /**
      * Set the email verified or mobile verified claim to TRUE according to the verified channel in the request.
      *
      * @param user                           User
@@ -1254,17 +1266,21 @@ public class UserSelfRegistrationManager {
                 }
                 // If no verification claims are sent, set the email verified claim to true.
                 // This is to support backward compatibility.
-                userClaims.put(IdentityRecoveryConstants.EMAIL_VERIFIED_CLAIM, Boolean.TRUE.toString());
+                if (shouldSetVerificationClaim(recoveryScenario)) {
+                    userClaims.put(IdentityRecoveryConstants.EMAIL_VERIFIED_CLAIM, Boolean.TRUE.toString());
+                }
             }
         } else if (NotificationChannels.SMS_CHANNEL.getChannelType().equalsIgnoreCase(verificationChannel)) {
             if (log.isDebugEnabled()) {
                 String message = String
                         .format("Self sign-up via SMS channel detected. Updating %s value for user : %s in tenant "
-                                        + "domain : %s ", NotificationChannels.EMAIL_CHANNEL.getVerifiedClaimUrl(),
+                                        + "domain : %s ", NotificationChannels.SMS_CHANNEL.getVerifiedClaimUrl(),
                                 user.getUserName(), user.getTenantDomain());
                 log.debug(message);
             }
-            userClaims.put(NotificationChannels.SMS_CHANNEL.getVerifiedClaimUrl(), Boolean.TRUE.toString());
+            if (shouldSetVerificationClaim(recoveryScenario)) {
+                userClaims.put(NotificationChannels.SMS_CHANNEL.getVerifiedClaimUrl(), Boolean.TRUE.toString());
+            }
         } else if (NotificationChannels.EMAIL_CHANNEL.getChannelType().equalsIgnoreCase(verificationChannel)) {
             if (log.isDebugEnabled()) {
                 String message = String
@@ -1273,7 +1289,9 @@ public class UserSelfRegistrationManager {
                                 user.getUserName(), user.getTenantDomain());
                 log.debug(message);
             }
-            userClaims.put(IdentityRecoveryConstants.EMAIL_VERIFIED_CLAIM, Boolean.TRUE.toString());
+            if (shouldSetVerificationClaim(recoveryScenario)) {
+                userClaims.put(IdentityRecoveryConstants.EMAIL_VERIFIED_CLAIM, Boolean.TRUE.toString());
+            }
         } else {
             if (log.isDebugEnabled()) {
                 String message = String.format("No notification channel detected for user : %s in tenant domain : %s "
@@ -1281,7 +1299,9 @@ public class UserSelfRegistrationManager {
                         user.getUserName(), user.getTenantDomain(), recoveryScenario);
                 log.debug(message);
             }
-            userClaims.put(IdentityRecoveryConstants.EMAIL_VERIFIED_CLAIM, Boolean.TRUE.toString());
+            if (shouldSetVerificationClaim(recoveryScenario)) {
+                userClaims.put(IdentityRecoveryConstants.EMAIL_VERIFIED_CLAIM, Boolean.TRUE.toString());
+            }
         }
     }
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1951,4 +1951,39 @@ public class Utils {
                     " for user: " + user.toFullQualifiedUsername(), e);
         }
     }
+
+    /**
+     * Retrieve user claim of the user from the user store manager.
+     * Note : This method can be used to retrieve identity claim values of the user.
+     *
+     * @param userStoreManager The user store manager instance.
+     * @param user             The user object containing user details.
+     * @param claimURI         The URI of the claim to be retrieved.
+     * @return The claim value for the given claim URI. Returns null if no claim value is found.
+     * @throws IdentityEventException If an error occurs while retrieving the user claim value.
+     */
+    public static String getUserClaim(org.wso2.carbon.user.core.UserStoreManager userStoreManager, User user,
+                                      String claimURI) throws IdentityEventException {
+
+        Map<String, String> userClaimsMap;
+
+        try {
+            userClaimsMap = userStoreManager.getUserClaimValues(user.getUserName(), new String[]{claimURI}, null);
+        } catch (org.wso2.carbon.user.core.UserStoreException e) {
+            throw new IdentityEventException(String.format("Error while getting user claim: '%s' for user: %s",
+                    claimURI, user.getUserName()), e);
+        }
+
+        if (MapUtils.isEmpty(userClaimsMap)) {
+            return null;
+        }
+
+        for (Map.Entry<String, String> entry : userClaimsMap.entrySet()) {
+            String userClaimURI = entry.getKey();
+            if (userClaimURI.equals(claimURI)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1953,6 +1953,26 @@ public class Utils {
     }
 
     /**
+     * Retrieves the existing claim value for a given claim URI.
+     *
+     * @param userStoreManager User store manager.
+     * @param user             User object.
+     * @param claimURI         Claim URI to retrieve.
+     * @return List of existing claim values.
+     * @throws IdentityEventException If an error occurs while retrieving the claim value.
+     */
+    public static String getSingleValuedClaim(UserStoreManager userStoreManager, User user, String claimURI)
+            throws IdentityEventException {
+
+        try {
+            return userStoreManager.getUserClaimValue(user.getUserName(), claimURI, null);
+        } catch (UserStoreException e) {
+            throw new IdentityEventException("Error retrieving claim " + claimURI +
+                    " for user: " + maskIfRequired(user.toFullQualifiedUsername()), e);
+        }
+    }
+
+    /**
      * Retrieve user claim of the user from the user store manager.
      * Note : This method can be used to retrieve identity claim values of the user.
      *

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1971,7 +1971,7 @@ public class Utils {
             userClaimsMap = userStoreManager.getUserClaimValues(user.getUserName(), new String[]{claimURI}, null);
         } catch (org.wso2.carbon.user.core.UserStoreException e) {
             throw new IdentityEventException(String.format("Error while getting user claim: '%s' for user: %s",
-                    claimURI, user.getUserName()), e);
+                    claimURI, maskIfRequired(user.getUserName())), e);
         }
 
         if (MapUtils.isEmpty(userClaimsMap)) {

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -26,6 +26,7 @@ import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.event.IdentityEventClientException;
 import org.wso2.carbon.identity.event.IdentityEventException;
@@ -303,36 +304,37 @@ public class MobileNumberVerificationHandlerTest {
                 NEW_MOBILE_NUMBER);
 
         /*
-         Case 2: New mobile number is same as existing primary mobile number.
+         Case 2: New mobile number is same as existing verified primary mobile number.
          */
         mockExistingPrimaryMobileNumber(NEW_MOBILE_NUMBER);
         Event event2 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, null,
                 null, null, NEW_MOBILE_NUMBER);
+        mockPrimaryMobileVerificationStatus(true);
 
         mobileNumberVerificationHandler.handleEvent(event2);
-
         Map<String, String> userClaims2 = getUserClaimsFromEvent(event2);
         Assert.assertEquals(userClaims2.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM),
                 StringUtils.EMPTY);
 
         /*
-         Case 3: Enable userVerify and send verifyMobileClaim as false.
+         Case 3: New mobile number is same as existing unverified primary mobile number.
+         */
+        Event event3 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, null,
+                null, null, NEW_MOBILE_NUMBER);
+        mockPrimaryMobileVerificationStatus(false);
+
+        mobileNumberVerificationHandler.handleEvent(event3);
+        Map<String, String> userClaims3 = getUserClaimsFromEvent(event3);
+        Assert.assertEquals(userClaims3.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM),
+                NEW_MOBILE_NUMBER);
+
+        /*
+         Case 4: Enable userVerify and send verifyMobileClaim as false.
          */
         mockExistingPrimaryMobileNumber(EXISTING_NUMBER_1);
         mockedUtils.when(Utils::isUseVerifyClaimEnabled).thenReturn(true);
-        Event event3 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, NEW_MOBILE_NUMBER);
-
-        mobileNumberVerificationHandler.handleEvent(event3);
-        mockedUtils.verify(() -> Utils.setThreadLocalToSkipSendingSmsOtpVerificationOnUpdate(
-                IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates
-                        .SKIP_ON_INAPPLICABLE_CLAIMS.toString()), atLeastOnce());
-
-        /*
-         Case 4: Mobile number claim is null.
-         */
         Event event4 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, null);
+                null, null, NEW_MOBILE_NUMBER);
 
         mobileNumberVerificationHandler.handleEvent(event4);
         mockedUtils.verify(() -> Utils.setThreadLocalToSkipSendingSmsOtpVerificationOnUpdate(
@@ -340,7 +342,18 @@ public class MobileNumberVerificationHandlerTest {
                         .SKIP_ON_INAPPLICABLE_CLAIMS.toString()), atLeastOnce());
 
         /*
-         Case 5: Throw error when retrieving existing mobile number.
+         Case 5: Mobile number claim is null.
+         */
+        Event event5 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
+                null, null, null);
+
+        mobileNumberVerificationHandler.handleEvent(event5);
+        mockedUtils.verify(() -> Utils.setThreadLocalToSkipSendingSmsOtpVerificationOnUpdate(
+                IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates
+                        .SKIP_ON_INAPPLICABLE_CLAIMS.toString()), atLeastOnce());
+
+        /*
+         Case 6: Throw error when retrieving existing mobile number.
          */
         when(userStoreManager.getUserClaimValue(anyString(),
                 eq(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM), isNull()))
@@ -435,7 +448,7 @@ public class MobileNumberVerificationHandlerTest {
             Assert.assertTrue(e instanceof IdentityEventClientException);
         }
 
-        // Case 3: Added new number is existing primary mobile number.
+        // Case 3: Added new number is existing verified primary mobile number.
         String newVerifiedMobileNumbers3 = EXISTING_NUMBER_1 + "," + NEW_MOBILE_NUMBER;
         Event event3 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS,
                 IdentityRecoveryConstants.FALSE,
@@ -444,14 +457,36 @@ public class MobileNumberVerificationHandlerTest {
         mockExistingVerifiedNumbersList(new ArrayList<>(Arrays.asList(EXISTING_NUMBER_1)));
         mockExistingNumbersList(new ArrayList<>(Arrays.asList(EXISTING_NUMBER_1)));
         mockExistingPrimaryMobileNumber(NEW_MOBILE_NUMBER);
+        mockPrimaryMobileVerificationStatus(true);
 
         mobileNumberVerificationHandler.handleEvent(event3);
-
         Map<String, String> userClaims3 = getUserClaimsFromEvent(event3);
         Assert.assertTrue(
-                StringUtils.contains(userClaims3.get(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM), NEW_MOBILE_NUMBER));
+                StringUtils.contains(userClaims3.get(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM),
+                        NEW_MOBILE_NUMBER));
         Assert.assertTrue(StringUtils.contains(userClaims3.get(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM),
                 NEW_MOBILE_NUMBER));
+
+        // Case 4: Added new number is existing unverified primary mobile number.
+        Event event4 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS,
+                IdentityRecoveryConstants.FALSE,
+                newVerifiedMobileNumbers3, null, null);
+        mockExistingVerifiedNumbersList(new ArrayList<>(Arrays.asList(EXISTING_NUMBER_1)));
+        mockExistingNumbersList(new ArrayList<>(Arrays.asList(EXISTING_NUMBER_1)));
+        mockExistingPrimaryMobileNumber(NEW_MOBILE_NUMBER);
+        mockPrimaryMobileVerificationStatus(false);
+
+        mobileNumberVerificationHandler.handleEvent(event4);
+        Map<String, String> userClaims4 = getUserClaimsFromEvent(event4);
+        Assert.assertTrue(
+                StringUtils.contains(userClaims4.get(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM),
+                        NEW_MOBILE_NUMBER));
+        Assert.assertFalse(
+                StringUtils.contains(userClaims4.get(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM),
+                        NEW_MOBILE_NUMBER));
+        Assert.assertTrue(
+                StringUtils.contains(userClaims4.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM),
+                        NEW_MOBILE_NUMBER));
     }
 
     @Test(description = "POST_SET_USER_CLAIMS: Verification enabled, Multi-attribute enabled")
@@ -542,6 +577,41 @@ public class MobileNumberVerificationHandlerTest {
         Assert.assertEquals(RecoverySteps.VERIFY_MOBILE_NUMBER, capturedRecoveryData2.getRecoveryStep());
     }
 
+    @DataProvider(name = "claimDeletionData")
+    public Object[][] getClaimDeletionData() {
+
+        return new Object[][]{
+                // claimURI, shouldCallSetUserClaimValues
+                {IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM, true},
+                {"some.other.claim", false}
+        };
+    }
+
+    @Test(description = "Test handling of claim deletion events - verifies that 'phoneVerified' claim is cleared when " +
+            "mobile claim is deleted, and no action for other claims.", dataProvider = "claimDeletionData")
+    public void testHandleEventPreDeleteUserClaim(String claimURI, boolean shouldCallSetUserClaimValues)
+            throws IdentityEventException, org.wso2.carbon.user.core.UserStoreException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.USER_NAME, TEST_USERNAME);
+        eventProperties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, TEST_TENANT_DOMAIN);
+        eventProperties.put(IdentityEventConstants.EventProperty.USER_STORE_MANAGER, userStoreManager);
+        eventProperties.put(IdentityEventConstants.EventProperty.CLAIM_URI, claimURI);
+        Event event = new Event(IdentityEventConstants.Event.PRE_DELETE_USER_CLAIM, eventProperties);
+
+        mobileNumberVerificationHandler.handleEvent(event);
+
+        if (shouldCallSetUserClaimValues) {
+            // Verify that setUserClaimValues was called with empty string for phoneVerified claim.
+            Map<String, String> expectedClaims = new HashMap<>();
+            expectedClaims.put(IdentityRecoveryConstants.MOBILE_VERIFIED_CLAIM, StringUtils.EMPTY);
+            verify(userStoreManager).setUserClaimValues(eq(TEST_USERNAME), eq(expectedClaims), isNull());
+        } else {
+            // Verify that setUserClaimValues was not called for other claims.
+            verify(userStoreManager, never()).setUserClaimValues(anyString(), any(), any());
+        }
+    }
+
     private void mockExistingPrimaryMobileNumber(String mobileNumber) throws UserStoreException {
 
         when(userStoreManager.getUserClaimValue(anyString(),
@@ -553,6 +623,12 @@ public class MobileNumberVerificationHandlerTest {
         mockedUtils.when(() -> Utils.getMultiValuedClaim(any(), any(),
                         eq(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM)))
                 .thenReturn(existingAllMobileNumbers);
+    }
+
+    private void mockPrimaryMobileVerificationStatus(boolean isVerified) {
+
+        mockedUtils.when(() -> Utils.getUserClaim(any(), any(), eq(IdentityRecoveryConstants.MOBILE_VERIFIED_CLAIM)))
+                .thenReturn(String.valueOf(isVerified));
     }
 
     private void mockExistingVerifiedNumbersList(List<String> exisitingVerifiedNumbersList) {

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -27,6 +27,7 @@ import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
@@ -72,6 +73,8 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.isNull;
 
 public class UserEmailVerificationHandlerTest {
 
@@ -262,15 +265,29 @@ public class UserEmailVerificationHandlerTest {
         Map<String, String> userClaimsC2 = getUserClaimsFromEvent(event2);
         Assert.assertFalse(userClaimsC2.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM));
 
-        // Case 3: Try to change the primary email value with existing primary email value.
+        // Case 3: Try to change the primary email value with existing verified primary email value.
         Event event3 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, null, NEW_EMAIL);
         mockPendingVerificationEmail(EXISTING_EMAIL_1);
         mockPrimaryEmail(NEW_EMAIL);
+        mockPrimaryEmailVerificationStatus(true);
+
         userEmailVerificationHandler.handleEvent(event3);
         Map<String, String> userClaimsC3 = getUserClaimsFromEvent(event3);
         Assert.assertEquals(userClaimsC3.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM),
                 StringUtils.EMPTY);
+
+        // Case 4: Try to change the primary email value with existing unverified primary email value.
+        Event event4 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
+                null, null, NEW_EMAIL);
+        mockPendingVerificationEmail(EXISTING_EMAIL_1);
+        mockPrimaryEmail(NEW_EMAIL);
+        mockPrimaryEmailVerificationStatus(false);
+
+        userEmailVerificationHandler.handleEvent(event4);
+        Map<String, String> userClaimsC4 = getUserClaimsFromEvent(event4);
+        Assert.assertEquals(userClaimsC4.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM),
+                NEW_EMAIL);
     }
 
     @Test(description = "Verification - Enabled, Multi attribute - Disabled, User verify - Enabled")
@@ -379,12 +396,11 @@ public class UserEmailVerificationHandlerTest {
         Assert.assertEquals(userClaims1.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM), NEW_EMAIL);
 
         /*
-         Case 2: Update verified email list with the existing primary email which is not in the verified email list.
-         Expected: Email should be added to the updated verified email list.
+         Case 2: Update verified email list with the existing verified primary email which is not in the verified
+         email list.
+         Expected: Email should be added to the updated verified email list only if primary email is verified.
          */
         String newVerifiedEmails2 = String.format("%s,%s", EXISTING_EMAIL_1, NEW_EMAIL);
-        Event event2 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                newVerifiedEmails2, null, null);
 
         mockUtilMethods(true, true, false,
                 false);
@@ -396,17 +412,32 @@ public class UserEmailVerificationHandlerTest {
 
         mockPrimaryEmail(NEW_EMAIL);
 
+        // Case 2.1: Test when primary email is already verified.
+        Event event2 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
+                newVerifiedEmails2, null, null);
+        mockPrimaryEmailVerificationStatus(true);
+
         userEmailVerificationHandler.handleEvent(event2);
         Map<String, String> userClaims2 = getUserClaimsFromEvent(event2);
         String updatedVerifiedEmails = userClaims2.get(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM);
         Assert.assertTrue(StringUtils.contains(updatedVerifiedEmails, NEW_EMAIL));
+
+        // Case 2.2: Test when primary email is not verified.
+        Event event3 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
+                newVerifiedEmails2, null, null);
+        mockPrimaryEmailVerificationStatus(false);
+
+        userEmailVerificationHandler.handleEvent(event3);
+        Map<String, String> userClaims3 = getUserClaimsFromEvent(event3);
+        String updatedVerifiedEmails3 = userClaims3.get(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM);
+        Assert.assertFalse(StringUtils.contains(updatedVerifiedEmails3, NEW_EMAIL));
 
         /*
          Case 3: Add multiple new emails to verified emails list.
          Expected: Error should be thrown.
          */
         String newVerifiedEmails3 = String.format("%s,%s", EXISTING_EMAIL_1, NEW_EMAIL);
-        Event event3 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
+        Event event4 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 newVerifiedEmails3, null, null);
 
         mockUtilMethods(true, true, false,
@@ -415,8 +446,8 @@ public class UserEmailVerificationHandlerTest {
         mockExistingVerifiedEmailAddressesList(new ArrayList<>());
 
         try {
-            userEmailVerificationHandler.handleEvent(event3);
-        } catch(IdentityEventClientException e) {
+            userEmailVerificationHandler.handleEvent(event4);
+        } catch (IdentityEventClientException e) {
             Assert.assertEquals(e.getErrorCode(), IdentityRecoveryConstants.ErrorMessages.
                     ERROR_CODE_VERIFY_MULTIPLE_EMAILS.getCode());
         }
@@ -735,6 +766,41 @@ public class UserEmailVerificationHandlerTest {
         Assert.assertEquals(response, userRecoveryData);
     }
 
+    @DataProvider(name = "claimDeletionData")
+    public Object[][] getClaimDeletionData() {
+
+        return new Object[][]{
+                // claimURI, shouldCallSetUserClaimValues
+                {IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM, true},
+                {"some.other.claim", false}
+        };
+    }
+
+    @Test(description = "Test handling of claim deletion events - verifies that ;emailVerified' claim is cleared when " +
+            "email claim is deleted, and no action for other claims.", dataProvider = "claimDeletionData")
+    public void testHandleEventPreDeleteUserClaim(String claimURI, boolean shouldCallSetUserClaimValues)
+            throws IdentityEventException, UserStoreException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.USER_NAME, TEST_USERNAME);
+        eventProperties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, TEST_TENANT_DOMAIN);
+        eventProperties.put(IdentityEventConstants.EventProperty.USER_STORE_MANAGER, userStoreManager);
+        eventProperties.put(IdentityEventConstants.EventProperty.CLAIM_URI, claimURI);
+        Event event = new Event(IdentityEventConstants.Event.PRE_DELETE_USER_CLAIM, eventProperties);
+
+        userEmailVerificationHandler.handleEvent(event);
+
+        if (shouldCallSetUserClaimValues) {
+            // Verify that setUserClaimValues was called with empty string for emailVerified claim.
+            Map<String, String> expectedClaims = new HashMap<>();
+            expectedClaims.put(IdentityRecoveryConstants.EMAIL_VERIFIED_CLAIM, StringUtils.EMPTY);
+            verify(userStoreManager).setUserClaimValues(eq(TEST_USERNAME), eq(expectedClaims), isNull());
+        } else {
+            // Verify that setUserClaimValues was not called for other claims.
+            verify(userStoreManager, never()).setUserClaimValues(anyString(), any(), any());
+        }
+    }
+
     private void mockExistingEmailAddressesList(List<String> existingEmails) {
 
         mockedUtils.when(() -> Utils.getMultiValuedClaim(any(), any(),
@@ -762,6 +828,12 @@ public class UserEmailVerificationHandlerTest {
         when(userStoreManager.getUserClaimValues(anyString(),
                 eq(new String[]{IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM}),
                 any())).thenReturn(pendingEmailClaim);
+    }
+
+    private void mockPrimaryEmailVerificationStatus(boolean isVerified) {
+        
+        mockedUtils.when(() -> Utils.getUserClaim(any(), any(), eq(IdentityRecoveryConstants.EMAIL_VERIFIED_CLAIM)))
+                .thenReturn(String.valueOf(isVerified));
     }
 
     private void mockUtilMethods(boolean emailVerificationEnabled, boolean multiAttributeEnabled,

--- a/pom.xml
+++ b/pom.xml
@@ -710,7 +710,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.8.114</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.130</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request

- $Subject
- Resolves
    - https://github.com/wso2/product-is/issues/23958
    - https://github.com/wso2/product-is/issues/23451

- This PR:
    - Ensures that the `phoneVerified` and `emailVerified` claims are associated with the primary value and are set to true only when the primary value is explicitly verified. If the primary value is removed, these claims will also be cleared.
    - Previously, an existing primary email or mobile value was considered verified even without explicit user verification. With this PR, a primary email/mobile that is not explicitly verified by the user will no longer be treated as verified.

### To be merged after
- https://github.com/wso2/carbon-identity-framework/pull/6704

### Related PRs
- https://github.com/wso2/identity-apps/pull/8137

