### PR TITLE
Update PasswordProvisioningExecutor to support recovery flows

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutor.java
@@ -104,9 +104,9 @@ public class PasswordProvisioningExecutor implements Executor {
 
         try {
             if (context.getFlowType().equals(PASSWORD_RECOVERY)) {
-                return recoveryLogic(context, password);
+                return handlePasswordRecoveryFlow(context, password);
             } else if (context.getFlowType().equals(ASK_PASSWORD)) {
-                return askPasswordLogic(context, password);
+                return handleAskPasswordFlow(context, password);
             }
 
             return new ExecutorResponse();
@@ -115,7 +115,7 @@ public class PasswordProvisioningExecutor implements Executor {
         }
     }
 
-    private ExecutorResponse askPasswordLogic(FlowExecutionContext context, char[] password) {
+    private ExecutorResponse handleAskPasswordFlow(FlowExecutionContext context, char[] password) {
 
         String confirmationCode = (String) context.getProperty(CONFIRMATION_CODE);
         if (StringUtils.isBlank(confirmationCode)) {
@@ -141,7 +141,7 @@ public class PasswordProvisioningExecutor implements Executor {
         }
     }
 
-    private ExecutorResponse recoveryLogic(FlowExecutionContext context, char[] password) {
+    private ExecutorResponse handlePasswordRecoveryFlow(FlowExecutionContext context, char[] password) {
 
         try {
             int tenantId = IdentityTenantUtil.getTenantId(context.getTenantDomain());

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutorTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutorTest.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.recovery.executor;
 import org.mockito.MockedStatic;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.flow.execution.engine.Constants;
@@ -57,6 +58,7 @@ public class PasswordProvisioningExecutorTest {
     private static final String TENANT_DOMAIN = "carbon.super";
     private static final String USER_ID = "abc123";
     private static final String ASK_PASSWORD = "ASK_PASSWORD";
+    private static final String PASSWORD_RECOVERY = "PASSWORD_RECOVERY";
     private static final Map<String, String> userInputData = new HashMap<>();
     private static final int TENANT_ID = 1234;
     private PasswordProvisioningExecutor executor;
@@ -79,6 +81,14 @@ public class PasswordProvisioningExecutorTest {
         mockedRecoveryStatic.close();
         mockedDataHolderStatic.close();
         mockedIdentityTenantUtil.close();
+    }
+
+    @DataProvider(name = "flowTypes")
+    public Object[][] provideFlowTypes() {
+        return new Object[][] {
+                { ASK_PASSWORD },
+                { PASSWORD_RECOVERY }
+        };
     }
 
     @Test
@@ -111,11 +121,11 @@ public class PasswordProvisioningExecutorTest {
         assertTrue(response.getRequiredData().contains(PASSWORD_KEY));
     }
 
-    @Test
-    public void testExecuteWithValidData() throws Exception {
+    @Test(dataProvider = "flowTypes")
+    public void testExecuteWithValidData(String flowType) throws Exception {
 
         FlowExecutionContext context = mock(FlowExecutionContext.class);
-        when(context.getFlowType()).thenReturn(ASK_PASSWORD);
+        when(context.getFlowType()).thenReturn(flowType);
         FlowUser flowUser = new FlowUser();
         flowUser.setUsername(USERNAME);
         when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
@@ -142,8 +152,10 @@ public class PasswordProvisioningExecutorTest {
 
         ExecutorResponse response = executor.execute(context);
 
+        if (flowType.equals(ASK_PASSWORD)) {
+            assertEquals(flowUser.getUserId(), USER_ID);
+        }
         assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_COMPLETE);
-        assertEquals(flowUser.getUserId(), USER_ID);
     }
 
     @Test


### PR DESCRIPTION
This pull request refactors the `PasswordProvisioningExecutor` class to improve code readability and functionality by introducing flow-specific logic for password recovery and "ask password" operations. It also ensures sensitive data is cleared securely and updates exception handling.

### Refactoring for flow-specific logic:

* Added new constants `PASSWORD_RECOVERY` and `ASK_PASSWORD` to define flow types (`[components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutor.javaR66-R67](diffhunk://#diff-7e8c4ac7eb220a204ea018833047ad231ff23f7ef2a7c678b6212374fcc266beR66-R67)`).
* Refactored the `execute` method to delegate flow-specific logic to new methods: `recoveryLogic` and `askPasswordLogic`. This improves modularity and readability (`[[1]](diffhunk://#diff-7e8c4ac7eb220a204ea018833047ad231ff23f7ef2a7c678b6212374fcc266beL101-R119)`, `[[2]](diffhunk://#diff-7e8c4ac7eb220a204ea018833047ad231ff23f7ef2a7c678b6212374fcc266beL121-R155)`).

### Security improvements:

* Ensured sensitive data (`password`) is cleared securely using `Arrays.fill` in a `finally` block within the `execute` method (`[components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutor.javaL101-R119](diffhunk://#diff-7e8c4ac7eb220a204ea018833047ad231ff23f7ef2a7c678b6212374fcc266beL101-R119)`).

### Exception handling updates:

* Expanded exception handling in the `execute` method to include `FlowEngineException` for better error coverage (`[components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutor.javaL121-R155](diffhunk://#diff-7e8c4ac7eb220a204ea018833047ad231ff23f7ef2a7c678b6212374fcc266beL121-R155)`).

### Code cleanup:

* Removed unused import `org.apache.commons.collections.CollectionUtils` to reduce clutter (`[components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutor.javaL21](diffhunk://#diff-7e8c4ac7eb220a204ea018833047ad231ff23f7ef2a7c678b6212374fcc266beL21)`).
* Added a static import for the `ERROR` constant to simplify error handling logic (`[components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutor.javaR49](diffhunk://#diff-7e8c4ac7eb220a204ea018833047ad231ff23f7ef2a7c678b6212374fcc266beR49)`).