### PR TITLE
Support registration flow in PasswordProvisioningExecutor

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutor.java
@@ -116,6 +116,9 @@ public class PasswordProvisioningExecutor extends AuthenticationExecutor {
             }
         }
 
+        if (REGISTRATION.getType().equalsIgnoreCase(context.getFlowType())) {
+            return new ExecutorResponse(STATUS_COMPLETE);
+        }
 
         char[] password = credentials.getOrDefault(PASSWORD_KEY, new DefaultPasswordGenerator().generatePassword());
         try {
@@ -123,8 +126,6 @@ public class PasswordProvisioningExecutor extends AuthenticationExecutor {
                 return handlePasswordRecoveryFlow(context, password);
             } else if (INVITED_USER_REGISTRATION.getType().equalsIgnoreCase(context.getFlowType())) {
                 return handleAskPasswordFlow(context, password);
-            } else if (REGISTRATION.getType().equalsIgnoreCase(context.getFlowType())) {
-                return new ExecutorResponse(STATUS_COMPLETE);
             }
             return new ExecutorResponse();
         } finally {


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25160

This pull request makes a small change to the flow control logic in `PasswordProvisioningExecutor.java` to improve clarity and maintainability. The check for the `REGISTRATION` flow type is moved out of the conditional block, allowing for an early return and simplifying the remaining logic.

Flow control improvement:

* Moved the `REGISTRATION` flow type check outside the conditional block in the `execute` method of `PasswordProvisioningExecutor.java` to allow for an early return and reduce nesting.