### PR TITLE
Improve error handling of password policy validation in IdentityMgtEventListener

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
@@ -1707,12 +1707,16 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
 
             if (StringUtils.isNotEmpty(errorCode)) {
                 //This error code 22001 means user password history is violated.
-                if (StringUtils.equals(errorCode, "22001") || StringUtils.equals(errorCode, "40001")
+                if (StringUtils.equals(errorCode, "22001")
                         || StringUtils.equals(errorCode, "40002")
                         || UserCoreConstants.ErrorCode.USER_IS_LOCKED.equals(errorCode)
                         || IdentityCoreConstants.USER_ACCOUNT_DISABLED_ERROR_CODE.equals(errorCode)
                         || IdentityCoreConstants.USER_ACCOUNT_NOT_CONFIRMED_ERROR_CODE.equals(errorCode)) {
                     throw new UserStoreException(e.getMessage(), e);
+                }
+                // This error code 40001 password policy could not be loaded.
+                if (StringUtils.equals(errorCode, "40001")) {
+                    throw new UserStoreException(e.getMessage(),errorCode,  e);
                 }
                 if (e instanceof IdentityEventClientException) {
                     throw new UserStoreClientException(e.getMessage(), errorCode, e);

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java
@@ -1716,7 +1716,7 @@ public class IdentityMgtEventListener extends AbstractIdentityUserOperationEvent
                 }
                 // This error code 40001 password policy could not be loaded.
                 if (StringUtils.equals(errorCode, "40001")) {
-                    throw new UserStoreException(e.getMessage(),errorCode,  e);
+                    throw new UserStoreException(e.getMessage(), errorCode, e);
                 }
                 if (e instanceof IdentityEventClientException) {
                     throw new UserStoreClientException(e.getMessage(), errorCode, e);


### PR DESCRIPTION
### Purpose

This PR improves how the IdentityMgtEventListener return error when the password-policy cannot be loaded (error code `40001`). Previously, `40001` was grouped with other policy-violation codes and thrown without propagating the specific error code. Now, we:

- Remove `40001` from the generic policy-violation block.

- Add a dedicated check for errorCode == "40001" that throws a UserStoreException including the original error code.

Adding the error code helps the SCIM User Manager to identify the specific scenario and send a proper error response for the user creation calls.

### Related Issues
- https://github.com/wso2/product-is/issues/23943

### Related PRs
- https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/637