### PR TITLE
Migrate to use Unified HTTP Client

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/CaptchaApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/CaptchaApiServiceImpl.java
@@ -18,12 +18,8 @@
 package org.wso2.carbon.identity.recovery.endpoint.impl;
 
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.hc.core5.http.ClassicHttpResponse;
-import org.apache.hc.core5.http.HttpEntity;
 import org.wso2.carbon.identity.captcha.util.CaptchaConstants;
 import org.wso2.carbon.identity.recovery.endpoint.CaptchaApiService;
 import org.wso2.carbon.identity.recovery.endpoint.Constants;
@@ -32,9 +28,8 @@ import org.wso2.carbon.identity.recovery.endpoint.dto.ReCaptchaPropertiesDTO;
 import org.wso2.carbon.identity.recovery.endpoint.dto.ReCaptchaResponseTokenDTO;
 import org.wso2.carbon.identity.recovery.endpoint.dto.ReCaptchaVerificationResponseDTO;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.Properties;
+
 import javax.ws.rs.core.Response;
 
 /**
@@ -87,38 +82,23 @@ public class CaptchaApiServiceImpl extends CaptchaApiService {
 
         ReCaptchaVerificationResponseDTO reCaptchaVerificationResponseDTO = new ReCaptchaVerificationResponseDTO();
 
-        try (ClassicHttpResponse response =
-                     RecoveryUtil.makeCaptchaVerificationHttpClient5Request(reCaptchaResponse, properties)) {
-            HttpEntity entity = response != null ? response.getEntity() : null;
-            if (entity == null) {
-                RecoveryUtil.handleBadRequest("ReCaptcha verification response is not received.",
-                        Constants.STATUS_INTERNAL_SERVER_ERROR_MESSAGE_DEFAULT);
-            }
-            try (InputStream in = entity.getContent()) {
-                JsonObject verificationResponse = new JsonParser().parse(IOUtils.toString(in)).getAsJsonObject();
-
-                if (CaptchaConstants.RE_CAPTCHA_TYPE_ENTERPRISE.equals(reCaptchaType)) {
-                    // For Recaptcha Enterprise.
-                    JsonObject tokenProperties = verificationResponse.get(CaptchaConstants.CAPTCHA_TOKEN_PROPERTIES)
-                            .getAsJsonObject();
-                    boolean success = tokenProperties.get(CaptchaConstants.CAPTCHA_VALID).getAsBoolean();
-                    reCaptchaVerificationResponseDTO.setSuccess(success);
-                } else {
-                    // For ReCaptcha v2 and v3.
-                    reCaptchaVerificationResponseDTO.setSuccess(verificationResponse.get(
-                            CaptchaConstants.CAPTCHA_SUCCESS).getAsBoolean());
-                }
-            } catch (IOException e) {
-                log.error("Unable to read the verification response.", e);
-                RecoveryUtil.handleBadRequest("Unable to read the verification response.",
-                        Constants.STATUS_INTERNAL_SERVER_ERROR_MESSAGE_DEFAULT);
-            }
-        } catch (IOException e) {
-            log.error("Unable to read the verification response.", e);
-            RecoveryUtil.handleBadRequest("Unable to read the verification response.",
+        JsonObject verificationResponse = RecoveryUtil.makeCaptchaVerificationHttpClient5Request(
+                reCaptchaResponse, properties);
+        if (verificationResponse == null) {
+            RecoveryUtil.handleBadRequest("ReCaptcha verification response is not received.",
                     Constants.STATUS_INTERNAL_SERVER_ERROR_MESSAGE_DEFAULT);
         }
-
+        if (CaptchaConstants.RE_CAPTCHA_TYPE_ENTERPRISE.equals(reCaptchaType)) {
+            // For Recaptcha Enterprise.
+            JsonObject tokenProperties = verificationResponse.get(CaptchaConstants.CAPTCHA_TOKEN_PROPERTIES)
+                    .getAsJsonObject();
+            boolean success = tokenProperties.get(CaptchaConstants.CAPTCHA_VALID).getAsBoolean();
+            reCaptchaVerificationResponseDTO.setSuccess(success);
+        } else {
+            // For ReCaptcha v2 and v3.
+            reCaptchaVerificationResponseDTO.setSuccess(verificationResponse.get(
+                    CaptchaConstants.CAPTCHA_SUCCESS).getAsBoolean());
+        }
         return Response.ok(reCaptchaVerificationResponseDTO).build();
     }
 }

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/CaptchaApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/CaptchaApiServiceImpl.java
@@ -22,8 +22,8 @@ import com.google.gson.JsonParser;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpEntity;
 import org.wso2.carbon.identity.captcha.util.CaptchaConstants;
 import org.wso2.carbon.identity.recovery.endpoint.CaptchaApiService;
 import org.wso2.carbon.identity.recovery.endpoint.Constants;
@@ -85,27 +85,33 @@ public class CaptchaApiServiceImpl extends CaptchaApiService {
             RecoveryUtil.handleBadRequest("ReCaptcha is disabled", Constants.INVALID);
         }
 
-        HttpResponse response = RecoveryUtil.makeCaptchaVerificationHttpRequest(reCaptchaResponse, properties);
-        HttpEntity entity = response.getEntity();
         ReCaptchaVerificationResponseDTO reCaptchaVerificationResponseDTO = new ReCaptchaVerificationResponseDTO();
 
-        if (entity == null) {
-            RecoveryUtil.handleBadRequest("ReCaptcha verification response is not received.",
-                    Constants.STATUS_INTERNAL_SERVER_ERROR_MESSAGE_DEFAULT);
-        }
-        try (InputStream in = entity.getContent()) {
-            JsonObject verificationResponse = new JsonParser().parse(IOUtils.toString(in)).getAsJsonObject();
+        try (ClassicHttpResponse response =
+                     RecoveryUtil.makeCaptchaVerificationHttpClient5Request(reCaptchaResponse, properties)) {
+            HttpEntity entity = response != null ? response.getEntity() : null;
+            if (entity == null) {
+                RecoveryUtil.handleBadRequest("ReCaptcha verification response is not received.",
+                        Constants.STATUS_INTERNAL_SERVER_ERROR_MESSAGE_DEFAULT);
+            }
+            try (InputStream in = entity.getContent()) {
+                JsonObject verificationResponse = new JsonParser().parse(IOUtils.toString(in)).getAsJsonObject();
 
-            if (CaptchaConstants.RE_CAPTCHA_TYPE_ENTERPRISE.equals(reCaptchaType)) {
-                // For Recaptcha Enterprise.
-                JsonObject tokenProperties = verificationResponse.get(CaptchaConstants.CAPTCHA_TOKEN_PROPERTIES)
-                        .getAsJsonObject();
-                boolean success = tokenProperties.get(CaptchaConstants.CAPTCHA_VALID).getAsBoolean();
-                reCaptchaVerificationResponseDTO.setSuccess(success);
-            } else {
-                // For ReCaptcha v2 and v3.
-                reCaptchaVerificationResponseDTO.setSuccess(verificationResponse.get(
-                        CaptchaConstants.CAPTCHA_SUCCESS).getAsBoolean());
+                if (CaptchaConstants.RE_CAPTCHA_TYPE_ENTERPRISE.equals(reCaptchaType)) {
+                    // For Recaptcha Enterprise.
+                    JsonObject tokenProperties = verificationResponse.get(CaptchaConstants.CAPTCHA_TOKEN_PROPERTIES)
+                            .getAsJsonObject();
+                    boolean success = tokenProperties.get(CaptchaConstants.CAPTCHA_VALID).getAsBoolean();
+                    reCaptchaVerificationResponseDTO.setSuccess(success);
+                } else {
+                    // For ReCaptcha v2 and v3.
+                    reCaptchaVerificationResponseDTO.setSuccess(verificationResponse.get(
+                            CaptchaConstants.CAPTCHA_SUCCESS).getAsBoolean());
+                }
+            } catch (IOException e) {
+                log.error("Unable to read the verification response.", e);
+                RecoveryUtil.handleBadRequest("Unable to read the verification response.",
+                        Constants.STATUS_INTERNAL_SERVER_ERROR_MESSAGE_DEFAULT);
             }
         } catch (IOException e) {
             log.error("Unable to read the verification response.", e);

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtilsTest.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/Utils/RecoveryUtilsTest.java
@@ -17,11 +17,18 @@
 
 package org.wso2.carbon.identity.recovery.endpoint.Utils;
 
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
+import org.mockito.MockedStatic;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.captcha.util.CaptchaConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
+import org.wso2.carbon.identity.recovery.endpoint.dto.ReCaptchaResponseTokenDTO;
 import org.wso2.carbon.identity.recovery.util.Utils;
+import org.wso2.carbon.utils.httpclient5.HTTPClientUtils;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -32,6 +39,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_FAILURE;
@@ -40,6 +51,8 @@ import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ErrorM
  * Unit tests for RecoveryUtils.java
  */
 public class RecoveryUtilsTest {
+
+    private static final String RECAPTCHA_API_URL = "https://www.google.com/recaptcha/api/siteverify";
 
     @Test(description = "To test the getValidatedCaptchaConfigs method.")
     public void testGetValidatedCaptchaConfigs() throws IdentityRecoveryException {
@@ -96,5 +109,28 @@ public class RecoveryUtilsTest {
         assertEquals(exception.getMessage(), message);
         assertEquals(exception.getDescription(), null);
         assertEquals(cause, exception.getCause());
+    }
+
+    @Test
+    public void testMakeCaptchaVerificationHttpClient5Request() throws IOException {
+
+        ReCaptchaResponseTokenDTO reCaptchaResponse = new ReCaptchaResponseTokenDTO();
+        Properties properties = new Properties();
+        properties.setProperty(CaptchaConstants.RE_CAPTCHA_VERIFY_URL, RECAPTCHA_API_URL);
+        properties.setProperty(CaptchaConstants.RE_CAPTCHA_SECRET_KEY, "testSecretKey");
+
+        HttpClientBuilder httpClientBuilder = mock(HttpClientBuilder.class);
+        CloseableHttpClient mockHttpClient = mock(CloseableHttpClient.class);
+        try (MockedStatic<HTTPClientUtils> mockedUtils = mockStatic(HTTPClientUtils.class)) {
+
+            mockedUtils.when(HTTPClientUtils::createClientWithCustomHostnameVerifier)
+                    .thenReturn(httpClientBuilder);
+            when(httpClientBuilder.build()).thenReturn(mockHttpClient);
+            when(mockHttpClient.execute(any(ClassicHttpRequest.class),
+                    (HttpClientResponseHandler<?>) any())).thenReturn(null);
+
+            // Call the method
+            RecoveryUtil.makeCaptchaVerificationHttpClient5Request(reCaptchaResponse, properties);
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/impl/CaptchaApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/impl/CaptchaApiServiceImplTest.java
@@ -17,11 +17,9 @@
 
 package org.wso2.carbon.identity.recovery.endpoint.impl;
 
+import com.google.gson.JsonParser;
 import org.apache.commons.lang.StringUtils;
-import org.apache.hc.core5.http.ClassicHttpResponse;
-import org.apache.hc.core5.http.HttpEntity;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -34,9 +32,7 @@ import org.wso2.carbon.identity.recovery.endpoint.Utils.RecoveryUtil;
 import org.wso2.carbon.identity.recovery.endpoint.dto.ReCaptchaPropertiesDTO;
 import org.wso2.carbon.identity.recovery.endpoint.dto.ReCaptchaResponseTokenDTO;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
@@ -44,9 +40,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
+
 import javax.ws.rs.core.Response;
 
-import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
@@ -60,10 +56,6 @@ public class CaptchaApiServiceImplTest{
 
     @InjectMocks
     CaptchaApiServiceImpl captchaApiService;
-    @Mock
-    HttpEntity httpEntity;
-    @Mock
-    ClassicHttpResponse classicHttpResponse;
 
     @BeforeMethod
     public void setUp() {
@@ -138,8 +130,6 @@ public class CaptchaApiServiceImplTest{
 
         ReCaptchaResponseTokenDTO reCaptchaResponse = new ReCaptchaResponseTokenDTO();
         String captchaType = "ReCaptcha";
-        InputStream jsonStream = new ByteArrayInputStream(responseString.getBytes());
-
 
         Properties sampleProperties = getSampleConfigFile();
         sampleProperties.setProperty(CaptchaConstants.RE_CAPTCHA_ENABLED, "true");
@@ -147,11 +137,7 @@ public class CaptchaApiServiceImplTest{
 
         mockedRecoveryUtil.when(RecoveryUtil::getValidatedCaptchaConfigs).thenReturn(sampleProperties);
         mockedRecoveryUtil.when(() -> RecoveryUtil.makeCaptchaVerificationHttpClient5Request(
-                reCaptchaResponse, sampleProperties)).thenReturn(classicHttpResponse);
-
-        when(classicHttpResponse.getEntity()).thenReturn(httpEntity);
-        when(httpEntity.getContent()).thenReturn(jsonStream);
-        when(classicHttpResponse.getCode()).thenReturn(200);
+                reCaptchaResponse, sampleProperties)).thenReturn(JsonParser.parseString(responseString));
 
         Response response = captchaApiService.verifyCaptcha(reCaptchaResponse, captchaType, "carbon.super");
 

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/impl/CaptchaApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/impl/CaptchaApiServiceImplTest.java
@@ -18,7 +18,10 @@
 package org.wso2.carbon.identity.recovery.endpoint.impl;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpEntity;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -29,7 +32,11 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.identity.captcha.util.CaptchaConstants;
 import org.wso2.carbon.identity.recovery.endpoint.Utils.RecoveryUtil;
 import org.wso2.carbon.identity.recovery.endpoint.dto.ReCaptchaPropertiesDTO;
+import org.wso2.carbon.identity.recovery.endpoint.dto.ReCaptchaResponseTokenDTO;
+
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
@@ -38,7 +45,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
 import javax.ws.rs.core.Response;
+
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
 /**
@@ -50,6 +60,10 @@ public class CaptchaApiServiceImplTest{
 
     @InjectMocks
     CaptchaApiServiceImpl captchaApiService;
+    @Mock
+    HttpEntity httpEntity;
+    @Mock
+    ClassicHttpResponse classicHttpResponse;
 
     @BeforeMethod
     public void setUp() {
@@ -106,6 +120,43 @@ public class CaptchaApiServiceImplTest{
         } else {
             assertEquals(reCaptchaPropertiesDTO.getReCaptchaAPI(), reCaptchaAPI);
         }
+    }
+
+    @DataProvider(name = "captchaResponseDataProvider")
+    public static Object[][] captchaResponseDataProvider() {
+
+        String reCaptchaEnterprise = CaptchaConstants.RE_CAPTCHA_TYPE_ENTERPRISE;
+
+        return new Object[][]{
+                {"", "{\"success\":\"true\"}"},
+                {reCaptchaEnterprise, "{ \"tokenProperties\": { \"valid\": \"true\" } }"}
+        };
+    }
+
+    @Test(description = "Test verify successful captcha response", dataProvider = "captchaResponseDataProvider")
+    void testVerifyCaptchaSuccessful(String reCaptchaType, String responseString) throws Exception {
+
+        ReCaptchaResponseTokenDTO reCaptchaResponse = new ReCaptchaResponseTokenDTO();
+        String captchaType = "ReCaptcha";
+        InputStream jsonStream = new ByteArrayInputStream(responseString.getBytes());
+
+
+        Properties sampleProperties = getSampleConfigFile();
+        sampleProperties.setProperty(CaptchaConstants.RE_CAPTCHA_ENABLED, "true");
+        sampleProperties.setProperty(CaptchaConstants.RE_CAPTCHA_TYPE, reCaptchaType);
+
+        mockedRecoveryUtil.when(RecoveryUtil::getValidatedCaptchaConfigs).thenReturn(sampleProperties);
+        mockedRecoveryUtil.when(() -> RecoveryUtil.makeCaptchaVerificationHttpClient5Request(
+                reCaptchaResponse, sampleProperties)).thenReturn(classicHttpResponse);
+
+        when(classicHttpResponse.getEntity()).thenReturn(httpEntity);
+        when(httpEntity.getContent()).thenReturn(jsonStream);
+        when(classicHttpResponse.getCode()).thenReturn(200);
+
+        Response response = captchaApiService.verifyCaptcha(reCaptchaResponse, captchaType, "carbon.super");
+
+        assertNotNull(response);
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
     }
 
     public Properties getSampleConfigFile() throws IOException {

--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -46,6 +46,10 @@
             <artifactId>taglibs-standard-impl</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.utils</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
             <artifactId>httpclient5</artifactId>
         </dependency>
@@ -192,6 +196,7 @@
                             org.wso2.carbon.user.api.*; version="${carbon.user.api.imp.pkg.version.range}",
                             org.wso2.carbon.utils.multitenancy.*;
                             version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.utils.httpclient5; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.application.common.model;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.util;

--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -47,11 +47,11 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
+            <artifactId>httpclient5</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents.wso2</groupId>
-            <artifactId>httpcore</artifactId>
+            <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
+            <artifactId>httpcore5</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -174,10 +174,10 @@
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",
                             org.apache.commons.logging.*; version="${commons-logging.osgi.version.range}",
-                            org.apache.http.*,
-                            org.apache.http.client.*;version="${httpcomponents-httpclient.imp.pkg.version.range}",
-                            org.apache.http.impl.client.*;version="${httpcomponents-httpclient.imp.pkg.version.range}",
-                            org.apache.http.message.*;version="${httpcore.osgi.version.range}",
+                            org.apache.hc.*,
+                            org.apache.hc.client5.http.*;version="${httpcomponents-httpclient.imp.pkg.version.range}",
+                            org.apache.hc.client5.http.impl.*;version="${httpcomponents-httpclient.imp.pkg.version.range}",
+                            org.apache.hc.core5.http.message.*;version="${httpcore.osgi.version.range}",
 
                             javax.servlet.*; version="${imp.pkg.version.javax.servlet}",
 

--- a/components/org.wso2.carbon.identity.captcha/src/test/java/org/wso2/carbon/identity/captcha/util/CaptchaUtilTest.java
+++ b/components/org.wso2.carbon.identity.captcha/src/test/java/org/wso2/carbon/identity/captcha/util/CaptchaUtilTest.java
@@ -17,8 +17,8 @@
 package org.wso2.carbon.identity.captcha.util;
 
 import com.google.gson.JsonObject;
-import org.apache.http.HttpEntity;
-import org.apache.http.client.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.core5.http.HttpEntity;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
@@ -31,6 +31,7 @@ import java.io.IOException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.URISyntaxException;
 
 import static org.testng.Assert.assertThrows;
 
@@ -102,7 +103,7 @@ public class CaptchaUtilTest {
 
     @Test (description = "This method is used to test the createReCaptchaEnterpriseVerificationHttpPost method")
     public void testCreateReCaptchaEnterpriseVerificationHttpPost() throws NoSuchMethodException,
-            InvocationTargetException, IllegalAccessException {
+            InvocationTargetException, IllegalAccessException, URISyntaxException {
 
         CaptchaDataHolder.getInstance().setReCaptchaVerifyUrl(RECAPTCHA_ENTERPRISE_API_URL);
         CaptchaDataHolder.getInstance().setReCaptchaAPIKey("dummyKey");
@@ -112,13 +113,13 @@ public class CaptchaUtilTest {
         Method method = getCreateReCaptchaEnterpriseVerificationHttpPostMethod();
         HttpPost httpPost = (HttpPost) method.invoke(null, "reCaptchaEnterpriseResponse");
         String expectedURI = RECAPTCHA_ENTERPRISE_API_URL+ "/v1/projects/dummyProjectId/assessments?key=dummyKey";
-        Assert.assertEquals(httpPost.getURI().toString(), expectedURI);
+        Assert.assertEquals(httpPost.getUri().toString(), expectedURI);
 
     }
 
     @Test (description = "This method is used to test the createReCaptchaEnterpriseVerificationHttpPost method")
     public void testCreateReCaptchaVerificationHttpPost() throws NoSuchMethodException,
-            InvocationTargetException, IllegalAccessException {
+            InvocationTargetException, IllegalAccessException, URISyntaxException {
 
         CaptchaDataHolder.getInstance().setReCaptchaVerifyUrl(RECAPTCHA_API_URL);
         CaptchaDataHolder.getInstance().setReCaptchaSecretKey("dummyKey");
@@ -127,7 +128,7 @@ public class CaptchaUtilTest {
 
         Method method = getCreateReCaptchaVerificationHttpPostMethod();
         HttpPost httpPost = (HttpPost) method.invoke(null, "reCaptchaEnterpriseResponse");
-        Assert.assertEquals(httpPost.getURI().toString(), RECAPTCHA_API_URL);
+        Assert.assertEquals(httpPost.getUri().toString(), RECAPTCHA_API_URL);
     }
 
 

--- a/components/org.wso2.carbon.identity.captcha/src/test/java/org/wso2/carbon/identity/captcha/util/CaptchaUtilTest.java
+++ b/components/org.wso2.carbon.identity.captcha/src/test/java/org/wso2/carbon/identity/captcha/util/CaptchaUtilTest.java
@@ -16,24 +16,16 @@
 
 package org.wso2.carbon.identity.captcha.util;
 
-import com.google.gson.JsonObject;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
-import org.apache.hc.core5.http.HttpEntity;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.captcha.internal.CaptchaDataHolder;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
-
-import static org.testng.Assert.assertThrows;
 
 /**
  * Unit tests for CaptchaUtil.java
@@ -65,42 +57,6 @@ public class CaptchaUtilTest {
         return method;
     }
 
-    private Method getVerifyReCaptchaEnterpriseResponseMethod() throws NoSuchMethodException {
-
-        Method method = CaptchaUtil.class.getDeclaredMethod("verifyReCaptchaEnterpriseResponse",
-                HttpEntity.class);
-        method.setAccessible(true);
-        return method;
-    }
-
-    private Method getVerifyReCaptchaResponseMethod() throws NoSuchMethodException {
-
-        Method method = CaptchaUtil.class.getDeclaredMethod("verifyReCaptchaResponse",
-                HttpEntity.class);
-        method.setAccessible(true);
-        return method;
-    }
-
-    private JsonObject getReCaptchaEnterpriseJsonObject(boolean valid, double score) {
-
-        JsonObject verificationResponse = new JsonObject();
-        JsonObject tokenProperties = new JsonObject();
-        tokenProperties.addProperty(CaptchaConstants.CAPTCHA_VALID, valid);
-        verificationResponse.add(CaptchaConstants.CAPTCHA_TOKEN_PROPERTIES, tokenProperties);
-        JsonObject riskAnalysis = new JsonObject();
-        riskAnalysis.addProperty(CaptchaConstants.CAPTCHA_SCORE, score);
-        verificationResponse.add(CaptchaConstants.CAPTCHA_RISK_ANALYSIS, riskAnalysis);
-        return verificationResponse;
-    }
-
-    private JsonObject getReCaptchaJsonObject(boolean valid, double score) {
-
-        JsonObject verificationResponse = new JsonObject();
-        verificationResponse.addProperty(CaptchaConstants.CAPTCHA_SUCCESS, valid);
-        verificationResponse.addProperty(CaptchaConstants.CAPTCHA_SCORE, score);
-        return verificationResponse;
-    }
-
     @Test (description = "This method is used to test the createReCaptchaEnterpriseVerificationHttpPost method")
     public void testCreateReCaptchaEnterpriseVerificationHttpPost() throws NoSuchMethodException,
             InvocationTargetException, IllegalAccessException, URISyntaxException {
@@ -129,98 +85,5 @@ public class CaptchaUtilTest {
         Method method = getCreateReCaptchaVerificationHttpPostMethod();
         HttpPost httpPost = (HttpPost) method.invoke(null, "reCaptchaEnterpriseResponse");
         Assert.assertEquals(httpPost.getUri().toString(), RECAPTCHA_API_URL);
-    }
-
-
-    @Test (description = "This method is used to test the verifyReCaptchaEnterpriseResponse method, " +
-            "with high captcha score")
-    public void testVerifyReCaptchaEnterpriseResponseWithHighScore() throws IOException, NoSuchMethodException,
-            InvocationTargetException, IllegalAccessException {
-
-        CaptchaDataHolder.getInstance().setReCaptchaScoreThreshold(CaptchaConstants.CAPTCHA_V3_DEFAULT_THRESHOLD);
-
-        JsonObject verificationResponse = getReCaptchaEnterpriseJsonObject(true, 0.7);
-        Method method = getVerifyReCaptchaEnterpriseResponseMethod();
-        HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
-        Mockito.when(httpEntity.getContent()).thenReturn(new ByteArrayInputStream(
-                verificationResponse.toString().getBytes()));
-        // Verify no exception is thrown for high score.
-        method.invoke(null, httpEntity);
-    }
-
-    @Test (description = "This method is used to test the verifyReCaptchaEnterpriseResponse method, " +
-            "with low captcha score")
-    public void testVerifyReCaptchaEnterpriseResponseWithLowScore() throws IOException, NoSuchMethodException {
-
-        CaptchaDataHolder.getInstance().setReCaptchaScoreThreshold(CaptchaConstants.CAPTCHA_V3_DEFAULT_THRESHOLD);
-
-        JsonObject verificationResponse = getReCaptchaEnterpriseJsonObject(true, 0.4);
-        Method method = getVerifyReCaptchaEnterpriseResponseMethod();
-        HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
-        Mockito.when(httpEntity.getContent()).thenReturn(new ByteArrayInputStream(verificationResponse.toString().
-                getBytes()));
-        // Verify an exception is thrown for low score.
-        assertThrows(InvocationTargetException.class, () -> method.invoke(null, httpEntity));
-    }
-
-    @Test (description = "This method is used to test the verifyReCaptchaEnterpriseResponse method, " +
-                "with invalid response")
-    public void testVerifyReCaptchaEnterpriseResponseWithInvalidResponse() throws IOException, NoSuchMethodException {
-
-        CaptchaDataHolder.getInstance().setReCaptchaScoreThreshold(CaptchaConstants.CAPTCHA_V3_DEFAULT_THRESHOLD);
-
-        JsonObject verificationResponse = getReCaptchaEnterpriseJsonObject(false, 0.7);
-        Method method = getVerifyReCaptchaEnterpriseResponseMethod();
-        HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
-        Mockito.when(httpEntity.getContent()).thenReturn(new ByteArrayInputStream(verificationResponse.
-                toString().getBytes()));
-        // Verify an exception is thrown for invalid response.
-        assertThrows(InvocationTargetException.class, () -> method.invoke(null, httpEntity));
-    }
-
-    @Test (description = "This method is used to test the verifyReCaptchaResponse method, " +
-            "with high captcha score")
-    public void testVerifyReCaptchaResponseWithHighScore() throws IOException, NoSuchMethodException,
-            InvocationTargetException, IllegalAccessException {
-
-        CaptchaDataHolder.getInstance().setReCaptchaScoreThreshold(CaptchaConstants.CAPTCHA_V3_DEFAULT_THRESHOLD);
-
-        JsonObject verificationResponse = getReCaptchaJsonObject(true, 0.7);
-        Method method = getVerifyReCaptchaResponseMethod();
-        HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
-        Mockito.when(httpEntity.getContent()).thenReturn(new ByteArrayInputStream(verificationResponse.toString().
-                getBytes()));
-        // Verify no exception is thrown for high score.
-        method.invoke(null, httpEntity);
-    }
-
-    @Test (description = "This method is used to test the verifyReCaptchaResponse method, " +
-            "with low captcha score")
-    public void testVerifyReCaptchaResponseWithLowScore() throws IOException, NoSuchMethodException {
-
-        CaptchaDataHolder.getInstance().setReCaptchaScoreThreshold(CaptchaConstants.CAPTCHA_V3_DEFAULT_THRESHOLD);
-
-        JsonObject verificationResponse = getReCaptchaJsonObject(true, 0.4);
-        Method method = getVerifyReCaptchaResponseMethod();
-        HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
-        Mockito.when(httpEntity.getContent()).thenReturn(new ByteArrayInputStream(verificationResponse.toString().
-                getBytes()));
-        // Verify no exception is thrown for low score.
-        assertThrows(InvocationTargetException.class, () -> method.invoke(null, httpEntity));
-    }
-
-    @Test (description = "This method is used to test the verifyReCaptchaResponse method, " +
-            "with invalid response")
-    public void testVerifyReCaptchaResponseWithInvalidResponse() throws IOException, NoSuchMethodException {
-
-        CaptchaDataHolder.getInstance().setReCaptchaScoreThreshold(CaptchaConstants.CAPTCHA_V3_DEFAULT_THRESHOLD);
-
-        JsonObject verificationResponse = getReCaptchaJsonObject(false, 0.7);
-        Method method = getVerifyReCaptchaResponseMethod();
-        HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
-        Mockito.when(httpEntity.getContent()).thenReturn(new ByteArrayInputStream(verificationResponse.toString().
-                getBytes()));
-        // Verify no exception is thrown for invalid response.
-        assertThrows(InvocationTargetException.class, () -> method.invoke(null, httpEntity));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,16 @@
                 <version>${httpcore.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>${httpclient5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
+                <artifactId>httpcore5</artifactId>
+                <version>${httpcore5.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>annotations</artifactId>
                 <version>${findbugs.annotation.version}</version>
@@ -194,6 +204,11 @@
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.utils</artifactId>
+                <version>${carbon.kernel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon</groupId>
+                <artifactId>org.wso2.carbon.utils.httpclient5</artifactId>
                 <version>${carbon.kernel.version}</version>
             </dependency>
             <dependency>
@@ -679,13 +694,15 @@
         <json.wso2.version.range>[3.0.0.wso2v1, 4.0.0)</json.wso2.version.range>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
         <httpcore.version>4.3.3.wso2v1</httpcore.version>
-        <httpcore.osgi.version.range>[4.3.3, 5.0.0)</httpcore.osgi.version.range>
+        <httpcore.osgi.version.range>[5.3.1, 6.0.0)</httpcore.osgi.version.range>
+        <httpcore5.version>5.3.1.wso2v1</httpcore5.version>
+        <httpclient5.version>5.4.1.wso2v1</httpclient5.version>
         <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>
         <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>
         <servlet-api.version>2.5</servlet-api.version>
         <taglibs-standard-impl.version>1.2.5</taglibs-standard-impl.version>
         <httpcomponents-httpclient.wso2.version>4.3.6.wso2v2</httpcomponents-httpclient.wso2.version>
-        <httpcomponents-httpclient.imp.pkg.version.range>[4.3.1.wso2v2,5.0.0)
+        <httpcomponents-httpclient.imp.pkg.version.range>[4.3.1.wso2v2,6.0.0)
         </httpcomponents-httpclient.imp.pkg.version.range>
         <com.google.code.gson.version>2.9.0</com.google.code.gson.version>
         <com.google.code.gson.osgi.version.range>[2.3.1,3.0.0)</com.google.code.gson.osgi.version.range>


### PR DESCRIPTION
## Proposed changes in this pull request
- Modify to use Apache HTTP Client 5, instead of previously used Apache HTTP Client 4.
- Methods in the Carbon Kernel (see PRs mentioned below) are used for creating HTTP clients.

### Related PRs
- https://github.com/wso2-extensions/identity-governance/pull/954

### Related issue
- https://github.com/wso2/product-is/issues/24106