### PR TITLE
Handle the recovery scenario change when resend code is used once

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AccountConfirmationValidationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AccountConfirmationValidationHandler.java
@@ -126,6 +126,12 @@ public class AccountConfirmationValidationHandler extends AbstractEventHandler {
                 IdentityUtil.setIdentityErrorMsg(customErrorMessageContext);
                 throw new IdentityEventException(IdentityCoreConstants.USER_EMAIL_NOT_VERIFIED_ERROR_CODE,
                         "User : " + Utils.maskIfRequired(userName) + "'s email is not confirmed yet.");
+            } else if (!isSelfSignupEnabled && operationStatus && !isUserEmailVerificationScenario(user)) {
+                IdentityErrorMsgContext customErrorMessageContext =
+                        new IdentityErrorMsgContext(IdentityCoreConstants.USER_EMAIL_NOT_VERIFIED_ERROR_CODE);
+                IdentityUtil.setIdentityErrorMsg(customErrorMessageContext);
+                throw new IdentityEventException(IdentityCoreConstants.USER_EMAIL_NOT_VERIFIED_ERROR_CODE,
+                        "User : " + Utils.maskIfRequired(userName) + "'s email is not verified yet.");
             } else if (isInvalidCredentialsScenario(operationStatus, user)) {
                 if (log.isDebugEnabled()) {
                     log.debug(String.format("Account unconfirmed user: %s in userstore: %s in tenant: %s is trying " +
@@ -201,6 +207,19 @@ public class AccountConfirmationValidationHandler extends AbstractEventHandler {
             throw new IdentityEventException("Error occurred while checking whether this user is confirmed or not, " + e.getMessage(), e);
         }
         return userConfirmed ;
+    }
+
+    private boolean isUserEmailVerificationScenario(User user) throws IdentityEventException {
+
+        boolean isUserEmailVerificationScenario = false;
+        try {
+            isUserEmailVerificationScenario =
+                    UserSelfRegistrationManager.getInstance().isUserEmailVerificationScenario(user);
+        } catch (IdentityRecoveryException e) {
+            throw new IdentityEventException(
+                    "Error occurred while checking whether this user's email is verified or not, " + e.getMessage(), e);
+        }
+        return isUserEmailVerificationScenario;
     }
 
     private boolean isUserExistsInDomain(UserStoreManager userStoreManager, String userName)

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AccountConfirmationValidationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AccountConfirmationValidationHandler.java
@@ -18,8 +18,10 @@
 
 package org.wso2.carbon.identity.recovery.handler;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
@@ -126,7 +128,7 @@ public class AccountConfirmationValidationHandler extends AbstractEventHandler {
                 IdentityUtil.setIdentityErrorMsg(customErrorMessageContext);
                 throw new IdentityEventException(IdentityCoreConstants.USER_EMAIL_NOT_VERIFIED_ERROR_CODE,
                         "User : " + Utils.maskIfRequired(userName) + "'s email is not confirmed yet.");
-            } else if (!isSelfSignupEnabled && operationStatus && !isUserEmailVerificationScenario(user)) {
+            } else if (!isSelfSignupEnabled && operationStatus && isUserEmailVerificationScenario(user)) {
                 IdentityErrorMsgContext customErrorMessageContext =
                         new IdentityErrorMsgContext(IdentityCoreConstants.USER_EMAIL_NOT_VERIFIED_ERROR_CODE);
                 IdentityUtil.setIdentityErrorMsg(customErrorMessageContext);
@@ -213,8 +215,22 @@ public class AccountConfirmationValidationHandler extends AbstractEventHandler {
 
         boolean isUserEmailVerificationScenario = false;
         try {
-            isUserEmailVerificationScenario =
-                    UserSelfRegistrationManager.getInstance().isUserEmailVerificationScenario(user);
+            if (StringUtils.isBlank(user.getTenantDomain())) {
+                user.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+                log.info("isUserEmailVerificationScenario :Tenant domain is not in the request. " +
+                        "set to default for user : " + user.getUserName());
+            }
+            if (StringUtils.isBlank(user.getUserStoreDomain())) {
+                user.setUserStoreDomain(IdentityUtil.getPrimaryDomainName());
+                log.info("isUserEmailVerificationScenario :User store domain is not in the request. " +
+                        " set to default for user : " + user.getUserName());
+            }
+            UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
+            UserRecoveryData load = userRecoveryDataStore.loadWithoutCodeExpiryValidation(user);
+
+            if (load != null && RecoveryScenarios.EMAIL_VERIFICATION.equals(load.getRecoveryScenario())) {
+                isUserEmailVerificationScenario = true;
+            }
         } catch (IdentityRecoveryException e) {
             throw new IdentityEventException(
                     "Error occurred while checking whether this user's email is verified or not, " + e.getMessage(), e);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -585,38 +585,6 @@ public class UserSelfRegistrationManager {
     }
 
     /**
-     * Check whether the recovery scenario is email verification or not.
-     *
-     * @param user User object
-     * @return true if the recovery scenario is not email verification, false otherwise.
-     * @throws IdentityRecoveryException Identity Recovery Exception
-     */
-    public boolean isUserEmailVerificationScenario(User user) throws IdentityRecoveryException {
-
-        boolean isUserEmailVerificationScenario = false;
-        if (StringUtils.isBlank(user.getTenantDomain())) {
-            user.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
-            log.info(
-                    "isUserEmailVerificationScenario :Tenant domain is not in the request. " +
-                            "set to default for user : " + user.getUserName());
-        }
-        if (StringUtils.isBlank(user.getUserStoreDomain())) {
-            user.setUserStoreDomain(IdentityUtil.getPrimaryDomainName());
-            log.info("isUserEmailVerificationScenario :User store domain is not in the request. " +
-                    " set to default for user : " +
-                    user.getUserName());
-        }
-        UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
-        UserRecoveryData load =
-                userRecoveryDataStore.loadWithoutCodeExpiryValidation(user);
-
-        if (load != null && !RecoveryScenarios.EMAIL_VERIFICATION.equals(load.getRecoveryScenario())) {
-            isUserEmailVerificationScenario = true;
-        }
-        return isUserEmailVerificationScenario;
-    }
-
-    /**
      * This method is deprecated.
      *
      * @since 1.1.37

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -105,7 +105,6 @@ import java.net.MalformedURLException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -583,6 +582,38 @@ public class UserSelfRegistrationManager {
         }
         return isUserConfirmed;
 
+    }
+
+    /**
+     * Check whether the recovery scenario is email verification or not.
+     *
+     * @param user User object
+     * @return true if the recovery scenario is not email verification, false otherwise.
+     * @throws IdentityRecoveryException Identity Recovery Exception
+     */
+    public boolean isUserEmailVerificationScenario(User user) throws IdentityRecoveryException {
+
+        boolean isUserEmailVerificationScenario = false;
+        if (StringUtils.isBlank(user.getTenantDomain())) {
+            user.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+            log.info(
+                    "isUserEmailVerificationScenario :Tenant domain is not in the request. " +
+                            "set to default for user : " + user.getUserName());
+        }
+        if (StringUtils.isBlank(user.getUserStoreDomain())) {
+            user.setUserStoreDomain(IdentityUtil.getPrimaryDomainName());
+            log.info("isUserEmailVerificationScenario :User store domain is not in the request. " +
+                    " set to default for user : " +
+                    user.getUserName());
+        }
+        UserRecoveryDataStore userRecoveryDataStore = JDBCRecoveryDataStore.getInstance();
+        UserRecoveryData load =
+                userRecoveryDataStore.loadWithoutCodeExpiryValidation(user);
+
+        if (load != null && !RecoveryScenarios.EMAIL_VERIFICATION.equals(load.getRecoveryScenario())) {
+            isUserEmailVerificationScenario = true;
+        }
+        return isUserEmailVerificationScenario;
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request

- The recovery scenario is set to `EMAIL_VERIFICATION` once the resend-code API is used with the above scenario.
- So this scenario should be properly considered to send the correct error message during the subsequent failed login attempts
- This PR adds the change