### PR TITLE
Improve self registration flow completion when account is locked

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/ConfirmationCodeValidationExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/ConfirmationCodeValidationExecutor.java
@@ -91,7 +91,15 @@ public class ConfirmationCodeValidationExecutor implements Executor {
             }
 
             response.setResult(STATUS_COMPLETE);
-        } catch (IdentityRecoveryException | UserStoreException e) {
+        } catch (IdentityRecoveryException e) {
+            if (e.getErrorCode().equals(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CODE
+                    .getCode())) {
+                return userErrorResponse(response, e.getMessage());
+            }
+            String errorMessage = "Error while validating the confirmation code.";
+            LOG.error(errorMessage, e);
+            return errorResponse(response, errorMessage);
+        } catch (UserStoreException e) {
             String errorMessage = "Error while validating the confirmation code.";
             LOG.error(errorMessage, e);
             return errorResponse(response, errorMessage);
@@ -211,6 +219,20 @@ public class ConfirmationCodeValidationExecutor implements Executor {
 
         response.setResult(Constants.ExecutorStatus.STATUS_CLIENT_INPUT_REQUIRED);
         response.setRequiredData(Arrays.asList(fields));
+        return response;
+    }
+
+    /**
+     * Creates a user error response with the provided message.
+     *
+     * @param response ExecutorResponse to be modified with user error details.
+     * @param message  User error message to be set in the response.
+     * @return Modified ExecutorResponse with user error details.
+     */
+    private ExecutorResponse userErrorResponse(ExecutorResponse response, String message) {
+
+        response.setErrorMessage(message);
+        response.setResult(Constants.ExecutorStatus.STATUS_USER_ERROR);
         return response;
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/listener/SelfRegistrationCompletionListener.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/listener/SelfRegistrationCompletionListener.java
@@ -87,9 +87,9 @@ public class SelfRegistrationCompletionListener extends AbstractFlowExecutionLis
     private static final String REGISTRATION_COMPLETION_LISTENER = "registration-completion-listener";
     private static final String TRIGGER_NOTIFICATION = "trigger-notification";
     private static final String FLOW_ID = "flowId";
-    public static final String USER_NAME = "userName";
-    public static final String NOTIFICATION_CHANNEL = "notificationChannel";
-    public static final String ACCOUNT_LOCKED = "accountLocked";
+    private static final String USER_NAME = "userName";
+    private static final String NOTIFICATION_CHANNEL = "notificationChannel";
+    private static final String ACCOUNT_LOCKED = "accountLocked";
 
     @Override
     public int getDefaultOrderId() {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/listener/SelfRegistrationCompletionListener.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/listener/SelfRegistrationCompletionListener.java
@@ -89,6 +89,7 @@ public class SelfRegistrationCompletionListener extends AbstractFlowExecutionLis
     private static final String FLOW_ID = "flowId";
     public static final String USER_NAME = "userName";
     public static final String NOTIFICATION_CHANNEL = "notificationChannel";
+    public static final String ACCOUNT_LOCKED = "accountLocked";
 
     @Override
     public int getDefaultOrderId() {
@@ -109,8 +110,7 @@ public class SelfRegistrationCompletionListener extends AbstractFlowExecutionLis
     }
 
     @Override
-    public boolean doPostExecute(FlowExecutionStep step, FlowExecutionContext flowExecutionContext)
-            throws FlowEngineException {
+    public boolean doPostExecute(FlowExecutionStep step, FlowExecutionContext flowExecutionContext) {
 
         if (Constants.COMPLETE.equals(step.getFlowStatus()) && REGISTRATION_FLOW_TYPE.equals(flowExecutionContext.getFlowType())) {
 
@@ -146,6 +146,8 @@ public class SelfRegistrationCompletionListener extends AbstractFlowExecutionLis
                         UserStoreManager userStoreManager = getUserStoreManager(tenantDomain, userStoreDomain);
                         lockUserAccount(isAccountLockOnCreation, isEnableConfirmationOnCreation, tenantDomain,
                                 userStoreManager, user.getUsername());
+                        step.setStepType(Constants.StepTypes.VIEW);
+                        step.getData().addAdditionalData(ACCOUNT_LOCKED, Boolean.TRUE.toString());
                     } catch (UserStoreException | IdentityEventException e) {
                         LOG.error("Error while locking the user account from the registration completion listener " +
                                 "in the flow: " + flowExecutionContext.getContextIdentifier(), e);


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25415

This pull request makes a few targeted improvements to the `SelfRegistrationCompletionListener` class, focusing on the handling of account locking during self-registration flow completion. The main changes involve updating constant visibility, refining exception handling, and ensuring the flow step type and additional data are set when an account is locked.

Key improvements to account locking and flow step management:

* Changed the visibility of `USER_NAME` and `NOTIFICATION_CHANNEL` constants from `public` to `private`, and added a new `ACCOUNT_LOCKED` constant for internal use.
* Removed the unnecessary `throws FlowEngineException` declaration from the `doPostExecute` method signature, simplifying exception management.
* After locking the user account, updated the flow step type to `VIEW` and added an `ACCOUNT_LOCKED` flag to the step's additional data to clearly indicate the account status in the flow context.