### PR TITLE
Skip the test run in report generate phase in the PR builder.

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -43,7 +43,7 @@ jobs:
         run: mvn clean install -U -B
 
       - name: Generate coverage report
-        run: mvn test jacoco:report
+        run: mvn jacoco:report
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
### Proposed changes in this pull request
- $subject to reduce the PR builder running time.
- PR builder running time has reduced from 6m to 4m now.