### PR TITLE
Extend authentication executor and support registration flow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -738,7 +738,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.8.396</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.403</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/24768

This pull request refactors the `PasswordProvisioningExecutor` to improve its integration with the authentication flow engine and enhance password provisioning logic. The changes focus on updating inheritance, flow type handling, and event publishing, as well as upgrading the identity framework version.

**Executor refactoring and flow integration:**

* Changed `PasswordProvisioningExecutor` to extend `AuthenticationExecutor` instead of implementing `Executor`, aligning it with the authentication flow architecture. Added the `getAMRValue()` method to specify the authentication method reference. [[1]](diffhunk://#diff-7e8c4ac7eb220a204ea018833047ad231ff23f7ef2a7c678b6212374fcc266beL33-R33) [[2]](diffhunk://#diff-7e8c4ac7eb220a204ea018833047ad231ff23f7ef2a7c678b6212374fcc266beR58-R84)
* Updated flow type checks in the `execute` method to use constants from `FlowTypes` and improved logic for handling password recovery, invited user registration, and registration flows.
* Modified credentials assignment to use a mutable `HashMap` instead of an immutable singleton map, allowing for easier credential management.

**Code quality and encapsulation improvements:**

* Changed the visibility of the `publishEvent` method from public to private, encapsulating event publishing logic within the executor.
* Minor formatting and whitespace improvements for readability.

**Dependency update:**

* Upgraded the `carbon.identity.framework.version` in `pom.xml` from `7.8.396` to `7.8.403` for better compatibility and access to recent framework enhancements.