### PR TITLE
Add utm parameter so lite user resend notification

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/LiteApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/LiteApiServiceImpl.java
@@ -175,6 +175,12 @@ public class LiteApiServiceImpl extends LiteApiService {
                     campaignDTO.setValue(value);
                     propertiesList.add(campaignDTO);
                 }
+                if (StringUtils.startsWith(key, IdentityRecoveryConstants.UTM_PARAMETERS_PREFIX)) {
+                    PropertyDTO templateDTO = new PropertyDTO();
+                    templateDTO.setKey(key);
+                    templateDTO.setValue(value);
+                    propertiesList.add(templateDTO);
+                }
             }
         }
         return Utils.getProperties(propertiesList);

--- a/components/org.wso2.carbon.identity.api.user.governance/src/test/java/org/wso2/carbon/identity/user/endpoint/impl/LiteApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/test/java/org/wso2/carbon/identity/user/endpoint/impl/LiteApiServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.api.user.governance/src/test/java/org/wso2/carbon/identity/user/endpoint/impl/LiteApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/test/java/org/wso2/carbon/identity/user/endpoint/impl/LiteApiServiceImplTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2016-2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.user.endpoint.impl;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
+import org.wso2.carbon.identity.recovery.bean.NotificationResponseBean;
+import org.wso2.carbon.identity.recovery.confirmation.ResendConfirmationManager;
+import org.wso2.carbon.identity.recovery.model.Property;
+import org.wso2.carbon.identity.recovery.signup.UserSelfRegistrationManager;
+import org.wso2.carbon.identity.user.endpoint.dto.LiteUserRegistrationRequestDTO;
+import org.wso2.carbon.identity.user.endpoint.dto.PropertyDTO;
+import org.wso2.carbon.identity.user.endpoint.util.Utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Unit test class for LiteApiServiceImpl.
+ */
+public class LiteApiServiceImplTest {
+
+    private LiteApiServiceImpl liteApiService;
+
+    private static final String TEST_DOMAIN = "test.com";
+
+    @BeforeMethod
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        liteApiService = new LiteApiServiceImpl();
+    }
+
+    /**
+     * Data provider for litePost test.
+     *
+     * @return Object[][] with test data.
+     * @throws IdentityRecoveryException on to replicate the behaviour when a user already exists.
+     */
+    @DataProvider
+    public Object[][] getLiteUserRegistrationRequestData() throws IdentityRecoveryException {
+
+        // Data for testing umt_parameter_filtering
+        LiteUserRegistrationRequestDTO liteUserRegistrationRequestDTO = new LiteUserRegistrationRequestDTO();
+        liteUserRegistrationRequestDTO.setEmail("unitTestUser@wso2.com");
+        liteUserRegistrationRequestDTO.setProperties(new ArrayList<PropertyDTO>() {
+            {
+                add(new PropertyDTO() {{
+                    setKey("utm_source");
+                    setValue("test_utm_source_value");
+                }});
+                add(new PropertyDTO() {{
+                    setKey("not_utm_medium");
+                    setValue("test_not_utm_medium_value");
+                }});
+            }
+        });
+        UserSelfRegistrationManager mockedUserSelfRegistrationManager =
+                Mockito.mock(UserSelfRegistrationManager.class);
+        when(mockedUserSelfRegistrationManager.registerLiteUser(any(), any(), any()))
+                .thenThrow(new IdentityRecoveryClientException(
+                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS.getCode(),
+                        IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS.getMessage()));
+
+        ArgumentCaptor<Property[]> propertiesListCaptor = ArgumentCaptor.forClass(Property[].class);
+        ResendConfirmationManager mockedResendConfirmationManager = Mockito.mock(ResendConfirmationManager.class);
+        when(mockedResendConfirmationManager.resendConfirmationCode(any(), any(), any(), any(),
+                propertiesListCaptor.capture())).thenReturn(new NotificationResponseBean(new User()));
+
+        return new Object[][]{
+                {liteUserRegistrationRequestDTO, mockedUserSelfRegistrationManager,
+                        mockedResendConfirmationManager, propertiesListCaptor}
+        };
+    }
+
+    /**
+     * Test for litePost method in LiteApiServiceImpl.
+     *
+     * @param liteUserRegistrationRequestDTO     liteUserRegistrationRequestDTO object to replicate the real request.
+     * @param mockedUserSelfRegistrationManager  mocked UserSelfRegistrationManager.
+     * @param mockedResendConfirmationManager    mocked ResendConfirmationManager.
+     * @param propertiesListCaptor               captor for properties list.
+     */
+    @Test(dataProvider = "getLiteUserRegistrationRequestData")
+    public void testLitePost(LiteUserRegistrationRequestDTO liteUserRegistrationRequestDTO,
+                             UserSelfRegistrationManager mockedUserSelfRegistrationManager,
+                             ResendConfirmationManager mockedResendConfirmationManager,
+                             ArgumentCaptor<Property[]> propertiesListCaptor) {
+
+        try (MockedStatic<IdentityUtil> mockedIdentityUtil = Mockito.mockStatic(IdentityUtil.class);
+             MockedStatic<Utils> mockedUtils = Mockito.mockStatic(Utils.class);
+             MockedStatic<org.wso2.carbon.identity.recovery.util.Utils> mockedRecoveryUtils =
+                     Mockito.mockStatic(org.wso2.carbon.identity.recovery.util.Utils.class)) {
+
+            mockedIdentityUtil.when(IdentityUtil::getPrimaryDomainName).thenReturn(TEST_DOMAIN);
+            mockedUtils.when(Utils::getUserSelfRegistrationManager).thenReturn(mockedUserSelfRegistrationManager);
+            mockedRecoveryUtils.when(() -> org.wso2.carbon.identity.recovery.util.Utils.getConnectorConfig(
+                    anyString(), anyString())).thenReturn("true");
+            mockedUtils.when(() -> Utils.getProperties(any(List.class))).thenCallRealMethod();
+
+            mockedUtils.when(Utils::getResendConfirmationManager).thenReturn(mockedResendConfirmationManager);
+            liteApiService.litePost(liteUserRegistrationRequestDTO);
+
+            Property[] capturedProperties = propertiesListCaptor.getValue();
+            assertEquals(capturedProperties.length, 1);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.api.user.governance/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/test/resources/testng.xml
@@ -28,6 +28,7 @@
             <class name="org.wso2.carbon.identity.user.endpoint.impl.PiInfoApiServiceImplTest" />
             <class name="org.wso2.carbon.identity.user.endpoint.impl.ValidateUsernameApiServiceImplTest" />
             <class name="org.wso2.carbon.identity.user.endpoint.impl.UpdateUsernameApiServiceImplTest"/>
+            <class name="org.wso2.carbon.identity.user.endpoint.impl.LiteApiServiceImplTest"/>
         </classes>
     </test>
 </suite>

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -81,6 +81,7 @@ public class IdentityRecoveryConstants {
     public static final String RESEND_EMAIL_TEMPLATE_NAME = "resendTemplateName";
     public static final String INITIATED_PLATFORM = "initiated-platform";
     public static final String CAMPAIGN = "campaign";
+    public static final String UTM_PARAMETERS_PREFIX = "utm_";
     public static final String CONFIRMATION_CODE = "confirmation-code";
     public static final String OTP_CODE = "OTPCode";
     public static final String OTP_TOKEN = "otpToken";


### PR DESCRIPTION
### Purpose 
As part of the feature to support UTM parameter tracking, this PR introduces the improvements to generate the sub query for UTM parameters which is to be used for the `utm-parameters` placeholders in email templates.

### Description 
This pull request introduces functionality to handle UTM parameters in the user governance API by adding a new constant and updating the logic for processing properties. Below are the most important changes :

#### Enhancements to UTM parameter handling:

* [`components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java`](diffhunk://#diff-3040477809cbb5d4423ab760bacc6699f38ac48ad66cf64e7612cb5f1fd4176dR84): Added a new constant, `UTM_PARAMETERS_PREFIX`, to define the prefix for UTM parameters (`utm_`).
* [`components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/LiteApiServiceImpl.java`](diffhunk://#diff-47b9f551e57f590aacef7c61db9fac62b29d549389a058070d68f759a4028753R178-R183): Updated the `getPropertyDTOList` method to check for keys starting with `UTM_PARAMETERS_PREFIX` and add them to the properties list as `PropertyDTO` objects.

### Related PR/s
- https://github.com/wso2-extensions/identity-event-handler-notification/pull/323