### PR TITLE
Support ne operation for user's filtering with identity claims

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
@@ -461,8 +461,14 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
                 String claimValue = expressionCondition.getAttributeValue();
 
                 try {
-                    List<String> usernames = identityDataStoreService.listUsersByClaimURIAndValue(claimUri,
-                            getClaimValueForOperation(expressionCondition.getOperation(), claimValue), userManager);
+                    List<String> usernames;
+                    if (ExpressionOperation.NE.toString().equals(expressionCondition.getOperation())) {
+                        usernames = identityDataStoreService
+                                .getUserNamesByClaimURINotEqualValue(claimUri, claimValue, userManager);
+                    } else {
+                        usernames = identityDataStoreService.listUsersByClaimURIAndValue(claimUri,
+                                getClaimValueForOperation(expressionCondition.getOperation(), claimValue), userManager);
+                    }
 
                     updateUserList(usernames, filteredUserNameList, domain, isFirstClaimFilter);
 

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/IdentityDataStoreService.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/IdentityDataStoreService.java
@@ -94,6 +94,19 @@ public interface IdentityDataStoreService {
     void removeIdentityClaims(String username, UserStoreManager userStoreManager) throws IdentityException;
 
     /**
+     * Get the list of usernames who either do not have a value configured for the given claim URI
+     * or have a value that differs from the provided claim value.
+     *
+     * @param claimURI         Claim URI.
+     * @param claimValue       Claim value.
+     * @param userStoreManager UserStoreManager instance.
+     * @return List of usernames.
+     * @throws IdentityException Identity exception.
+     */
+    List<String> getUserNamesByClaimURINotEqualValue(String claimURI, String claimValue,
+                                                     UserStoreManager userStoreManager) throws IdentityException;
+
+    /**
      * Get the list of usernames who have the claim value less than the provided claim value for a given claim URI.
      *
      * @param claimURI              Claim URI.

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/IdentityDataStoreServiceImpl.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/IdentityDataStoreServiceImpl.java
@@ -159,6 +159,14 @@ public class IdentityDataStoreServiceImpl implements IdentityDataStoreService {
     }
 
     @Override
+    public List<String> getUserNamesByClaimURINotEqualValue(String claimURI, String claimValue,
+                                                            UserStoreManager userStoreManager)
+            throws IdentityException {
+
+        return identityDataStore.getUserNamesByClaimURINotEqualValue(claimURI, claimValue, userStoreManager);
+    }
+
+    @Override
     public List<String> getUserNamesLessThanProvidedClaimValue(String claimURI, String claimValue, int tenantId)
             throws IdentityException {
 

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/UserIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/UserIdentityDataStore.java
@@ -117,6 +117,23 @@ public abstract class UserIdentityDataStore {
     }
 
     /**
+     * Get the list of usernames who either do not have a value configured for the given claim URI
+     * or have a value that differs from the provided claim value.
+     *
+     * @param claimURI         Claim URI.
+     * @param claimValue       Claim value.
+     * @param userStoreManager UserStoreManager instance.
+     * @return List of usernames.
+     * @throws IdentityException Identity exception.
+     */
+    public List<String> getUserNamesByClaimURINotEqualValue(String claimURI, String claimValue,
+                                                            org.wso2.carbon.user.core.UserStoreManager userStoreManager)
+            throws IdentityException {
+
+        return Collections.emptyList();
+    }
+
+    /**
      * Get the list of usernames who have the claim value less than the provided claim value for a given claim URI.
      *
      * @param claimURI              Claim URI.

--- a/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/store/JDBCIdentityDataStoreTest.java
+++ b/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/store/JDBCIdentityDataStoreTest.java
@@ -20,7 +20,9 @@ package org.wso2.carbon.identity.governance.store;
 
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -31,16 +33,26 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.governance.service.IdentityDataStoreService;
 import org.wso2.carbon.identity.governance.service.IdentityDataStoreServiceImpl;
 import org.wso2.carbon.identity.governance.store.Utils.TestUtils;
+import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.model.ExpressionCondition;
+import org.wso2.carbon.user.core.model.ExpressionOperation;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.utils.dbcreator.DatabaseCreator;
 
 import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 public class JDBCIdentityDataStoreTest {
@@ -51,31 +63,71 @@ public class JDBCIdentityDataStoreTest {
     private static final String CLAIM_URI = "http://wso2.org/claims/identity/lastLogonTime";
     private static final String CLAIM_VALUE_1 = "1680000000000";
     private static final String CLAIM_VALUE_2 = "1673000000000";
-    private static final String NESTED_CLAIM_URI = "http://wso2.org/claims/identity/accountState";
-    private static final String NESTED_CLAIM_VALUE = "DISABLED";
+    private static final String ACCOUNT_STATE_CLAIM_URI = "http://wso2.org/claims/identity/accountState";
+    private static final String ACCOUNT_STATE_CLAIM_VALUE = "DISABLED";
+    private static final String EMAIL_VERIFIED_CLAIM = "http://wso2.org/claims/identity/emailVerified";
 
     private MockedStatic<IdentityDatabaseUtil> mockedIdentityDatabaseUtils;
     private MockedStatic<IdentityTenantUtil> mockedIdentityTenantUtil;
     private MockedStatic<CarbonContext> mockedCarbonContext;
     private MockedStatic<IdentityUtil> mockedIdentityUtil;
+    private MockedStatic<UserCoreUtil> mockedUserCoreUtil;
+    private MockedStatic<DatabaseCreator> mockedDatabaseCreator;
 
     private UserStoreManager userStoreManager;
     IdentityDataStoreService identityDataStoreService;
+    private JDBCIdentityDataStore jdbcIdentityDataStore;
+    private RealmConfiguration realmConfiguration;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+
+        TestUtils.initiateH2Base();
+        TestUtils.mockDataSource();
+    }
 
     @BeforeMethod
     public void setUp() throws Exception {
 
-        TestUtils.initiateH2Base();
-        TestUtils.mockDataSource();
+        setupIdentityDatabaseUtilMocks();
+        setupDatabaseCreatorMocks();
+        setupIdentityTenantUtilMocks();
+        setupIdentityUtilMocks();
+        setupCarbonContextMocks();
+        setupUserCoreUtilMocks();
 
-        Connection connection = TestUtils.getConnection();
+        identityDataStoreService = spy(new IdentityDataStoreServiceImpl());
+        jdbcIdentityDataStore = new JDBCIdentityDataStore();
+    }
+
+    private void setupIdentityDatabaseUtilMocks() {
+
         mockedIdentityDatabaseUtils = Mockito.mockStatic(IdentityDatabaseUtil.class);
+
         mockedIdentityDatabaseUtils.when(() -> IdentityDatabaseUtil.getDBConnection(anyBoolean()))
-                .thenReturn(connection);
+                .thenAnswer(invocation -> TestUtils.getConnection());
+        mockedIdentityDatabaseUtils.when(IdentityDatabaseUtil::getDBConnection)
+                .thenAnswer(invocation -> TestUtils.getConnection());
+        mockedIdentityDatabaseUtils.when(() -> IdentityDatabaseUtil.commitTransaction(any(Connection.class)))
+                .thenAnswer(invocation -> null);
+        mockedIdentityDatabaseUtils.when(() -> IdentityDatabaseUtil.rollbackTransaction(any(Connection.class)))
+                .thenAnswer(invocation -> null);
+        mockedIdentityDatabaseUtils.when(() -> IdentityDatabaseUtil.closeConnection(any(Connection.class)))
+                .thenAnswer(invocation -> null);
+        mockedIdentityDatabaseUtils.when(() -> IdentityDatabaseUtil.closeStatement(any()))
+                .thenAnswer(invocation -> null);
+        mockedIdentityDatabaseUtils.when(() -> IdentityDatabaseUtil.closeResultSet(any()))
+                .thenAnswer(invocation -> null);
+    }
+
+    private void setupIdentityTenantUtilMocks() {
 
         mockedIdentityTenantUtil = Mockito.mockStatic(IdentityTenantUtil.class);
         mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString()))
                 .thenReturn(TENANT_ID);
+    }
+
+    private void setupCarbonContextMocks() {
 
         UserRealm userRealm = mock(UserRealm.class);
         userStoreManager = mock(UserStoreManager.class);
@@ -87,11 +139,31 @@ public class JDBCIdentityDataStoreTest {
         mockedCarbonContext.when(userRealm::getUserStoreManager).thenReturn(userStoreManager);
         mockedCarbonContext.when(() ->
                 userStoreManager.getSecondaryUserStoreManager(anyString())).thenReturn(userStoreManager);
+    }
+
+    private void setupIdentityUtilMocks() {
 
         mockedIdentityUtil = Mockito.mockStatic(IdentityUtil.class);
         mockedIdentityUtil.when(() -> IdentityUtil.getProperty(anyString())).thenReturn
                 (IDENTITY_DATA_STORE_TYPE);
-        identityDataStoreService = spy(new IdentityDataStoreServiceImpl());
+    }
+
+    private void setupUserCoreUtilMocks() throws UserStoreException {
+
+        realmConfiguration = mock(RealmConfiguration.class);
+        mockedUserCoreUtil = Mockito.mockStatic(UserCoreUtil.class);
+        when(userStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
+        when(userStoreManager.getTenantId()).thenReturn(3);
+        mockedUserCoreUtil
+                .when(() -> UserCoreUtil.getDomainName(realmConfiguration))
+                .thenReturn("DEFAULT");
+    }
+
+    private void setupDatabaseCreatorMocks() {
+
+        mockedDatabaseCreator = Mockito.mockStatic(DatabaseCreator.class);
+        mockedDatabaseCreator.when(() -> DatabaseCreator.getDatabaseType(any(Connection.class)))
+                .thenReturn("h2");
     }
 
     @AfterMethod
@@ -101,6 +173,13 @@ public class JDBCIdentityDataStoreTest {
         mockedIdentityTenantUtil.close();
         mockedCarbonContext.close();
         mockedIdentityUtil.close();
+        mockedUserCoreUtil.close();
+        mockedDatabaseCreator.close();
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+
         TestUtils.closeH2Base();
     }
 
@@ -125,7 +204,7 @@ public class JDBCIdentityDataStoreTest {
 
         List<String> userNames =
                 identityDataStoreService.getUserNamesLessThanClaimWithNestedClaim(CLAIM_URI, CLAIM_VALUE_1,
-                        NESTED_CLAIM_URI, NESTED_CLAIM_VALUE, TENANT_ID, isIncluded);
+                        ACCOUNT_STATE_CLAIM_URI, ACCOUNT_STATE_CLAIM_VALUE, TENANT_ID, isIncluded);
 
         assertEquals(userNames.size(), expected);
     }
@@ -135,8 +214,171 @@ public class JDBCIdentityDataStoreTest {
 
         List<String> userNames =
                 identityDataStoreService.getUserNamesBetweenGivenClaimsWithNestedClaim(CLAIM_URI, CLAIM_VALUE_2,
-                        CLAIM_VALUE_1, NESTED_CLAIM_URI, NESTED_CLAIM_VALUE, TENANT_ID, isIncluded);
+                        CLAIM_VALUE_1, ACCOUNT_STATE_CLAIM_URI, ACCOUNT_STATE_CLAIM_VALUE, TENANT_ID, isIncluded);
 
         assertEquals(userNames.size(), expected);
+    }
+
+    @DataProvider
+    Object[][] testDataForListUsersNamesWithNE() {
+        return new Object[][]{
+                {EMAIL_VERIFIED_CLAIM, "true", 4},
+                {ACCOUNT_STATE_CLAIM_URI, ACCOUNT_STATE_CLAIM_VALUE, 2}
+        };
+    }
+
+    @Test(description = "Test getUserNamesByClaimURINotEqualValue which retrieves usernames where the claim URI " +
+            "value is not equal to the given value.", dataProvider = "testDataForListUsersNamesWithNE")
+    public void testGetUserNamesByClaimURINotEqualValue(String claimUri, String claimValue, int expected)
+            throws Exception {
+
+        List<String> userNames = jdbcIdentityDataStore
+                .getUserNamesByClaimURINotEqualValue(claimUri, claimValue, userStoreManager);
+
+        assertEquals(userNames.size(), expected);
+    }
+
+    @DataProvider
+    Object[][] testDataForListPaginatedUsersNamesWithSingleNE() {
+        return new Object[][]{
+                {ACCOUNT_STATE_CLAIM_URI, ACCOUNT_STATE_CLAIM_VALUE, "DEFAULT", 10, 1, 2},
+                {EMAIL_VERIFIED_CLAIM, "true", "DEFAULT", 10, 1, 4}
+        };
+    }
+
+    @Test(description = "Test listPaginatedUsersNames with NE (Not Equal) operation for filtering users.",
+            dataProvider = "testDataForListPaginatedUsersNamesWithSingleNE")
+    public void testListPaginatedUsersNamesWithSingleNEOperation(String claimUri, String claimValue, String domain,
+                                                                 int limit, int offset, int expectedCount)
+            throws Exception {
+
+        ExpressionCondition neCondition = new ExpressionCondition(
+                ExpressionOperation.NE.toString(), claimUri, claimValue);
+        List<ExpressionCondition> conditions = Collections.singletonList(neCondition);
+
+        List<String> filteredUserNames = new ArrayList<>();
+
+        List<String> result = jdbcIdentityDataStore.listPaginatedUsersNames(
+                conditions, filteredUserNames, domain, userStoreManager, limit, offset);
+
+        // Verify the results.
+        assertEquals(result.size(), expectedCount,
+                "Expected " + expectedCount + " users for NE operation on claim: " + claimUri);
+    }
+
+    @DataProvider
+    Object[][] testDataForListPaginatedUsersNamesWithMultipleNE() {
+        return new Object[][]{
+                {10, 1, 2},
+                {1, 1, 1} // Test with pagination.
+        };
+    }
+
+    @Test(description = "Test listPaginatedUsersNames with multiple NE operations for filtering users without " +
+            "DISABLED state AND without emailVerified true.",
+            dataProvider = "testDataForListPaginatedUsersNamesWithMultipleNE")
+    public void testListPaginatedUsersNamesWithMultipleNEOperations(int limit, int offset, int expectedCount)
+            throws Exception {
+
+        List<ExpressionCondition> conditions = new ArrayList<>();
+
+        // Add NE condition for accountState.
+        conditions.add(new ExpressionCondition(
+                ExpressionOperation.NE.toString(), ACCOUNT_STATE_CLAIM_URI, ACCOUNT_STATE_CLAIM_VALUE));
+        // Add NE condition for emailVerified.
+        conditions.add(new ExpressionCondition(
+                ExpressionOperation.NE.toString(), EMAIL_VERIFIED_CLAIM, "true"));
+
+
+        List<String> filteredUserNames = new ArrayList<>();
+        List<String> result = jdbcIdentityDataStore.listPaginatedUsersNames(
+                conditions, filteredUserNames, "DEFAULT", userStoreManager, limit, offset);
+
+        // Verify the results.
+        assertEquals(result.size(), expectedCount,
+                "Expected " + expectedCount + " users for multiple NE operations");
+    }
+
+    @Test(description = "Test listPaginatedUsersNames with mixed operations (EQ and NE) for filtering users with" +
+            "DISABLED state AND without emailVerified true.")
+    public void testListPaginatedUsersNamesMixedOperations() throws Exception {
+
+        List<ExpressionCondition> conditions = new ArrayList<>();
+
+        // Add NE condition for accountState.
+        conditions.add(new ExpressionCondition(
+                ExpressionOperation.EQ.toString(), ACCOUNT_STATE_CLAIM_URI, ACCOUNT_STATE_CLAIM_VALUE));
+        // Add NE condition for emailVerified.
+        conditions.add(new ExpressionCondition(
+                ExpressionOperation.NE.toString(), EMAIL_VERIFIED_CLAIM, "true"));
+
+
+        List<String> filteredUserNames = new ArrayList<>();
+
+        List<String> result = jdbcIdentityDataStore.listPaginatedUsersNames(
+                conditions, filteredUserNames, "DEFAULT", userStoreManager, 10, 1);
+
+        // Verify the results.
+        assertEquals(result.size(), 2, "Expected 2 user for mixed operations with EQ and NE");
+    }
+
+    @Test(description = "Test listPaginatedUsersNames with NE operation and pagination parameters.")
+    public void testListPaginatedUsersNamesWithNEAndPagination() throws Exception {
+
+        // Create ExpressionCondition with NE operation for accountState.
+        ExpressionCondition neCondition = new ExpressionCondition(
+                ExpressionOperation.NE.toString(), ACCOUNT_STATE_CLAIM_URI, ACCOUNT_STATE_CLAIM_VALUE);
+        List<ExpressionCondition> conditions = Collections.singletonList(neCondition);
+
+        List<String> filteredUserNames = new ArrayList<>();
+
+        // Test with limit 1, offset 1.
+        List<String> result1 = jdbcIdentityDataStore.listPaginatedUsersNames(
+                conditions, filteredUserNames, "DEFAULT", userStoreManager, 1, 1);
+        assertEquals(result1.size(), 1, "Should return 1 user with limit 1");
+
+        // Test with limit 2, offset 1.
+        filteredUserNames.clear();
+        List<String> result2 = jdbcIdentityDataStore.listPaginatedUsersNames(
+                conditions, filteredUserNames, "DEFAULT", userStoreManager, 2, 1);
+        assertEquals(result2.size(), 2, "Should return 2 users with limit 2");
+
+        // Test with limit 1, offset 2.
+        filteredUserNames.clear();
+        List<String> result3 = jdbcIdentityDataStore.listPaginatedUsersNames(
+                conditions, filteredUserNames, "DEFAULT", userStoreManager, 1, 2);
+        assertEquals(result3.size(), 1, "Should return 1 user with limit 1, offset 2");
+    }
+
+    @Test(description = "Test listPaginatedUsersNames with NE operation for non-existent claim values.")
+    public void testListPaginatedUsersNamesWithNEForNonExistentValues() throws Exception {
+
+        ExpressionCondition neCondition = new ExpressionCondition(
+                ExpressionOperation.NE.toString(), ACCOUNT_STATE_CLAIM_URI, "NON_EXISTENT_STATE");
+        List<ExpressionCondition> conditions = Collections.singletonList(neCondition);
+
+        List<String> filteredUserNames = new ArrayList<>();
+
+        List<String> result = jdbcIdentityDataStore.listPaginatedUsersNames(
+                conditions, filteredUserNames, "DEFAULT", userStoreManager, 10, 1);
+
+        // Verify the results.
+        assertEquals(result.size(), 5, "Should return all 5 users for NE operation with non-existent value");
+    }
+
+    @Test(description = "Test listPaginatedUsersNames with NE operation for non-existent claim URI.")
+    public void testListPaginatedUsersNamesWithNEForNonExistentClaimURI() throws Exception {
+
+        ExpressionCondition neCondition = new ExpressionCondition(
+                ExpressionOperation.NE.toString(), "http://wso2.org/claims/identity/nonExistentClaim", "anyValue");
+        List<ExpressionCondition> conditions = Collections.singletonList(neCondition);
+
+        List<String> filteredUserNames = new ArrayList<>();
+
+        List<String> result = jdbcIdentityDataStore.listPaginatedUsersNames(
+                conditions, filteredUserNames, "DEFAULT", userStoreManager, 10, 1);
+
+        // Verify the results. Should return all 5 users since none have the non-existent claim URI.
+        assertEquals(result.size(), 5, "Should return all 5 users for NE operation with non-existent claim URI");
     }
 }

--- a/components/org.wso2.carbon.identity.governance/src/test/resources/dbscripts/h2.sql
+++ b/components/org.wso2.carbon.identity.governance/src/test/resources/dbscripts/h2.sql
@@ -17,4 +17,5 @@ INSERT INTO IDN_IDENTITY_USER_DATA (TENANT_ID, USER_NAME, DATA_KEY, DATA_VALUE) 
 (3, 'DEFAULT/sampleUser5@xmail.com', 'http://wso2.org/claims/identity/lastLogonTime', '1674950400000'),
 (3, 'DEFAULT/sampleUser1@xmail.com', 'http://wso2.org/claims/identity/accountState', 'DISABLED'),
 (3, 'DEFAULT/sampleUser3@xmail.com', 'http://wso2.org/claims/identity/accountState', 'DISABLED'),
-(3, 'DEFAULT/sampleUser5@xmail.com', 'http://wso2.org/claims/identity/accountState', 'DISABLED');
+(3, 'DEFAULT/sampleUser5@xmail.com', 'http://wso2.org/claims/identity/accountState', 'DISABLED'),
+(3, 'DEFAULT/sampleUser5@xmail.com', 'http://wso2.org/claims/identity/emailVerified', 'true');

--- a/pom.xml
+++ b/pom.xml
@@ -703,7 +703,7 @@
         <identity.data.publisher.authentication.version>5.3.27</identity.data.publisher.authentication.version>
 
         <!--Carbon Kernel Version-->
-        <carbon.kernel.version>4.10.25</carbon.kernel.version>
+        <carbon.kernel.version>4.10.55</carbon.kernel.version>
         <carbon.kernel.feature.version>4.9.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>


### PR DESCRIPTION
### Purpose 
- $Subject

> **Note:**  
> In [`AbstractUserStoreManager.handlePreGetUserListWithIdentityClaims()`](https://github.com/wso2/carbon-kernel/blob/089209a1b3aaa4069e15ddc503a3209f94601638/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java#L17241-L17263), two different methods are invoked based on whether non-identity claims are included in the filter:  
> - If **non-identity claims** are present, `doPreGetUserList()` is called.  
> - If **only identity claims** are present, `doPreGetPaginatedUserList()` is used.  
>   
> This PR ensures that conditions using the `NE` operator are handled correctly in both scenarios.

### To be merged after
- https://github.com/wso2/carbon-kernel/pull/4305