### PR TITLE
Update json version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -605,7 +605,7 @@
         <!--Orbit Version-->
         <axis2.wso2.version>1.6.1-wso2v38</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v16</axiom.wso2.version>
-        <json.wso2.version>3.0.0.wso2v1</json.wso2.version>
+        <json.wso2.version>3.0.0.wso2v7</json.wso2.version>
         <json.wso2.version.range>[3.0.0.wso2v1, 4.0.0)</json.wso2.version.range>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
         <httpcore.version>4.3.3.wso2v1</httpcore.version>


### PR DESCRIPTION
This pull request makes a minor update to the `pom.xml` file, upgrading the `json.wso2.version` dependency from `3.0.0.wso2v1` to `3.0.0.wso2v7`. This change likely includes important bug fixes or improvements from the newer version. 

- Dependency update:
  * Upgraded the `json.wso2.version` property in `pom.xml` from `3.0.0.wso2v1` to `3.0.0.wso2v7` to use a newer version of the JSON library.