### PR TITLE
Fix username issue in captcha FailLoginAttemptValidationHandler

### DIFF
--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/validator/FailLoginAttemptValidationHandler.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/validator/FailLoginAttemptValidationHandler.java
@@ -144,7 +144,7 @@ public class FailLoginAttemptValidationHandler extends AbstractEventHandler {
 
     private String getDomainQualifiedUsername(User user) {
 
-        String username = user.getUserName();
+        String username = user.toFullQualifiedUsername();
         if (!StringUtils.isBlank(user.getUserStoreDomain()) &&
                 !IdentityUtil.getPrimaryDomainName().equals(user.getUserStoreDomain())) {
             username = UserCoreUtil.addDomainToName(username, user.getUserStoreDomain());

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/validator/FailLoginAttemptValidator.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/validator/FailLoginAttemptValidator.java
@@ -88,7 +88,7 @@ public class FailLoginAttemptValidator extends AbstractIdentityMessageHandler im
 
             if (map.get(FrameworkConstants.AnalyticsAttributes.USER) instanceof User) {
                 User failedUser = (User) map.get(FrameworkConstants.AnalyticsAttributes.USER);
-                String username = failedUser.getUserName();
+                String username = failedUser.toFullQualifiedUsername();
                 if (!StringUtils.isBlank(failedUser.getUserStoreDomain()) &&
                         !IdentityUtil.getPrimaryDomainName().equals(failedUser.getUserStoreDomain())) {
                     username = UserCoreUtil.addDomainToName(username, failedUser.getUserStoreDomain());


### PR DESCRIPTION
### Proposed changes in this pull request
In CaptchaUtil.isMaximumFailedLoginAttemptsReached method it removes the tenant domain from the username before passing to the `getUserClaimValues`, so if a tenant aware username is passed to this email (eg: test@wso2.com) this will remove the email domain part assuming its tenant domain and pass to getUserClaimValues. Which causes UserNotFoundError since we are only passing part of username to user store manager.

```
claimValues = userStoreManager.getUserClaimValues(MultitenantUtils.getTenantAwareUsername(usernameWithDomain),
                    new String[]{failedAttemptsClaim}, UserCoreConstants.DEFAULT_PROFILE);
```

Further Considerations:

The isMaximumFailedLoginAttemptsReached method is utilized in other areas (e.g., [2], [3], [4]). A comprehensive analysis is needed to determine if these usages are also affected, especially since current reCAPTCHA connectors [5] expectes different authenticator names than built-in authenticators. Currently with built in email otp and sms otp authenticators there are not properly working. Created a separate issue to track this.
- https://github.com/wso2/product-is/issues/24183

[1] - https://github.com/wso2-extensions/identity-governance/blob/34fc440ae1ee3b80e023a1426b0e46ab68e82179/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaUtil.java#L524
[2] - https://github.com/wso2-extensions/identity-governance/blob/4750c8097b75cdb7e1d170545d2ff2e9504f13ea/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/EmailOTPCaptchaConnector.java#L151
[3] - https://github.com/wso2-extensions/identity-governance/blob/f952c00b084a825f00fc756303ca038f9c18e734/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/SMSOTPCaptchaConnector.java#L246
[4] - https://github.com/wso2-extensions/identity-governance/blob/54f396076f7c2ce7990053c20130be6f9525fed9/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/SSOLoginReCaptchaConfig.java#L162
- https://github.com/wso2-extensions/identity-governance/pull/753