### PR TITLE
Support ne operation for user's filtering with identity claims

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
@@ -464,8 +464,8 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
                 try {
                     List<String> usernames;
                    if (ExpressionOperation.NE.toString().equals(operation)) {
-                       usernames = identityDataStoreService.getUserNamesByClaimURINotEqualValue(claimUri, claimValue,
-                               userManager);
+                       usernames = identityDataStoreService.getUserNamesByClaimURINotEqualValue(condition, claimUri,
+                               claimValue, userManager);
                    } else {
                         usernames = identityDataStoreService.listUsersByClaimURIAndValue(claimUri,
                                 getClaimValueForOperation(operation, claimValue), userManager);

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListener.java
@@ -459,11 +459,17 @@ public class IdentityStoreEventListener extends AbstractIdentityUserOperationEve
             String claimUri = expressionCondition.getAttributeName();
             if (claimUri.contains(UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI)) {
                 String claimValue = expressionCondition.getAttributeValue();
+                String operation = expressionCondition.getOperation();
 
                 try {
-                    List<String> usernames = identityDataStoreService.listUsersByClaimURIAndValue(claimUri,
-                            getClaimValueForOperation(expressionCondition.getOperation(), claimValue), userManager);
-
+                    List<String> usernames;
+                   if (ExpressionOperation.NE.toString().equals(operation)) {
+                       usernames = identityDataStoreService.getUserNamesByClaimURINotEqualValue(claimUri, claimValue,
+                               userManager);
+                   } else {
+                        usernames = identityDataStoreService.listUsersByClaimURIAndValue(claimUri,
+                                getClaimValueForOperation(operation, claimValue), userManager);
+                   }
                     updateUserList(usernames, filteredUserNameList, domain, isFirstClaimFilter);
 
                     if (log.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/IdentityDataStoreService.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/IdentityDataStoreService.java
@@ -22,6 +22,7 @@ import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.governance.model.UserIdentityClaim;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.model.Condition;
 import org.wso2.carbon.user.core.model.ExpressionCondition;
 
 import java.util.Collections;
@@ -97,14 +98,19 @@ public interface IdentityDataStoreService {
      * Get the list of usernames who either do not have a value configured for the given claim URI
      * or have a value that differs from the provided claim value.
      *
+     * @param condition        Condition.
      * @param claimURI         Claim URI.
      * @param claimValue       Claim value.
      * @param userStoreManager UserStoreManager instance.
      * @return List of usernames.
      * @throws IdentityException Identity exception.
      */
-    List<String> getUserNamesByClaimURINotEqualValue(String claimURI, String claimValue,
-                                                     UserStoreManager userStoreManager) throws IdentityException;
+    default List<String> getUserNamesByClaimURINotEqualValue(Condition condition, String claimURI, String claimValue,
+                                                             UserStoreManager userStoreManager)
+            throws IdentityException {
+
+        return Collections.emptyList();
+    }
 
     /**
      * Get the list of usernames who have the claim value less than the provided claim value for a given claim URI.

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/IdentityDataStoreService.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/IdentityDataStoreService.java
@@ -94,6 +94,19 @@ public interface IdentityDataStoreService {
     void removeIdentityClaims(String username, UserStoreManager userStoreManager) throws IdentityException;
 
     /**
+     * Get the list of usernames who either do not have a value configured for the given claim URI
+     * or have a value that differs from the provided claim value.
+     *
+     * @param claimURI         Claim URI.
+     * @param claimValue       Claim value.
+     * @param userStoreManager UserStoreManager instance.
+     * @return List of usernames.
+     * @throws IdentityException Identity exception.
+     */
+    List<String> getUserNamesByClaimURINotEqualValue(String claimURI, String claimValue,
+                                                     UserStoreManager userStoreManager) throws IdentityException;
+
+    /**
      * Get the list of usernames who have the claim value less than the provided claim value for a given claim URI.
      *
      * @param claimURI              Claim URI.

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/IdentityDataStoreServiceImpl.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/IdentityDataStoreServiceImpl.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.governance.store.UserStoreBasedIdentityDataStore
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.model.Condition;
 import org.wso2.carbon.user.core.model.ExpressionCondition;
 
 import java.util.Iterator;
@@ -159,11 +160,11 @@ public class IdentityDataStoreServiceImpl implements IdentityDataStoreService {
     }
 
     @Override
-    public List<String> getUserNamesByClaimURINotEqualValue(String claimURI, String claimValue,
+    public List<String> getUserNamesByClaimURINotEqualValue(Condition condition, String claimURI, String claimValue,
                                                             UserStoreManager userStoreManager)
             throws IdentityException {
 
-        return identityDataStore.getUserNamesByClaimURINotEqualValue(claimURI, claimValue, userStoreManager);
+        return identityDataStore.getUserNamesByClaimURINotEqualValue(condition, claimURI, claimValue, userStoreManager);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/IdentityDataStoreServiceImpl.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/IdentityDataStoreServiceImpl.java
@@ -159,6 +159,14 @@ public class IdentityDataStoreServiceImpl implements IdentityDataStoreService {
     }
 
     @Override
+    public List<String> getUserNamesByClaimURINotEqualValue(String claimURI, String claimValue,
+                                                            UserStoreManager userStoreManager)
+            throws IdentityException {
+
+        return identityDataStore.getUserNamesByClaimURINotEqualValue(claimURI, claimValue, userStoreManager);
+    }
+
+    @Override
     public List<String> getUserNamesLessThanProvidedClaimValue(String claimURI, String claimValue, int tenantId)
             throws IdentityException {
 

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/JDBCIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/JDBCIdentityDataStore.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.governance.model.UserIdentityClaim;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.model.Condition;
 import org.wso2.carbon.user.core.model.ExpressionCondition;
 import org.wso2.carbon.user.core.model.ExpressionOperation;
 import org.wso2.carbon.user.core.model.SqlBuilder;
@@ -373,7 +374,7 @@ public class JDBCIdentityDataStore extends InMemoryIdentityDataStore {
     }
 
     @Override
-    public List<String> getUserNamesByClaimURINotEqualValue(String claimUri, String claimValue,
+    public List<String> getUserNamesByClaimURINotEqualValue(Condition condition, String claimUri, String claimValue,
                                                             org.wso2.carbon.user.core.UserStoreManager userStoreManager)
             throws IdentityException {
 
@@ -801,11 +802,10 @@ public class JDBCIdentityDataStore extends InMemoryIdentityDataStore {
                                                       String domain) throws IdentityException {
 
         try {
-            // Construct domain-aware filter
-            String filter = StringUtils.equalsIgnoreCase(domain, UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME)
-                    ? "/*" : domain + UserCoreConstants.DOMAIN_SEPARATOR + "*";
+            // Construct domain-aware filter.
+            String filter = domain + UserCoreConstants.DOMAIN_SEPARATOR + "*";
 
-            // Get users with domain filter - already returns domain-qualified usernames
+            // Get users with domain filter - already returns domain-qualified usernames.
             String[] users = userStoreManager.listUsers(filter, -1);
 
             return users != null ? Arrays.asList(users) : new ArrayList<>();

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/UserIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/UserIdentityDataStore.java
@@ -117,6 +117,23 @@ public abstract class UserIdentityDataStore {
     }
 
     /**
+     * Get the list of usernames who either do not have a value configured for the given claim URI
+     * or have a value that differs from the provided claim value.
+     *
+     * @param claimURI         Claim URI.
+     * @param claimValue       Claim value.
+     * @param userStoreManager UserStoreManager instance.
+     * @return List of usernames.
+     * @throws IdentityException Identity exception.
+     */
+    public List<String> getUserNamesByClaimURINotEqualValue(String claimURI, String claimValue,
+                                                            org.wso2.carbon.user.core.UserStoreManager userStoreManager)
+            throws IdentityException {
+
+        return Collections.emptyList();
+    }
+
+    /**
      * Get the list of usernames who have the claim value less than the provided claim value for a given claim URI.
      *
      * @param claimURI              Claim URI.

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/UserIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/UserIdentityDataStore.java
@@ -22,6 +22,7 @@ import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.governance.model.UserIdentityClaim;
 import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.model.Condition;
 import org.wso2.carbon.user.core.model.ExpressionCondition;
 
 import java.util.Collections;
@@ -126,7 +127,7 @@ public abstract class UserIdentityDataStore {
      * @return List of usernames.
      * @throws IdentityException Identity exception.
      */
-    public List<String> getUserNamesByClaimURINotEqualValue(String claimURI, String claimValue,
+    public List<String> getUserNamesByClaimURINotEqualValue(Condition condition, String claimURI, String claimValue,
                                                             org.wso2.carbon.user.core.UserStoreManager userStoreManager)
             throws IdentityException {
 

--- a/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListenerTest.java
+++ b/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/listener/IdentityStoreEventListenerTest.java
@@ -40,10 +40,14 @@ import org.wso2.carbon.identity.governance.store.UserIdentityDataStore;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.model.Condition;
+import org.wso2.carbon.user.core.model.ExpressionCondition;
+import org.wso2.carbon.user.core.model.ExpressionOperation;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -391,5 +395,47 @@ public class IdentityStoreEventListenerTest {
         }).when(userIdentityDataStore).remove(username, userStoreManager);
 
         Assert.assertTrue(identityStoreEventListener.doPostDeleteUser(username, userStoreManager));
+    }
+
+    @Test(description = "Verify doPreGetUserList supports NE operator on identity claims.")
+    public void testDoPreGetUserListWithNEClaim() throws Exception {
+
+        userStoreManager = mock(UserStoreManager.class);
+        realmConfiguration = mock(RealmConfiguration.class);
+        final String claimUri = "http://wso2.org/claims/identity/accountLocked";
+        final String claimValue = "true";
+        String domainName = "PRIMARY";
+
+        // Build an ExpressionCondition that uses the NE operation.
+        ExpressionCondition condition = new ExpressionCondition(
+                ExpressionOperation.NE.toString(), claimUri, claimValue);
+
+        Mockito.when(userStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
+        Mockito.when(realmConfiguration.getUserStoreProperty(STORE_IDENTITY_CLAIMS))
+                .thenReturn(String.valueOf(false));
+        Mockito.when(UserCoreUtil.getDomainName(realmConfiguration)).thenReturn(domainName);
+
+        List<String> expectedUsernames = Arrays.asList(
+                domainName + "/user1",
+                domainName + "/user2");
+
+        Mockito.doReturn(expectedUsernames).when(identityDataStoreService)
+                .getUserNamesByClaimURINotEqualValue(
+                        Mockito.any(Condition.class), Mockito.anyString(), Mockito.anyString(),
+                        Mockito.any(UserStoreManager.class));
+        Mockito.doReturn(false).when(identityDataStoreService).isUserStoreBasedIdentityDataStore();
+
+        List<String> filteredUserList = new ArrayList<>();
+        boolean result = identityStoreEventListener.doPreGetUserList(
+                condition, filteredUserList, userStoreManager, "SECONDARY");
+
+        // Assert that the method returns true and the filtered user list matches the expected usernames.
+        assertTrue(result, "doPreGetUserList should return true on success.");
+        assertEquals(filteredUserList, expectedUsernames,
+                "Filtered user list should match the data-store results for NE filtering.");
+
+        // Verify that the identity-data-store was actually queried with NE.
+        Mockito.verify(identityDataStoreService, Mockito.times(1))
+                .getUserNamesByClaimURINotEqualValue(condition, claimUri, claimValue, userStoreManager);
     }
 }

--- a/components/org.wso2.carbon.identity.governance/src/test/resources/dbscripts/h2.sql
+++ b/components/org.wso2.carbon.identity.governance/src/test/resources/dbscripts/h2.sql
@@ -17,4 +17,5 @@ INSERT INTO IDN_IDENTITY_USER_DATA (TENANT_ID, USER_NAME, DATA_KEY, DATA_VALUE) 
 (3, 'DEFAULT/sampleUser5@xmail.com', 'http://wso2.org/claims/identity/lastLogonTime', '1674950400000'),
 (3, 'DEFAULT/sampleUser1@xmail.com', 'http://wso2.org/claims/identity/accountState', 'DISABLED'),
 (3, 'DEFAULT/sampleUser3@xmail.com', 'http://wso2.org/claims/identity/accountState', 'DISABLED'),
-(3, 'DEFAULT/sampleUser5@xmail.com', 'http://wso2.org/claims/identity/accountState', 'DISABLED');
+(3, 'DEFAULT/sampleUser5@xmail.com', 'http://wso2.org/claims/identity/accountState', 'DISABLED'),
+(3, 'DEFAULT/sampleUser5@xmail.com', 'http://wso2.org/claims/identity/emailVerified', 'true');

--- a/pom.xml
+++ b/pom.xml
@@ -703,7 +703,7 @@
         <identity.data.publisher.authentication.version>5.3.27</identity.data.publisher.authentication.version>
 
         <!--Carbon Kernel Version-->
-        <carbon.kernel.version>4.10.44</carbon.kernel.version>
+        <carbon.kernel.version>4.10.55</carbon.kernel.version>
         <carbon.kernel.feature.version>4.9.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>


### PR DESCRIPTION
### Purpose 
- Add support for the `ne` operator in claim-based filtering.
- Ensure that when using `ne`, both:
  - Users in the identity store whose claim value does **not** match the filter, and  
  - Users not present in the identity store but existing in the user store  
  are all included in the result set.

> **Note:**  
> In [`AbstractUserStoreManager.handlePreGetUserListWithIdentityClaims()`](https://github.com/wso2/carbon-kernel/blob/089209a1b3aaa4069e15ddc503a3209f94601638/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java#L17241-L17263), two different methods are invoked based on whether non-identity claims are included in the filter:  
> - If **non-identity claims** are present, `doPreGetUserList()` is called.  
> - If **only identity claims** are present, `doPreGetPaginatedUserList()` is used.  
>   
> This PR ensures that conditions using the `NE` operator are handled correctly in both scenarios.

### To be merged after
- https://github.com/wso2/carbon-kernel/pull/4305