### PR TITLE
Fix user identifier mismatch in error message during password recovery with multi-attribute login

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
@@ -59,7 +59,7 @@ public class RecoverPasswordApiServiceImpl extends RecoverPasswordApiService {
             if (IdentityRecoveryServiceDataHolder.getInstance().getMultiAttributeLoginService()
                     .isEnabled(user.getTenantDomain())) {
                 Property[] properties =
-                        buildRecoveryPropertiesForMultiAttributeLoginEnabled(recoveryInitiatingRequest, user);
+                        buildRecoveryPropertiesForMultiAttributeLogin(recoveryInitiatingRequest, user);
                 ResolvedUserResult resolvedUserResult =
                         IdentityRecoveryServiceDataHolder.getInstance().getMultiAttributeLoginService()
                                 .resolveUser(user.getUsername(), user.getTenantDomain());
@@ -135,16 +135,12 @@ public class RecoverPasswordApiServiceImpl extends RecoverPasswordApiService {
      * @param user    User initiating the recovery.
      * @return        Property array with or without login identifier.
      */
-    private Property[] buildRecoveryPropertiesForMultiAttributeLoginEnabled(RecoveryInitiatingRequestDTO request,
+    private Property[] buildRecoveryPropertiesForMultiAttributeLogin(RecoveryInitiatingRequestDTO request,
                                                                             UserDTO user) {
 
         List<Property> propertyList = new ArrayList<>(
                 Arrays.asList(RecoveryUtil.getProperties(request.getProperties())));
-
-        Property loginIdentifierProp = new Property();
-        loginIdentifierProp.setKey(LOGIN_IDENTIFIER);
-        loginIdentifierProp.setValue(user.getUsername());
-        propertyList.add(loginIdentifierProp);
+        propertyList.add(new Property(LOGIN_IDENTIFIER, user.getUsername()));
 
         return propertyList.toArray(new Property[0]);
     }

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/RecoverPasswordApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/RecoverPasswordApiServiceImplTest.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.identity.recovery.endpoint.dto.RecoveryInitiatingRequestD
 import org.wso2.carbon.identity.recovery.endpoint.dto.UserDTO;
 import org.wso2.carbon.identity.recovery.endpoint.impl.RecoverPasswordApiServiceImpl;
 import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
+import org.wso2.carbon.identity.recovery.model.Property;
 import org.wso2.carbon.identity.recovery.password.NotificationPasswordRecoveryManager;
 
 import java.util.ArrayList;
@@ -105,6 +106,10 @@ public class RecoverPasswordApiServiceImplTest {
         mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
         mockedRecoveryUtil.when(RecoveryUtil::getNotificationBasedPwdRecoveryManager).thenReturn(
                 notificationPasswordRecoveryManager);
+        if(isMultiAttributeLoginEnabled) {
+            mockedRecoveryUtil.when(() -> RecoveryUtil.getProperties(Mockito.any()))
+                    .thenReturn(new Property[0]);
+        }
         Mockito.when(notificationPasswordRecoveryManager.sendRecoveryNotification(isNull(), anyString(), anyBoolean(),
                 isNull())).thenReturn(notificationResponseBean);
         mockedIdentityRecoveryServiceDataHolder.when(IdentityRecoveryServiceDataHolder::getInstance)

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -161,6 +161,7 @@ public class IdentityRecoveryConstants {
     public static final String EXECUTE_ACTION = "ui.execute";
     public static final String UTF_8 = "UTF-8";
     public static final String CALLBACK = "callback";
+    public static final String LOGIN_IDENTIFIER = "loginIdentifier";
     public static final String IS_ACCESS_URL_AVAILABLE = "isAccessUrlAvailable";
     public static final String IS_LITE_SIGN_UP = "isLiteSignUp";
     public static final String DEFAULT_CALLBACK_REGEX = ".*";


### PR DESCRIPTION
### Purpose
To ensure that the account locked error message in the password recovery flow accurately reflects the **login identifier entered by the user** (e.g., email or phone number), instead of the resolved internal username.
> This change is applied by default in `master` as a **PII protection measure**, without introducing a new configuration.

### Goals
* Display the correct identifier (e.g., email or phone number) used by the user when initiating a password recovery request.
* Prevent confusion caused by showing the resolved username in the error message when multi-attribute login is enabled.
* Prevent potential enumeration and PII exposure by ensuring the login identifier is only shown **when** `notify_user_account_status = true`.

### Approach
* In `NotificationPasswordRecoveryManager`, introduced a new method `getLoginIdentifierFromProperties` to extract the original identifier from the `Property[]` in the recovery request.
* In `RecoverPasswordApiServiceImpl`, always append the entered `user.getUsername()` as a property named `loginIdentifier` in the recovery request.
* Introduced the method `buildRecoveryPropertiesForMultiAttributeLoginEnabled` to build the recovery properties with or without the login identifier, when the multi-attribute login is enabled.
* Used `loginIdentifier` in the account locked error message if `notify_user_account_status` config is enabled.


## Related Issues
public issue: https://github.com/wso2/product-is/issues/24223
