### PR TITLE
Add property to thread local to indicate mobile verification triggered.

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -89,6 +89,7 @@ public class IdentityRecoveryConstants {
     public static final String VERIFICATION_PENDING_EMAIL = "verification-pending-email";
     public static final String NEW_EMAIL_ADDRESS = "new-email-address";
     public static final String NOTIFY = "notify";
+    public static final String OTP_VERIFICATION_TRIGGERED_CLAIM = "otpVerificationTriggeredClaim";
     public static final String WSO2CARBON_CLAIM_DIALECT = "http://wso2.org/claims";
     public static final String ACCOUNT_LOCKED_CLAIM = "http://wso2.org/claims/identity/accountLocked";
     public static final String ACCOUNT_LOCKED_REASON_CLAIM = "http://wso2.org/claims/identity/lockedReason";


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/23770

Add `otpVerificationTriggeredClaims` to the thread-local, containing the claim (http://wso2.org/claims/mobile or http://wso2.org/claims/verifiedMobileNumbers) that triggered the verification. This will be used during the authentication flow to display the OTP page and verify whether the provided value has been successfully validated.