### PR TITLE
Improve client error handling for data type and allowed values validation failures

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -372,6 +372,10 @@ public class IdentityRecoveryConstants {
         ERROR_CODE_INVALID_REGISTRATION_OPTION("USR-10007", "Invalid registration option."),
         ERROR_CODE_MULTIPLE_REGISTRATION_OPTIONS("USR-10008", "Multiple registration options are not supported."),
         ERROR_CODE_INVALID_DOMAIN("USR-10009", "The email domain does not match the organization's email domain."),
+        ERROR_CODE_INCOMPATIBLE_VALUE_FOR_USER_ATTRIBUTE("USR-10010", "The given values for the user attributes " +
+                "doesn't match with allowed data types."),
+        ERROR_CODE_NOT_ALLOWED_VALUE_FOR_USER_ATTRIBUTE("USR-10011", "The given values for the user attributes " +
+                "doesn't allowed."),
 
         // USR - User Self Registration - server exceptions.
         ERROR_CODE_UNEXPECTED_ERROR_VALIDATING_ATTRIBUTES("USR-15001", "Unexpected error while validating user " +

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -92,6 +92,7 @@ import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.Permission;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.UserStoreClientException;
 import org.wso2.carbon.user.core.UserStoreConfigConstants;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -378,6 +379,13 @@ public class UserSelfRegistrationManager {
                     ERROR_CODE_DOMAIN_VIOLATED, user.getUserStoreDomain(), e);
         }
 
+        if (e instanceof UserStoreClientException) {
+            IdentityRecoveryConstants.ErrorMessages error = getErrorMessages((UserStoreClientException) e);
+            if (error != null) {
+                throw Utils.handleClientException(error, StringUtils.EMPTY, e);
+            }
+        }
+
         if (e instanceof org.wso2.carbon.user.core.UserStoreException) {
             String errorCode = ((org.wso2.carbon.user.core.UserStoreException) e).getErrorCode();
             if (ERROR_CODE_EMAIL_DOMAIN_NOT_MAPPED_TO_ORGANIZATION.getCode().equals(errorCode)) {
@@ -387,6 +395,18 @@ public class UserSelfRegistrationManager {
         }
         throw Utils.handleServerException(IdentityRecoveryConstants.ErrorMessages.
                 ERROR_CODE_ADD_SELF_USER, user.getUserName(), e);
+    }
+
+    private static IdentityRecoveryConstants.ErrorMessages getErrorMessages(UserStoreClientException e) {
+
+        String errorCode = e.getErrorCode();
+        IdentityRecoveryConstants.ErrorMessages error = null;
+        if (Constants.ErrorMessages.ERROR_INVALID_ATTRIBUTE_VALUE_TYPE.getCode().equals(errorCode)) {
+            error = IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INCOMPATIBLE_VALUE_FOR_USER_ATTRIBUTE;
+        } else if (Constants.ErrorMessages.ERROR_NOT_ALLOWED_ATTRIBUTE_VALUE.getCode().equals(errorCode)) {
+            error = IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_NOT_ALLOWED_VALUE_FOR_USER_ATTRIBUTE;
+        }
+        return error;
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -710,7 +710,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.8.215</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.223-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request

Except for predefined errors, all client errors in the self-registration flow are treated as server errors.
However, the newly introduced client-side data type validations are now handled under client exception handling.


### Related Issues
- https://github.com/wso2/product-is/issues/24253

### Depends on
- https://github.com/wso2/carbon-identity-framework/pull/6847


<img width="928" alt="Screenshot 2025-06-15 at 17 31 35" src="https://github.com/user-attachments/assets/ae14f3ea-aa6b-4388-9cbd-bc0257318111" />
