### PR TITLE
Introduce abstract captcha provider based implementation for Google ReCaptcha

### DIFF
--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -106,6 +106,10 @@
             <artifactId>org.wso2.carbon.identity.user.registration.engine</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.datapublisher.authentication</groupId>
             <artifactId>org.wso2.carbon.identity.data.publisher.application.authentication</artifactId>
         </dependency>
@@ -197,6 +201,8 @@
                             org.wso2.carbon.identity.core.util;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.model;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.configuration.mgt.core.*;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.recovery.*;
                             version="${identity.governance.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/AbstractReCaptchaConnector.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/AbstractReCaptchaConnector.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2025, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -22,7 +22,7 @@ import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.captcha.connector.CaptchaConnector;
 import org.wso2.carbon.identity.captcha.exception.CaptchaClientException;
 import org.wso2.carbon.identity.captcha.exception.CaptchaException;
-import org.wso2.carbon.identity.captcha.util.CaptchaUtil;
+import org.wso2.carbon.identity.captcha.internal.CaptchaDataHolder;
 
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -38,14 +38,15 @@ public abstract class AbstractReCaptchaConnector implements CaptchaConnector {
             throws CaptchaException {
 
         if (((HttpServletRequest) servletRequest).getMethod().equalsIgnoreCase("GET")) {
-            throw new CaptchaClientException("reCaptcha response must send in a POST request.");
+            throw new CaptchaClientException("Captcha response must send in a POST request.");
         }
 
-        String reCaptchaResponse = servletRequest.getParameter("g-recaptcha-response");
-        if (StringUtils.isBlank(reCaptchaResponse)) {
-            throw new CaptchaClientException("reCaptcha response is not available in the request.");
+        String captchaResponse = servletRequest.getParameter(
+                CaptchaDataHolder.getInstance().getCaptchaRuntimeService().getCaptchaResponseIdentifier());
+        if (StringUtils.isBlank(captchaResponse)) {
+            throw new CaptchaClientException("Captcha response is not available in the request.");
         }
 
-        return CaptchaUtil.isValidCaptcha(reCaptchaResponse);
+        return CaptchaDataHolder.getInstance().getCaptchaRuntimeService().verifyCaptcha(captchaResponse);
     }
 }

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/LiteUserSelfSignUpReCaptchaConnector.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/LiteUserSelfSignUpReCaptchaConnector.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2022-2025, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 LLC. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -97,11 +97,12 @@ public class LiteUserSelfSignUpReCaptchaConnector extends AbstractReCaptchaConne
     public boolean verifyCaptcha(ServletRequest servletRequest, ServletResponse servletResponse)
             throws CaptchaException {
 
-        String reCaptchaResponse = ((HttpServletRequest) servletRequest).getHeader("g-recaptcha-response");
-        if (StringUtils.isBlank(reCaptchaResponse)) {
+        String captchaResponse = ((HttpServletRequest) servletRequest).getHeader(
+                CaptchaDataHolder.getInstance().getCaptchaRuntimeService().getCaptchaResponseIdentifier());
+        if (StringUtils.isBlank(captchaResponse)) {
             throw new CaptchaClientException("reCaptcha response is not available in the request.");
         }
-        return CaptchaUtil.isValidCaptcha(reCaptchaResponse);
+        return CaptchaDataHolder.getInstance().getCaptchaRuntimeService().verifyCaptcha(captchaResponse);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/PasswordRecoveryReCaptchaConnector.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/PasswordRecoveryReCaptchaConnector.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2025, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -273,12 +273,13 @@ public class PasswordRecoveryReCaptchaConnector extends AbstractReCaptchaConnect
     public boolean verifyCaptcha(ServletRequest servletRequest, ServletResponse servletResponse)
             throws CaptchaException {
 
-        String reCaptchaResponse = ((HttpServletRequest) servletRequest).getHeader("g-recaptcha-response");
-        if (StringUtils.isBlank(reCaptchaResponse)) {
+        String captchaResponse = ((HttpServletRequest) servletRequest).getHeader(
+                CaptchaDataHolder.getInstance().getCaptchaRuntimeService().getCaptchaResponseIdentifier());
+        if (StringUtils.isBlank(captchaResponse)) {
             throw new CaptchaClientException("reCaptcha response is not available in the request.");
         }
 
-        return CaptchaUtil.isValidCaptcha(reCaptchaResponse);
+        return CaptchaDataHolder.getInstance().getCaptchaRuntimeService().verifyCaptcha(captchaResponse);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/ResendConfirmationReCaptchaConnector.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/ResendConfirmationReCaptchaConnector.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020-2025, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -99,11 +99,12 @@ public class ResendConfirmationReCaptchaConnector extends AbstractReCaptchaConne
     public boolean verifyCaptcha(ServletRequest servletRequest, ServletResponse servletResponse)
             throws CaptchaException {
 
-        String reCaptchaResponse = ((HttpServletRequest) servletRequest).getHeader("g-recaptcha-response");
-        if (StringUtils.isBlank(reCaptchaResponse)) {
+        String captchaResponse = ((HttpServletRequest) servletRequest).getHeader(
+                CaptchaDataHolder.getInstance().getCaptchaRuntimeService().getCaptchaResponseIdentifier());
+        if (StringUtils.isBlank(captchaResponse)) {
             throw new CaptchaClientException("reCaptcha response is not available in the request.");
         }
-        return CaptchaUtil.isValidCaptcha(reCaptchaResponse);
+        return CaptchaDataHolder.getInstance().getCaptchaRuntimeService().verifyCaptcha(captchaResponse);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/SelfSignUpReCaptchaConnector.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/SelfSignUpReCaptchaConnector.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2025, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -120,12 +120,13 @@ public class SelfSignUpReCaptchaConnector extends AbstractReCaptchaConnector {
     public boolean verifyCaptcha(ServletRequest servletRequest, ServletResponse servletResponse)
             throws CaptchaException {
 
-        String reCaptchaResponse = ((HttpServletRequest) servletRequest).getHeader("g-recaptcha-response");
-        if (StringUtils.isBlank(reCaptchaResponse)) {
+        String captchaResponse = ((HttpServletRequest) servletRequest).getHeader(
+                CaptchaDataHolder.getInstance().getCaptchaRuntimeService().getCaptchaResponseIdentifier());
+        if (StringUtils.isBlank(captchaResponse)) {
             throw new CaptchaClientException("reCaptcha response is not available in the request.");
         }
 
-        return CaptchaUtil.isValidCaptcha(reCaptchaResponse);
+        return CaptchaDataHolder.getInstance().getCaptchaRuntimeService().verifyCaptcha(captchaResponse);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/UsernameRecoveryReCaptchaConnector.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/UsernameRecoveryReCaptchaConnector.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018-2025, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -93,11 +93,12 @@ public class UsernameRecoveryReCaptchaConnector extends AbstractReCaptchaConnect
     public boolean verifyCaptcha(ServletRequest servletRequest, ServletResponse servletResponse)
             throws CaptchaException {
 
-        String reCaptchaResponse = ((HttpServletRequest) servletRequest).getHeader("g-recaptcha-response");
-        if (StringUtils.isBlank(reCaptchaResponse)) {
+        String captchaResponse = ((HttpServletRequest) servletRequest).getHeader(
+                CaptchaDataHolder.getInstance().getCaptchaRuntimeService().getCaptchaResponseIdentifier());
+        if (StringUtils.isBlank(captchaResponse)) {
             throw new CaptchaClientException("reCaptcha response is not available in the request.");
         }
-        return CaptchaUtil.isValidCaptcha(reCaptchaResponse);
+        return CaptchaDataHolder.getInstance().getCaptchaRuntimeService().verifyCaptcha(captchaResponse);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaDataHolder.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaDataHolder.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2025, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -19,6 +19,10 @@
 package org.wso2.carbon.identity.captcha.internal;
 
 import org.wso2.carbon.identity.captcha.connector.CaptchaConnector;
+import org.wso2.carbon.identity.captcha.provider_mgt.provider.AbstractCaptchaProvider;
+import org.wso2.carbon.identity.captcha.provider_mgt.service.CaptchaConfigService;
+import org.wso2.carbon.identity.captcha.provider_mgt.service.CaptchaRuntimeService;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -27,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * Captcha Data Holder.
@@ -78,6 +83,16 @@ public class CaptchaDataHolder {
     private boolean forcefullyEnabledRecaptchaForAllTenants;
 
     private List<String> reCaptchaBypassedApiEndpoints = new ArrayList<>();
+
+    private ConfigurationManager configurationManager;
+
+    private HashMap<String, AbstractCaptchaProvider> captchaProviders = new HashMap<>();;
+
+    private CaptchaRuntimeService captchaRuntimeService;
+
+    private CaptchaConfigService captchaConfigService;
+
+    private HashMap<Integer, Properties> tenantCaptchaConfigs = new HashMap<>();
 
     private CaptchaDataHolder() {
 
@@ -279,5 +294,47 @@ public class CaptchaDataHolder {
     public void setReCaptchaBypassedApiEndpoints(List<String> reCaptchaBypassedApiEndpoints) {
 
         this.reCaptchaBypassedApiEndpoints = reCaptchaBypassedApiEndpoints;
+    }
+
+    public ConfigurationManager getConfigurationManager() {
+
+        return configurationManager;
+    }
+
+    public void setConfigurationManager(ConfigurationManager configurationManager) {
+
+        this.configurationManager = configurationManager;
+    }
+
+    public AbstractCaptchaProvider getCaptchaProviderForCaptchaType(String captchaType) {
+        return captchaProviders.get(captchaType);
+    }
+
+    public void setCaptchaProviderForCaptchaType(String captchaType, AbstractCaptchaProvider captchaProvider) {
+        this.captchaProviders.put(captchaType, captchaProvider);
+    }
+
+    public CaptchaRuntimeService getCaptchaRuntimeService() {
+        return captchaRuntimeService;
+    }
+
+    public void setCaptchaRuntimeService(CaptchaRuntimeService captchaRuntimeService) {
+        this.captchaRuntimeService = captchaRuntimeService;
+    }
+
+    public CaptchaConfigService getCaptchaConfigService() {
+        return captchaConfigService;
+    }
+
+    public void setCaptchaConfigService(CaptchaConfigService captchaConfigService) {
+        this.captchaConfigService = captchaConfigService;
+    }
+
+    public void addCaptchaConfigsForTenant(int tenantId, Properties config) {
+        tenantCaptchaConfigs.put(tenantId, config);
+    }
+
+    public Properties getCaptchaConfigsForTenant(int tenantId) {
+        return tenantCaptchaConfigs.get(tenantId);
     }
 }

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/provider/AbstractCaptchaProvider.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/provider/AbstractCaptchaProvider.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.captcha.provider_mgt.provider;
+
+import org.wso2.carbon.identity.captcha.exception.CaptchaException;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This interface is used to provide the captcha provider.
+ */
+public interface AbstractCaptchaProvider {
+
+    /**
+     * This method is used to get the captcha type.
+     *
+     * @return Captcha type.
+     */
+    String getCaptchaType();
+
+    /**
+     * Get the unique identifier for this captcha provider.
+     *
+     * @return the captcha identifier.
+     */
+    String getCaptchaIdentifier();
+
+    /**
+     * Get the identifier for the captcha response parameter expected in the request.
+     *
+     * @return the captcha response identifier.
+     */
+    String getCaptchaResponseIdentifier();
+
+    /**
+     * Get HTML widget attributes to render the reCAPTCHA widget on the client side.
+     *
+     * @return map containing widget attributes.
+     */
+    Map<String, String> getWidgetAttributes();
+
+    /**
+     * Get JavaScript script attributes needed to load and render reCAPTCHA.
+     *
+     * @return list of script attribute maps.
+     */
+    List<Map<String, String>> getScriptAttributes();
+
+    /**
+     * Get JavaScript function names used for rendering, resetting, and retrieving the reCAPTCHA response.
+     *
+     * @return map of function names.
+     */
+    Map<String, String> getCaptchaFunctions();
+
+    /**
+     * Get the reCAPTCHA API URL to load the reCAPTCHA script on the client side.
+     *
+     * @return the API URL.
+     */
+    String getCaptchaApiUrl();
+
+    /**
+     * Get the verification URL for reCAPTCHA validation.
+     *
+     * @return the captcha verification URL.
+     */
+    String getCaptchaVerifyUrl();
+
+    /**
+     * This method is used to verify the captcha response.
+     *
+     * @param captchaResponse captcha response received from the provider.
+     * @return true if the captcha is verified, false otherwise.
+     */
+    boolean verifyCaptcha(String captchaResponse) throws CaptchaException;
+
+}

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/provider/GoogleRecaptchaEnterpriseProvider.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/provider/GoogleRecaptchaEnterpriseProvider.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.captcha.provider_mgt.provider;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.wso2.carbon.identity.captcha.exception.CaptchaClientException;
+import org.wso2.carbon.identity.captcha.exception.CaptchaException;
+import org.wso2.carbon.identity.captcha.exception.CaptchaServerException;
+import org.wso2.carbon.identity.captcha.internal.CaptchaDataHolder;
+import org.wso2.carbon.identity.captcha.provider_mgt.service.CaptchaRuntimeService;
+import org.wso2.carbon.identity.captcha.provider_mgt.util.CaptchaProviderConstants;
+import org.wso2.carbon.identity.captcha.util.CaptchaConstants;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GoogleRecaptchaEnterpriseProvider extends GoogleRecaptchaProvider {
+
+    private static final Log log = LogFactory.getLog(GoogleRecaptchaProvider.class);
+
+    @Override
+    public String getCaptchaType() {
+
+        return CaptchaProviderConstants.RECAPTCHA_ENTERPRISE_TYPE;
+    }
+
+    @Override
+    public String getCaptchaVerifyUrl() {
+
+        return CaptchaProviderConstants.RECAPTCHA_ENTERPRISE_VERIFY_URL;
+    }
+
+    @Override
+    public Map<String, String> getCaptchaFunctions() {
+
+        Map<String, String> functions = new HashMap<>();
+        functions.put("render", CaptchaProviderConstants.RECAPTCHA_ENTERPRISE_RENDER_FUNCTION);
+        functions.put("reset", CaptchaProviderConstants.RECAPTCHA_ENTERPRISE_RESET_FUNCTION);
+        functions.put("getResponse", CaptchaProviderConstants.RECAPTCHA_ENTERPRISE_GET_RESPONSE_FUNCTION);
+        return functions;
+    }
+
+    @Override
+    public boolean verifyCaptcha(String captchaResponse)
+            throws CaptchaException {
+
+        CloseableHttpClient httpclient = HttpClientBuilder.create().useSystemProperties().build();
+
+        HttpPost httpPost = createReCaptchaEnterpriseVerificationHttpPost(captchaResponse);
+
+        HttpResponse response;
+        try {
+            response = httpclient.execute(httpPost);
+        } catch (IOException e) {
+            throw new CaptchaServerException("Unable to get the verification response.", e);
+        }
+
+        HttpEntity entity = response.getEntity();
+        if (entity == null) {
+            throw new CaptchaServerException("reCaptcha verification response is not received.");
+        }
+
+        verifyReCaptchaEnterpriseResponse(entity);
+
+        return true;
+    }
+
+    private HttpPost createReCaptchaEnterpriseVerificationHttpPost(String captchaResponse)
+            throws CaptchaServerException {
+
+        HttpPost httpPost;
+        String recaptchaUrl = getCaptchaVerifyUrl();
+        String projectID = getCaptchaRuntimeService().getCaptchaProjectID();
+        String siteKey = getCaptchaRuntimeService().getCaptchaSiteKey();
+        String apiKey = getCaptchaRuntimeService().getCaptchaApiKey();
+
+        String verifyUrl = recaptchaUrl + "/v1/projects/" + projectID + "/assessments?key=" + apiKey;
+        httpPost = new HttpPost(verifyUrl);
+
+        httpPost.setHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+
+        String json = String.format("{ \"event\": { \"token\": \"%s\", \"siteKey\": \"%s\" } }", captchaResponse,
+                siteKey);
+
+        StringEntity entity = new StringEntity(json, StandardCharsets.UTF_8);
+
+        httpPost.setEntity(entity);
+
+        return httpPost;
+    }
+
+    private void verifyReCaptchaEnterpriseResponse(HttpEntity entity)
+            throws CaptchaServerException, CaptchaClientException {
+
+        final double scoreThreshold = getCaptchaScoreThreshold();
+        final double warnScoreThreshold = getCaptchaWarnScoreThreshold();
+
+        try {
+            try (InputStream in = entity.getContent()) {
+                JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+                JsonObject verificationResponse = jsonElement.getAsJsonObject();
+                if (verificationResponse == null) {
+                    throw new CaptchaClientException("Error receiving reCaptcha response from the server");
+                }
+                JsonObject tokenProperties = verificationResponse.get(CaptchaConstants.CAPTCHA_TOKEN_PROPERTIES).
+                        getAsJsonObject();
+                boolean success = tokenProperties.get(CaptchaConstants.CAPTCHA_VALID).getAsBoolean();
+
+                JsonObject riskAnalysis = verificationResponse.get(CaptchaConstants.CAPTCHA_RISK_ANALYSIS).
+                        getAsJsonObject();
+
+                // Whether this request was a valid reCAPTCHA token.
+                if (!success) {
+                    throw new CaptchaClientException("reCaptcha token is invalid. Error:" +
+                            verificationResponse.get("error-codes"));
+                }
+                if (riskAnalysis.get(CaptchaConstants.CAPTCHA_SCORE) != null) {
+                    double score = riskAnalysis.get(CaptchaConstants.CAPTCHA_SCORE).getAsDouble();
+                    // reCAPTCHA enterprise response contains score.
+                    if (log.isDebugEnabled()) {
+                        log.debug("reCAPTCHA Enterprise response { timestamp:" +
+                                tokenProperties.get("createTime") + ", action: " +
+                                tokenProperties.get("action") + ", score: " + score + " }");
+                    }
+                    if (score < scoreThreshold) {
+                        throw new CaptchaClientException("reCaptcha score is less than the threshold.");
+                    } else if (score < warnScoreThreshold) {
+                        log.warn("User access with low reCaptcha score.");
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new CaptchaServerException("Unable to read the verification response.", e);
+        } catch (ClassCastException e) {
+            throw new CaptchaServerException("Unable to cast the response value.", e);
+        }
+    }
+
+    private CaptchaRuntimeService getCaptchaRuntimeService() {
+
+        return CaptchaDataHolder.getInstance().getCaptchaRuntimeService();
+    }
+}

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/provider/GoogleRecaptchaProvider.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/provider/GoogleRecaptchaProvider.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.captcha.provider_mgt.provider;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpEntity;
+import org.apache.http.message.BasicNameValuePair;
+import org.wso2.carbon.identity.captcha.exception.CaptchaClientException;
+import org.wso2.carbon.identity.captcha.exception.CaptchaException;
+import org.wso2.carbon.identity.captcha.exception.CaptchaServerException;
+import org.wso2.carbon.identity.captcha.internal.CaptchaDataHolder;
+import org.wso2.carbon.identity.captcha.provider_mgt.util.CaptchaProviderConstants;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.wso2.carbon.identity.captcha.provider_mgt.util.CaptchaProviderUtils.isValidCaptcha;
+
+public class GoogleRecaptchaProvider implements AbstractCaptchaProvider {
+
+    private static final Log log = LogFactory.getLog(GoogleRecaptchaProvider.class);
+
+    @Override
+    public String getCaptchaType() {
+
+        return CaptchaProviderConstants.RECAPTCHA_TYPE;
+    }
+
+    @Override
+    public String getCaptchaIdentifier() {
+
+        return CaptchaProviderConstants.RECAPTCHA_IDENTIFIER;
+    }
+
+    @Override
+    public String getCaptchaResponseIdentifier() {
+
+        return CaptchaProviderConstants.RECAPTCHA_RESPONSE_IDENTIFIER;
+    }
+
+    @Override
+    public String getCaptchaVerifyUrl() {
+
+        return CaptchaProviderConstants.RECAPTCHA_VERIFY_URL;
+    }
+
+    @Override
+    public Map<String, String> getWidgetAttributes() {
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("class", CaptchaProviderConstants.RECAPTCHA_IDENTIFIER);
+        attributes.put("data-size", "invisible");
+        attributes.put("data-callback", "onCompleted");
+        return attributes;
+    }
+
+    @Override
+    public List<Map<String, String>> getScriptAttributes() {
+
+        List<Map<String, String>> attributes = new ArrayList<>();
+        attributes.add(Collections.singletonMap("async", "true"));
+        attributes.add(Collections.singletonMap("defer", "true"));
+        attributes.add(Collections.singletonMap("src", getCaptchaApiUrl()));
+        return attributes;
+    }
+
+    @Override
+    public Map<String, String> getCaptchaFunctions() {
+
+        Map<String, String> functions = new HashMap<>();
+        functions.put("render", CaptchaProviderConstants.RECAPTCHA_RENDER_FUNCTION);
+        functions.put("reset", CaptchaProviderConstants.RECAPTCHA_RESET_FUNCTION);
+        functions.put("getResponse", CaptchaProviderConstants.RECAPTCHA_GET_RESPONSE_FUNCTION);
+        return functions;
+    }
+
+    @Override
+    public String getCaptchaApiUrl() {
+
+        return CaptchaProviderConstants.RECAPTCHA_API_URL;
+    }
+
+    /**
+     * Get the minimum score threshold for successful reCAPTCHA verification.
+     *
+     * @return the score threshold.
+     */
+    public double getCaptchaScoreThreshold() {
+
+        String threshold = CaptchaDataHolder.getInstance().getCaptchaRuntimeService().getCaptchaScoreThreshold();
+        if (threshold != null && !threshold.isEmpty()) {
+            try {
+                return Double.parseDouble(threshold);
+            } catch (NumberFormatException e) {
+                log.warn("Invalid score threshold value: " + threshold + ". Using default value of 0.5.", e);
+            }
+        }
+        return CaptchaProviderConstants.RECAPTCHA_DEFAULT_THRESHOLD;
+    }
+
+    /**
+     * Get the warning score threshold for reCAPTCHA verification.
+     * If the score is below this value, a warning is logged.
+     *
+     * @return the warn score threshold.
+     */
+    public double getCaptchaWarnScoreThreshold() {
+
+        String warnThreshold =
+                CaptchaDataHolder.getInstance().getCaptchaRuntimeService().getCaptchaWarnScoreThreshold();
+        if (warnThreshold != null && !warnThreshold.isEmpty()) {
+            try {
+                return Double.parseDouble(warnThreshold);
+            } catch (NumberFormatException e) {
+                log.warn("Invalid warn score threshold value: " + warnThreshold + ". Using default value of 0.7.", e);
+            }
+        }
+        return CaptchaProviderConstants.RECAPTCHA_DEFAULT_WARN_THRESHOLD;
+    }
+
+    @Override
+    public boolean verifyCaptcha(String captchaResponse)
+            throws CaptchaException {
+
+        List<BasicNameValuePair> params =
+                Arrays.asList(new BasicNameValuePair(CaptchaProviderConstants.PARAM_SECRET,
+                                CaptchaDataHolder.getInstance().getCaptchaRuntimeService().getCaptchaSiteSecret()),
+                        new BasicNameValuePair(CaptchaProviderConstants.PARAM_RESPONSE, captchaResponse));
+
+        HttpEntity entity = isValidCaptcha(getCaptchaVerifyUrl(), params);
+
+        verifyCaptchaResponse(entity);
+
+        return true;
+    }
+
+    private void verifyCaptchaResponse(HttpEntity entity)
+            throws CaptchaServerException, CaptchaClientException {
+
+        final double scoreThreshold = getCaptchaScoreThreshold();
+        final double warnScoreThreshold = getCaptchaWarnScoreThreshold();
+
+        try {
+            try (InputStream in = entity.getContent()) {
+                JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+                JsonObject verificationResponse = jsonElement.getAsJsonObject();
+                if (verificationResponse == null) {
+                    throw new CaptchaClientException("Error receiving reCaptcha response from the server");
+                }
+
+                boolean success = verificationResponse.get(CaptchaProviderConstants.PARAM_SUCCESS).getAsBoolean();
+
+                if (!success) {
+                    throw new CaptchaClientException("reCaptcha token is invalid. Error:" +
+                            verificationResponse.get("error-codes"));
+                }
+
+                if (verificationResponse.get(CaptchaProviderConstants.PARAM__SCORE) != null) {
+                    double score = verificationResponse.get(CaptchaProviderConstants.PARAM__SCORE).getAsDouble();
+
+                    if (log.isDebugEnabled()) {
+                        log.debug("CAPTCHA response :" + verificationResponse.getAsString());
+                    }
+                    if (score < scoreThreshold) {
+                        throw new CaptchaClientException("Captcha score is less than the threshold.");
+                    } else if (score < warnScoreThreshold) {
+                        log.warn("Captcha score is below warn threshold.");
+                    }
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("CAPTCHA response :" + verificationResponse.getAsString());
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new CaptchaServerException("Unable to read the verification response.", e);
+        } catch (ClassCastException e) {
+            throw new CaptchaServerException("Unable to cast the response value.", e);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/service/CaptchaConfigService.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/service/CaptchaConfigService.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.captcha.provider_mgt.service;
+
+import org.wso2.carbon.identity.captcha.exception.CaptchaServerException;
+import org.wso2.carbon.identity.captcha.provider_mgt.provider.AbstractCaptchaProvider;
+
+import java.util.Properties;
+
+public interface CaptchaConfigService {
+
+    /**
+     * Load captcha provider configurations from the configuration manager for the current tenant.
+     *
+     * @throws CaptchaServerException If an error occurs while loading the configurations.
+     */
+    void loadCaptchaConfigs() throws CaptchaServerException;
+
+    /**
+     * Store captcha provider instances in the CaptchaDataHolder.
+     *
+     * @throws CaptchaServerException If an error occurs while initializing the captcha providers.
+     */
+    void storeCaptchaProviders() throws CaptchaServerException;
+
+    /**
+     * Get the active captcha provider configurations for the current tenant.
+     *
+     * @return Captcha provider configurations as a {@link Properties} object.
+     * @throws CaptchaServerException If there is an error while retrieving the configurations.
+     */
+    Properties getActiveCaptchaProviderConfig() throws CaptchaServerException;
+
+    /**
+     * Check if captcha is enabled for the current tenant.
+     *
+     * @return {@code true} if captcha is enabled; {@code false} otherwise.
+     */
+    boolean isCaptchaEnabled();
+
+    /**
+     * Get the active captcha provider instance for the current tenant.
+     *
+     * @return The active {@link AbstractCaptchaProvider}.
+     * @throws CaptchaServerException If the captcha provider is not configured.
+     */
+    AbstractCaptchaProvider getCaptchaProvider() throws CaptchaServerException;
+
+    /**
+     * Get the captcha site key for the current tenant.
+     *
+     * @return Captcha site key as a string.
+     * @throws CaptchaServerException If the site key is not configured.
+     */
+    String getCaptchaSiteKey() throws CaptchaServerException;
+
+    /**
+     * Get the captcha site secret for the current tenant.
+     *
+     * @return Captcha site secret as a string.
+     * @throws CaptchaServerException If the site secret is not configured.
+     */
+    String getCaptchaSiteSecret() throws CaptchaServerException;
+
+    /**
+     * Get the captcha project ID for the current tenant.
+     *
+     * @return Captcha project ID as a string.
+     * @throws CaptchaServerException If the project ID is not configured.
+     */
+    String getCaptchaProjectID() throws CaptchaServerException;
+
+    /**
+     * Get the captcha API key for the current tenant.
+     *
+     * @return Captcha API key as a string.
+     * @throws CaptchaServerException If the API key is not configured.
+     */
+    String getCaptchaApiKey() throws CaptchaServerException;
+
+    /**
+     * Get the captcha score threshold for the current tenant.
+     *
+     * @return Captcha score threshold as a string.
+     */
+    String getCaptchaScoreThreshold();
+
+    /**
+     * Get the captcha warn score threshold for the current tenant.
+     *
+     * @return Captcha warn score threshold as a string.
+     */
+    String getCaptchaWarnScoreThreshold();
+}
+

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/service/CaptchaRuntimeService.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/service/CaptchaRuntimeService.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.captcha.provider_mgt.service;
+
+import org.wso2.carbon.identity.captcha.exception.CaptchaException;
+import org.wso2.carbon.identity.captcha.exception.CaptchaServerException;
+
+import java.util.List;
+import java.util.Map;
+
+public interface CaptchaRuntimeService {
+
+    /**
+     * Checks if CAPTCHA is enabled.
+     *
+     * @return {@code true} if CAPTCHA is enabled; {@code false} otherwise.
+     */
+    boolean isCaptchaEnabled();
+
+    /**
+     * Verifies the provided CAPTCHA response with the current CAPTCHA provider.
+     *
+     * @param captchaResponse The CAPTCHA response to verify.
+     * @return {@code true} if the verification is successful; {@code false} otherwise.
+     * @throws CaptchaException if verification fails or an error occurs.
+     */
+    boolean verifyCaptcha(String captchaResponse) throws CaptchaException;
+
+    /**
+     * Retrieves the CAPTCHA site key from the CAPTCHA configuration.
+     *
+     * @return The CAPTCHA site key.
+     * @throws CaptchaServerException if an error occurs while retrieving the site key.
+     */
+    String getCaptchaSiteKey() throws CaptchaServerException;
+
+    /**
+     * Retrieves the CAPTCHA site secret from the CAPTCHA configuration.
+     *
+     * @return The CAPTCHA site secret.
+     * @throws CaptchaServerException if an error occurs while retrieving the site secret.
+     */
+    String getCaptchaSiteSecret() throws CaptchaServerException;
+
+    /**
+     * Retrieves the CAPTCHA project ID from the CAPTCHA configuration.
+     *
+     * @return The CAPTCHA project ID.
+     * @throws CaptchaServerException if an error occurs while retrieving the project ID.
+     */
+    String getCaptchaProjectID() throws CaptchaServerException;
+
+    /**
+     * Retrieves the CAPTCHA API key from the CAPTCHA configuration.
+     *
+     * @return The CAPTCHA API key.
+     * @throws CaptchaServerException if an error occurs while retrieving the API key.
+     */
+    String getCaptchaApiKey() throws CaptchaServerException;
+
+    /**
+     * Retrieves widget attributes for rendering the CAPTCHA on the frontend.
+     *
+     * @return A map containing widget attributes; empty if not available.
+     * @throws CaptchaServerException if an error occurs while retrieving the widget attributes.
+     */
+    Map<String, String> getWidgetAttributes() throws CaptchaServerException;
+
+    /**
+     * Retrieves script attributes for loading CAPTCHA scripts on the frontend.
+     *
+     * @return A list of maps containing script attributes; empty if not available.
+     * @throws CaptchaServerException if an error occurs while retrieving the script attributes.
+     */
+    List<Map<String, String>> getScriptAttributes() throws CaptchaServerException;
+
+    /**
+     * Retrieves the CAPTCHA identifier used by the provider.
+     *
+     * @return The CAPTCHA identifier; empty if not available.
+     * @throws CaptchaServerException if an error occurs while retrieving the identifier.
+     */
+    String getCaptchaIdentifier() throws CaptchaServerException;
+
+    /**
+     * Retrieves the identifier for the CAPTCHA response field.
+     *
+     * @return The CAPTCHA response identifier; empty if not available.
+     * @throws CaptchaServerException if an error occurs while retrieving the response identifier.
+     */
+    String getCaptchaResponseIdentifier() throws CaptchaServerException;
+
+    /**
+     * Retrieves any additional CAPTCHA functions defined by the provider.
+     *
+     * @return A map containing CAPTCHA functions; empty if not available.
+     * @throws CaptchaServerException if an error occurs while retrieving the functions.
+     */
+    Map<String, String> getCaptchaFunctions() throws CaptchaServerException;
+
+    /**
+     * Retrieves the CAPTCHA API URL for the configured provider.
+     *
+     * @return The CAPTCHA API URL; empty if not available.
+     * @throws CaptchaServerException if an error occurs while retrieving the API URL.
+     */
+    String getCaptchaApiUrl() throws CaptchaServerException;
+
+    /**
+     * Retrieves the URL used for CAPTCHA verification by the configured provider.
+     *
+     * @return The CAPTCHA verification URL; empty if not available.
+     * @throws CaptchaServerException if an error occurs while retrieving the verification URL.
+     */
+    String getCaptchaVerifyUrl() throws CaptchaServerException;
+
+    /**
+     * Retrieves the CAPTCHA score threshold configured for the system.
+     *
+     * @return The CAPTCHA score threshold.
+     */
+    String getCaptchaScoreThreshold();
+
+    /**
+     * Retrieves the CAPTCHA warn score threshold configured for the system.
+     *
+     * @return The CAPTCHA warn score threshold.
+     */
+    String getCaptchaWarnScoreThreshold();
+}

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/service/impl/CaptchaConfigServiceImpl.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/service/impl/CaptchaConfigServiceImpl.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.captcha.provider_mgt.service.impl;
+
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.captcha.exception.CaptchaServerException;
+import org.wso2.carbon.identity.captcha.internal.CaptchaDataHolder;
+import org.wso2.carbon.identity.captcha.provider_mgt.provider.AbstractCaptchaProvider;
+import org.wso2.carbon.identity.captcha.provider_mgt.service.CaptchaConfigService;
+import org.wso2.carbon.identity.captcha.provider_mgt.util.CaptchaProviderConstants;
+import org.wso2.carbon.identity.captcha.util.CaptchaConstants;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+public class CaptchaConfigServiceImpl implements CaptchaConfigService {
+
+    @Override
+    public Properties getActiveCaptchaProviderConfig() throws CaptchaServerException {
+
+        CaptchaDataHolder captchaDataHolder = CaptchaDataHolder.getInstance();
+        Properties captchaProviderConfigs = captchaDataHolder
+                .getCaptchaConfigsForTenant(getTenantId());
+        if (captchaProviderConfigs != null && !captchaProviderConfigs.isEmpty()) {
+            captchaProviderConfigs.setProperty(CaptchaConstants.RE_CAPTCHA_API_URL,
+                    getCaptchaProvider().getCaptchaApiUrl());
+            captchaProviderConfigs.setProperty(CaptchaConstants.RE_CAPTCHA_VERIFY_URL,
+                    getCaptchaProvider().getCaptchaVerifyUrl());
+        } else {
+            captchaProviderConfigs = new Properties();
+            captchaProviderConfigs.setProperty(CaptchaConstants.RE_CAPTCHA_ENABLED,
+                    Boolean.toString(captchaDataHolder.isReCaptchaEnabled()));
+            captchaProviderConfigs.setProperty(CaptchaConstants.RE_CAPTCHA_TYPE,
+                    captchaDataHolder.getReCaptchaType() != null ? captchaDataHolder.getReCaptchaType() : "");
+            captchaProviderConfigs.setProperty(CaptchaConstants.RE_CAPTCHA_SITE_KEY,
+                    captchaDataHolder.getReCaptchaSiteKey() != null ? captchaDataHolder.getReCaptchaSiteKey() : "");
+            captchaProviderConfigs.setProperty(CaptchaConstants.RE_CAPTCHA_SECRET_KEY,
+                    captchaDataHolder.getReCaptchaSecretKey() != null ? captchaDataHolder.getReCaptchaSecretKey() : "");
+            captchaProviderConfigs.setProperty(CaptchaConstants.RE_CAPTCHA_API_URL,
+                    captchaDataHolder.getReCaptchaAPIUrl() != null ? captchaDataHolder.getReCaptchaAPIUrl() : "");
+            captchaProviderConfigs.setProperty(CaptchaConstants.RE_CAPTCHA_VERIFY_URL,
+                    captchaDataHolder.getReCaptchaVerifyUrl() != null ? captchaDataHolder.getReCaptchaVerifyUrl() : "");
+        }
+        return captchaProviderConfigs;
+    }
+
+    @Override
+    public boolean isCaptchaEnabled() {
+
+        int tenantId = getTenantId();
+        boolean isCaptchaConfigured = CaptchaDataHolder.getInstance().getCaptchaConfigsForTenant(tenantId) != null
+                && !CaptchaDataHolder.getInstance().getCaptchaConfigsForTenant(tenantId).isEmpty();
+
+        return CaptchaDataHolder.getInstance().isReCaptchaEnabled() || isCaptchaConfigured ||
+                CaptchaDataHolder.getInstance().isForcefullyEnabledRecaptchaForAllTenants();
+    }
+
+    @Override
+    public AbstractCaptchaProvider getCaptchaProvider() throws CaptchaServerException {
+
+        Properties captchaProviderConfigs = CaptchaDataHolder.getInstance().getCaptchaConfigsForTenant(getTenantId());
+
+        AbstractCaptchaProvider captchaProvider = null;
+        if (captchaProviderConfigs != null && !captchaProviderConfigs.isEmpty()) {
+            captchaProvider = CaptchaDataHolder.getInstance()
+                    .getCaptchaProviderForCaptchaType(
+                            captchaProviderConfigs.getProperty(CaptchaConstants.RE_CAPTCHA_TYPE));
+        }
+
+        if (captchaProvider == null && CaptchaDataHolder.getInstance().getReCaptchaType() != null &&
+                !CaptchaDataHolder.getInstance().getReCaptchaType().isEmpty()) {
+            captchaProvider = CaptchaDataHolder.getInstance()
+                    .getCaptchaProviderForCaptchaType(CaptchaDataHolder.getInstance().getReCaptchaType());
+        }
+
+        if (captchaProvider == null) {
+            throw new CaptchaServerException("Captcha site secret is not configured.");
+        }
+
+        return captchaProvider;
+    }
+
+    @Override
+    public String getCaptchaSiteKey() throws CaptchaServerException {
+
+        Properties tenantCaptchaConfigs = CaptchaDataHolder.getInstance().getCaptchaConfigsForTenant(getTenantId());
+        String siteKey = "";
+
+        if (tenantCaptchaConfigs != null && !tenantCaptchaConfigs.isEmpty()) {
+            siteKey = tenantCaptchaConfigs.getProperty(CaptchaConstants.RE_CAPTCHA_SITE_KEY);
+        }
+
+        if (siteKey.isEmpty()) {
+            siteKey = CaptchaDataHolder.getInstance().getReCaptchaSiteKey();
+        }
+
+        if (siteKey.isEmpty()) {
+            throw new CaptchaServerException("Captcha site key is not configured.");
+        }
+
+        return siteKey;
+    }
+
+    @Override
+    public String getCaptchaSiteSecret() throws CaptchaServerException {
+
+        Properties tenantCaptchaConfigs = CaptchaDataHolder.getInstance().getCaptchaConfigsForTenant(getTenantId());
+
+        String siteSecret = "";
+        if (tenantCaptchaConfigs != null && !tenantCaptchaConfigs.isEmpty()) {
+            siteSecret = tenantCaptchaConfigs.getProperty(CaptchaConstants.RE_CAPTCHA_SECRET_KEY);
+        }
+
+        if (siteSecret.isEmpty()) {
+            siteSecret = CaptchaDataHolder.getInstance().getReCaptchaSecretKey();
+        }
+
+        if (siteSecret.isEmpty()) {
+            throw new CaptchaServerException("Captcha site secret is not configured.");
+        }
+
+        return siteSecret;
+    }
+
+    @Override
+    public String getCaptchaProjectID() throws CaptchaServerException {
+
+        Properties tenantCaptchaConfigs = CaptchaDataHolder.getInstance().getCaptchaConfigsForTenant(getTenantId());
+
+        String projectID = "";
+        if (tenantCaptchaConfigs != null && !tenantCaptchaConfigs.isEmpty()) {
+            projectID = tenantCaptchaConfigs.getProperty(CaptchaConstants.RE_CAPTCHA_PROJECT_ID);
+        }
+
+        if (projectID.isEmpty()) {
+            projectID = CaptchaDataHolder.getInstance().getReCaptchaProjectID();
+        }
+
+        if (projectID.isEmpty()) {
+            throw new CaptchaServerException("Captcha project ID is not configured.");
+        }
+
+        return projectID;
+    }
+
+    @Override
+    public String getCaptchaApiKey() throws CaptchaServerException {
+
+        Properties tenantCaptchaConfigs = CaptchaDataHolder.getInstance().getCaptchaConfigsForTenant(getTenantId());
+
+        String apiKey = "";
+        if (tenantCaptchaConfigs != null && !tenantCaptchaConfigs.isEmpty()) {
+            apiKey = tenantCaptchaConfigs.getProperty(CaptchaConstants.RE_CAPTCHA_API_KEY);
+        }
+
+        if (apiKey.isEmpty()) {
+            apiKey = CaptchaDataHolder.getInstance().getReCaptchaAPIKey();
+        }
+
+        if (apiKey.isEmpty()) {
+            throw new CaptchaServerException("Captcha site secret is not configured.");
+        }
+
+        return apiKey;
+    }
+
+    @Override
+    public String getCaptchaScoreThreshold() {
+
+        Properties tenantCaptchaConfigs = CaptchaDataHolder.getInstance().getCaptchaConfigsForTenant(getTenantId());
+
+        String warnThreshold = "";
+        if (tenantCaptchaConfigs != null && !tenantCaptchaConfigs.isEmpty()) {
+            warnThreshold = tenantCaptchaConfigs.getProperty(CaptchaConstants.RE_CAPTCHA_WARN_SCORE_THRESHOLD);
+        }
+
+        if (warnThreshold.isEmpty()) {
+            warnThreshold = String.valueOf(CaptchaDataHolder.getInstance().getReCaptchaScoreThreshold());
+        }
+
+        return warnThreshold;
+    }
+
+    @Override
+    public String getCaptchaWarnScoreThreshold() {
+
+        Properties tenantCaptchaConfigs = CaptchaDataHolder.getInstance().getCaptchaConfigsForTenant(getTenantId());
+
+        String scoreThreshold = "";
+        if (tenantCaptchaConfigs != null && !tenantCaptchaConfigs.isEmpty()) {
+            scoreThreshold = tenantCaptchaConfigs.getProperty(CaptchaConstants.RE_CAPTCHA_SCORE_THRESHOLD);
+        }
+
+        if (scoreThreshold.isEmpty()) {
+            scoreThreshold = String.valueOf(CaptchaDataHolder.getInstance().getReCaptchaWarnScoreThreshold());
+        }
+
+        return scoreThreshold;
+    }
+
+    @Override
+    public void loadCaptchaConfigs() throws CaptchaServerException {
+
+        try {
+            int tenantId = getTenantId();
+            Properties captchaProviderConfig = new Properties();
+
+            Resource captchaResource = getConfigurationManager().getResource(
+                    CaptchaProviderConstants.CAPTCHA_RESOURCE_TYPE, CaptchaProviderConstants.CAPTCHA_RESOURCE_NAME);
+            List<Attribute> captchaResourceAttributes = captchaResource.getAttributes();
+
+            if (captchaResourceAttributes != null && !captchaResourceAttributes.isEmpty()) {
+                captchaProviderConfig.setProperty(CaptchaConstants.RE_CAPTCHA_ENABLED, "true");
+
+                for (Attribute attribute : captchaResourceAttributes) {
+                    String key = attribute.getKey();
+                    String value = attribute.getValue();
+
+                    switch (key) {
+                        case CaptchaProviderConstants.CAPTCHA_PROVIDER_CONFIG:
+                            captchaProviderConfig.setProperty(CaptchaConstants.RE_CAPTCHA_TYPE, value);
+                            break;
+                        case CaptchaProviderConstants.CAPTCHA_SITEKEY_CONFIG:
+                            captchaProviderConfig.setProperty(CaptchaConstants.RE_CAPTCHA_SITE_KEY, value);
+                            break;
+                        case CaptchaProviderConstants.CAPTCHA_SITESECRET_CONFIG:
+                            captchaProviderConfig.setProperty(CaptchaConstants.RE_CAPTCHA_SECRET_KEY, value);
+                            break;
+                        case CaptchaProviderConstants.CAPTCHA_SCORE_THRESHOLD_CONFIG:
+                            captchaProviderConfig.setProperty(CaptchaConstants.RE_CAPTCHA_SCORE_THRESHOLD, value);
+                            break;
+                        case CaptchaProviderConstants.CAPTCHA_SCORE_WARN_THRESHOLD_CONFIG:
+                            captchaProviderConfig.setProperty(CaptchaConstants.RE_CAPTCHA_WARN_SCORE_THRESHOLD, value);
+                            break;
+                        case CaptchaProviderConstants.CAPTCHA_API_KEY:
+                            captchaProviderConfig.setProperty(CaptchaConstants.RE_CAPTCHA_API_KEY, value);
+                            break;
+                        case CaptchaProviderConstants.CAPTCHA_PROJECT_ID:
+                            captchaProviderConfig.setProperty(CaptchaConstants.RE_CAPTCHA_PROJECT_ID, value);
+                            break;
+                        case CaptchaProviderConstants.CAPTCHA_REQUEST_WRAP_URLS:
+                            CaptchaDataHolder.getInstance().setReCaptchaRequestWrapUrls(value);
+                            captchaProviderConfig.setProperty(CaptchaConstants.RE_CAPTCHA_REQUEST_WRAP_URLS, value);
+                            break;
+                        case CaptchaProviderConstants.CAPTCHA_FAILED_REDIRECT_URLS:
+                            CaptchaDataHolder.getInstance().setReCaptchaErrorRedirectUrls(value);
+                            captchaProviderConfig.setProperty(CaptchaConstants.RE_CAPTCHA_FAILED_REDIRECT_URLS, value);
+                            break;
+                        case CaptchaProviderConstants.CAPTCHA_BYPASSED_API_ENDPOINTS:
+                            CaptchaDataHolder.getInstance()
+                                    .setReCaptchaBypassedApiEndpoints(Arrays.asList(value.split(",")));
+                            captchaProviderConfig.setProperty(CaptchaConstants.RE_CAPTCHA_BYPASSED_API_ENDPOINTS,
+                                    value);
+                            break;
+                        default:
+                            // Handle unknown config keys if needed
+                            break;
+                    }
+                }
+
+                captchaProviderConfig.setProperty(CaptchaConstants.RE_CAPTCHA_ENABLED, "true");
+
+                // Store the config in CaptchaDataHolder
+                CaptchaDataHolder.getInstance().addCaptchaConfigsForTenant(tenantId, captchaProviderConfig);
+            }
+        } catch (Exception e) {
+            throw new CaptchaServerException("Error while setting captcha provider configurations.", e);
+        }
+    }
+
+    @Override
+    public void storeCaptchaProviders() throws CaptchaServerException {
+
+        CaptchaDataHolder captchaDataHolder = CaptchaDataHolder.getInstance();
+
+        for (Map.Entry<String, Class<? extends AbstractCaptchaProvider>> entry :
+                CaptchaProviderConstants.CaptchaProviderRegistry.getProviderClasses().entrySet()) {
+            String captchaType = entry.getKey();
+            Class<? extends AbstractCaptchaProvider> providerClass = entry.getValue();
+
+            try {
+                AbstractCaptchaProvider providerInstance = providerClass.getDeclaredConstructor().newInstance();
+                captchaDataHolder.setCaptchaProviderForCaptchaType(captchaType, providerInstance);
+            } catch (Exception e) {
+                throw new CaptchaServerException("Failed to initialize captcha provider for type: " + captchaType, e);
+            }
+        }
+    }
+
+    private ConfigurationManager getConfigurationManager() {
+
+        return CaptchaDataHolder.getInstance().getConfigurationManager();
+    }
+
+    private static int getTenantId() {
+
+        return PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+    }
+}

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/service/impl/CaptchaRuntimeServiceImpl.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/service/impl/CaptchaRuntimeServiceImpl.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.captcha.provider_mgt.service.impl;
+
+import org.wso2.carbon.identity.captcha.exception.CaptchaException;
+import org.wso2.carbon.identity.captcha.exception.CaptchaServerException;
+import org.wso2.carbon.identity.captcha.internal.CaptchaDataHolder;
+import org.wso2.carbon.identity.captcha.provider_mgt.provider.AbstractCaptchaProvider;
+import org.wso2.carbon.identity.captcha.provider_mgt.service.CaptchaRuntimeService;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class CaptchaRuntimeServiceImpl implements CaptchaRuntimeService {
+
+    @Override
+    public boolean isCaptchaEnabled() {
+
+        return CaptchaDataHolder.getInstance().getCaptchaConfigService().isCaptchaEnabled();
+    }
+
+    @Override
+    public boolean verifyCaptcha(String captchaResponse) throws CaptchaException {
+
+        if (isCaptchaEnabled()) {
+            AbstractCaptchaProvider captchaProvider =
+                    CaptchaDataHolder.getInstance().getCaptchaConfigService().getCaptchaProvider();
+
+            if (captchaProvider != null) {
+                return captchaProvider.verifyCaptcha(captchaResponse);
+            }
+
+        }
+        return false;
+    }
+
+    @Override
+    public String getCaptchaSiteKey() throws CaptchaServerException {
+
+        return CaptchaDataHolder.getInstance().getCaptchaConfigService().getCaptchaSiteKey();
+    }
+
+    @Override
+    public String getCaptchaProjectID() throws CaptchaServerException {
+
+        return CaptchaDataHolder.getInstance().getCaptchaConfigService().getCaptchaProjectID();
+    }
+
+    @Override
+    public String getCaptchaApiKey() throws CaptchaServerException {
+
+        return CaptchaDataHolder.getInstance().getCaptchaConfigService().getCaptchaApiKey();
+    }
+
+    @Override
+    public String getCaptchaSiteSecret() throws CaptchaServerException {
+
+        return CaptchaDataHolder.getInstance().getCaptchaConfigService().getCaptchaSiteSecret();
+    }
+
+    @Override
+    public Map<String, String> getWidgetAttributes() throws CaptchaServerException {
+
+        if (isCaptchaEnabled()) {
+            AbstractCaptchaProvider captchaProvider =
+                    CaptchaDataHolder.getInstance().getCaptchaConfigService().getCaptchaProvider();
+
+            if (captchaProvider != null) {
+                return captchaProvider.getWidgetAttributes();
+            }
+
+        }
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<Map<String, String>> getScriptAttributes() throws CaptchaServerException {
+
+        if (isCaptchaEnabled()) {
+            AbstractCaptchaProvider captchaProvider =
+                    CaptchaDataHolder.getInstance().getCaptchaConfigService().getCaptchaProvider();
+
+            if (captchaProvider != null) {
+                return captchaProvider.getScriptAttributes();
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getCaptchaIdentifier() throws CaptchaServerException {
+
+        if (isCaptchaEnabled()) {
+            AbstractCaptchaProvider captchaProvider =
+                    CaptchaDataHolder.getInstance().getCaptchaConfigService().getCaptchaProvider();
+
+            if (captchaProvider != null) {
+                return captchaProvider.getCaptchaIdentifier();
+            }
+        }
+        return "";
+    }
+
+    @Override
+    public String getCaptchaResponseIdentifier() throws CaptchaServerException {
+
+        if (isCaptchaEnabled()) {
+            AbstractCaptchaProvider captchaProvider =
+                    CaptchaDataHolder.getInstance().getCaptchaConfigService().getCaptchaProvider();
+
+            if (captchaProvider != null) {
+                return captchaProvider.getCaptchaResponseIdentifier();
+            }
+        }
+        return "";
+    }
+
+    @Override
+    public Map<String, String> getCaptchaFunctions() throws CaptchaServerException {
+
+        if (isCaptchaEnabled()) {
+            AbstractCaptchaProvider captchaProvider =
+                    CaptchaDataHolder.getInstance().getCaptchaConfigService().getCaptchaProvider();
+
+            if (captchaProvider != null) {
+                return captchaProvider.getCaptchaFunctions();
+            }
+        }
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public String getCaptchaApiUrl() throws CaptchaServerException {
+
+        if (isCaptchaEnabled()) {
+            AbstractCaptchaProvider captchaProvider =
+                    CaptchaDataHolder.getInstance().getCaptchaConfigService().getCaptchaProvider();
+
+            if (captchaProvider != null) {
+                return captchaProvider.getCaptchaApiUrl();
+            }
+        }
+        return "";
+    }
+
+    @Override
+    public String getCaptchaVerifyUrl() throws CaptchaServerException {
+
+        if (isCaptchaEnabled()) {
+            AbstractCaptchaProvider captchaProvider =
+                    CaptchaDataHolder.getInstance().getCaptchaConfigService().getCaptchaProvider();
+
+            if (captchaProvider != null) {
+                return captchaProvider.getCaptchaVerifyUrl();
+            }
+        }
+        return "";
+    }
+
+    @Override
+    public String getCaptchaScoreThreshold() {
+
+        return CaptchaDataHolder.getInstance().getCaptchaConfigService().getCaptchaScoreThreshold();
+    }
+
+    @Override
+    public String getCaptchaWarnScoreThreshold() {
+
+        return CaptchaDataHolder.getInstance().getCaptchaConfigService().getCaptchaWarnScoreThreshold();
+    }
+}

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/util/CaptchaFEUtils.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/util/CaptchaFEUtils.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.captcha.provider_mgt.util;
+
+import org.wso2.carbon.identity.captcha.exception.CaptchaClientException;
+import org.wso2.carbon.identity.captcha.exception.CaptchaServerException;
+import org.wso2.carbon.identity.captcha.internal.CaptchaDataHolder;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class CaptchaFEUtils {
+
+    /**
+     * Checks whether CAPTCHA is enabled.
+     *
+     * @return true if CAPTCHA is enabled; false otherwise.
+     */
+    public static boolean isCaptchaEnabled() {
+
+        return CaptchaDataHolder.getInstance().getCaptchaRuntimeService().isCaptchaEnabled();
+    }
+
+    /**
+     * Retrieves the identifier for the CAPTCHA challenge.
+     *
+     * @return the CAPTCHA identifier.
+     * @throws CaptchaClientException if an error occurs while retrieving the CAPTCHA identifier.
+     */
+    public static String getCaptchaIdentifier() throws CaptchaClientException {
+
+        try {
+            return CaptchaDataHolder.getInstance().getCaptchaRuntimeService().getCaptchaIdentifier();
+        } catch (CaptchaServerException e) {
+            throw new CaptchaClientException("Error while retrieving the captcha identifier.", e);
+        }
+    }
+
+    /**
+     * Retrieves the identifier for the CAPTCHA response.
+     *
+     * @return the CAPTCHA response identifier.
+     * @throws CaptchaClientException if an error occurs while retrieving the CAPTCHA response identifier.
+     */
+    public static String getCaptchaResponseIdentifier() throws CaptchaClientException {
+
+        try {
+            return CaptchaDataHolder.getInstance().getCaptchaRuntimeService().getCaptchaResponseIdentifier();
+        } catch (CaptchaServerException e) {
+            throw new CaptchaClientException("Error while retrieving the captcha response identifier.", e);
+        }
+    }
+
+    /**
+     * Retrieves the API URL for the CAPTCHA service.
+     *
+     * @return the CAPTCHA API URL.
+     * @throws CaptchaClientException if an error occurs while retrieving the CAPTCHA API URL.
+     */
+    public static String getCaptchaApiUrl() throws CaptchaClientException {
+
+        try {
+            return CaptchaDataHolder.getInstance().getCaptchaRuntimeService().getCaptchaApiUrl();
+        } catch (CaptchaServerException e) {
+            throw new CaptchaClientException("Error while retrieving the captcha API URL.", e);
+        }
+    }
+
+    /**
+     * Retrieves the verification URL for the CAPTCHA service.
+     *
+     * @return the CAPTCHA verification URL.
+     * @throws CaptchaClientException if an error occurs while retrieving the CAPTCHA verification URL.
+     */
+    public static String getCaptchaVerifyUrl() throws CaptchaClientException {
+
+        try {
+            return CaptchaDataHolder.getInstance().getCaptchaRuntimeService().getCaptchaVerifyUrl();
+        } catch (CaptchaServerException e) {
+            throw new CaptchaClientException("Error while retrieving the captcha verify URL.", e);
+        }
+    }
+
+    /**
+     * Retrieves the widget attributes required for rendering the CAPTCHA in the frontend.
+     *
+     * @return a map containing the CAPTCHA widget attributes.
+     * @throws CaptchaClientException if an error occurs while retrieving the widget attributes.
+     */
+    public static Map<String, String> getWidgetAttributes() throws CaptchaClientException {
+
+        try {
+            return CaptchaDataHolder.getInstance().getCaptchaRuntimeService().getWidgetAttributes();
+        } catch (CaptchaServerException e) {
+            throw new CaptchaClientException("Error while retrieving the captcha widget attributes.", e);
+        }
+    }
+
+    /**
+     * Retrieves the script attributes required for rendering the CAPTCHA in the frontend.
+     *
+     * @return a list of maps, each containing script attributes for the CAPTCHA.
+     * @throws CaptchaClientException if an error occurs while retrieving the script attributes.
+     */
+    public static List<Map<String, String>> getScriptAttributes() throws CaptchaClientException {
+
+        try {
+            return CaptchaDataHolder.getInstance().getCaptchaRuntimeService().getScriptAttributes();
+        } catch (CaptchaServerException e) {
+            throw new CaptchaClientException("Error while retrieving the captcha script attributes.", e);
+        }
+    }
+
+    /**
+     * Retrieves the client-side functions for initializing or interacting with the CAPTCHA.
+     *
+     * @return a map containing the CAPTCHA functions.
+     * @throws CaptchaClientException if an error occurs while retrieving the CAPTCHA functions.
+     */
+    public static Map<String, String> getCaptchaFunctions() throws CaptchaClientException {
+
+        try {
+            return CaptchaDataHolder.getInstance().getCaptchaRuntimeService().getCaptchaFunctions();
+        } catch (CaptchaServerException e) {
+            throw new CaptchaClientException("Error while retrieving captcha functions.", e);
+        }
+    }
+
+    /**
+     * Retrieves the site key used for the CAPTCHA service.
+     *
+     * @return the CAPTCHA site key.
+     * @throws CaptchaClientException if an error occurs while retrieving the CAPTCHA site key.
+     */
+    public static String getCaptchaSiteKey() throws CaptchaClientException {
+
+        try {
+            return CaptchaDataHolder.getInstance().getCaptchaRuntimeService().getCaptchaSiteKey();
+        } catch (CaptchaServerException e) {
+            throw new CaptchaClientException("Error while retrieving the captcha site key.", e);
+        }
+    }
+
+    /**
+     * Retrieves the site secret used for the CAPTCHA service.
+     *
+     * @return the CAPTCHA site secret.
+     * @throws CaptchaClientException if an error occurs while retrieving the CAPTCHA site secret.
+     */
+    public static String getCaptchaSiteSecret() throws CaptchaClientException {
+
+        try {
+            return CaptchaDataHolder.getInstance().getCaptchaRuntimeService().getCaptchaSiteSecret();
+        } catch (CaptchaServerException e) {
+            throw new CaptchaClientException("Error while retrieving the captcha site secret.", e);
+        }
+    }
+
+    /**
+     * Adds CAPTCHA-related headers to the given HTTP servlet request.
+     *
+     * @param request the HTTP servlet request to which CAPTCHA headers should be added.
+     * @param headers a map containing CAPTCHA headers (e.g., reCaptcha, reCaptchaAPI, reCaptchaKey).
+     */
+    public static void addCaptchaHeaders(HttpServletRequest request, Map<String, List<String>> headers) {
+
+        if (headers != null && headers.get("reCaptcha") != null) {
+            request.setAttribute("reCaptcha", Boolean.TRUE.toString());
+            request.setAttribute("reCaptchaAPI", headers.get("reCaptchaAPI").get(0));
+            request.setAttribute("reCaptchaKey", headers.get("reCaptchaKey").get(0));
+        }
+    }
+}
+

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/util/CaptchaProviderConstants.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/util/CaptchaProviderConstants.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.captcha.provider_mgt.util;
+
+import org.wso2.carbon.identity.captcha.provider_mgt.provider.AbstractCaptchaProvider;
+import org.wso2.carbon.identity.captcha.provider_mgt.provider.GoogleRecaptchaEnterpriseProvider;
+import org.wso2.carbon.identity.captcha.provider_mgt.provider.GoogleRecaptchaProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CaptchaProviderConstants {
+
+    // Captcha Provider Configurations
+    public static final String CAPTCHA_RESOURCE_TYPE = "CAPTCHA_CONFIGURATION";
+    public static final String CAPTCHA_RESOURCE_NAME = "captcha";
+    public static final String CAPTCHA_PROVIDER_CONFIG = "captchaProvider";
+    public static final String CAPTCHA_SITEKEY_CONFIG = "siteKey";
+    public static final String CAPTCHA_SITESECRET_CONFIG = "siteSecret";
+    public static final String CAPTCHA_SCORE_THRESHOLD_CONFIG = "scoreThreshold";
+    public static final String CAPTCHA_SCORE_WARN_THRESHOLD_CONFIG = "scoreWarnThreshold";
+    public static final String CAPTCHA_API_KEY = "apiKey";
+    public static final String CAPTCHA_PROJECT_ID = "projectId";
+    public static final String CAPTCHA_REQUEST_WRAP_URLS = "requestWrapUrls";
+    public static final String CAPTCHA_FAILED_REDIRECT_URLS = "failedRedirectUrls";
+    public static final String CAPTCHA_BYPASSED_API_ENDPOINTS = "bypassedApiEndpoints";
+    // Google ReCAPTCHA
+    public static final String RECAPTCHA_TYPE = "reCaptcha";
+    public static final String RECAPTCHA_IDENTIFIER = "g-recaptcha";
+    public static final String RECAPTCHA_RESPONSE_IDENTIFIER = "g-recaptcha-response";
+    public static final String RECAPTCHA_API_URL = "https://www.google.com/recaptcha/api.js";
+    public static final String RECAPTCHA_VERIFY_URL = "https://www.google.com/recaptcha/api/siteverify";
+    public static final String RECAPTCHA_RENDER_FUNCTION = "grecaptcha.render";
+    public static final String RECAPTCHA_RESET_FUNCTION = "grecaptcha.reset";
+    public static final String RECAPTCHA_GET_RESPONSE_FUNCTION = "grecaptcha.getResponse";
+    public static final double RECAPTCHA_DEFAULT_THRESHOLD = 0.5;
+    public static final double RECAPTCHA_DEFAULT_WARN_THRESHOLD = 0.7;
+
+    // Google ReCAPTCHA Enterprise
+    public static final String RECAPTCHA_ENTERPRISE_TYPE = "recaptcha-enterprise";
+    public static final String RECAPTCHA_ENTERPRISE_RENDER_FUNCTION = "grecaptcha.enterprise.render";
+    public static final String RECAPTCHA_ENTERPRISE_RESET_FUNCTION = "grecaptcha.enterprise.reset";
+    public static final String RECAPTCHA_ENTERPRISE_GET_RESPONSE_FUNCTION = "grecaptcha.enterprise.getResponse";
+    public static final String RECAPTCHA_ENTERPRISE_VERIFY_URL = "https://recaptchaenterprise.googleapis.com";
+
+    // Common POST Parameters
+    public static final String PARAM_SECRET = "secret";
+    public static final String PARAM_RESPONSE = "response";
+    public static final String PARAM__SCORE = "score";
+    public static final String PARAM_SUCCESS = "success";
+
+    public static class CaptchaProviderRegistry {
+
+        private static final Map<String, Class<? extends AbstractCaptchaProvider>> PROVIDER_MAP = new HashMap<>();
+
+        static {
+            PROVIDER_MAP.put(RECAPTCHA_TYPE, GoogleRecaptchaProvider.class);
+            PROVIDER_MAP.put(RECAPTCHA_ENTERPRISE_TYPE, GoogleRecaptchaEnterpriseProvider.class);
+            // Add other providers here, e.g.:
+            // PROVIDER_MAP.put("friendly-captcha", FriendlyCaptchaProvider.class);
+        }
+
+        public static Map<String, Class<? extends AbstractCaptchaProvider>> getProviderClasses() {
+
+            return PROVIDER_MAP;
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/util/CaptchaProviderUtils.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/provider_mgt/util/CaptchaProviderUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.captcha.provider_mgt.util;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import org.wso2.carbon.identity.captcha.exception.CaptchaException;
+import org.wso2.carbon.identity.captcha.exception.CaptchaServerException;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class CaptchaProviderUtils {
+
+    /**
+     * Sends a CAPTCHA verification request to the CAPTCHA service and returns the HTTP entity containing the response.
+     *
+     * @param captchaVerifyUrl the URL of the CAPTCHA verification endpoint.
+     * @param params           the parameters to be sent in the POST request (e.g., secret, response).
+     * @return the HTTP entity containing the CAPTCHA verification response.
+     * @throws CaptchaException if an error occurs while sending the request or receiving the response.
+     */
+    public static HttpEntity isValidCaptcha(String captchaVerifyUrl, List<BasicNameValuePair> params)
+            throws CaptchaException {
+
+        CloseableHttpClient httpclient = HttpClientBuilder.create().useSystemProperties().build();
+
+        HttpPost httpPost = createCaptchaVerificationHttpPost(captchaVerifyUrl, params);
+
+        HttpResponse response;
+        try {
+            response = httpclient.execute(httpPost);
+        } catch (IOException e) {
+            throw new CaptchaServerException("Unable to get the captcha verification response.", e);
+        }
+
+        HttpEntity entity = response.getEntity();
+        if (entity == null) {
+            throw new CaptchaServerException("Captcha verification response is not received.");
+        }
+
+        return entity;
+    }
+
+    private static HttpPost createCaptchaVerificationHttpPost(String captchaVerifyUrl,
+                                                              List<BasicNameValuePair> params) {
+
+        HttpPost httpPost;
+        httpPost = new HttpPost(captchaVerifyUrl);
+        httpPost.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
+
+        return httpPost;
+    }
+
+}

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaUtil.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaUtil.java
@@ -588,6 +588,7 @@ public class CaptchaUtil {
                 throw new RuntimeException(getValidationErrorMessage(CaptchaConstants.RE_CAPTCHA_SECRET_KEY));
             }
             CaptchaDataHolder.getInstance().setReCaptchaSecretKey(reCaptchaSecretKey);
+            CaptchaDataHolder.getInstance().setReCaptchaType(CaptchaConstants.RE_CAPTCHA);
         }
 
         String reCaptchaAPIUrl = properties.getProperty(CaptchaConstants.RE_CAPTCHA_API_URL);


### PR DESCRIPTION
### Purpose

This PR refactor existing google captcha provider with abstract captcha provider based implementation. This introduces Captcha Config Service to handle the configurations of captcha providers and Captcha Runtime Service to provide necessary configurations and perform captcha verification during the runtime.

### Related Issues
- https://github.com/wso2/product-is/issues/23985

### Related PRs
- https://github.com/wso2/identity-apps/pull/8199

### TODO
Change request parameters to a common format without using 'ReCaptcha' specific parameter names.
