### PR TITLE
[Next] Improve self registration flow completion when account is locked

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/ConfirmationCodeValidationExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/ConfirmationCodeValidationExecutor.java
@@ -91,7 +91,15 @@ public class ConfirmationCodeValidationExecutor implements Executor {
             }
 
             response.setResult(STATUS_COMPLETE);
-        } catch (IdentityRecoveryException | UserStoreException e) {
+        } catch (IdentityRecoveryException e) {
+            if (e.getErrorCode().equals(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CODE
+                    .getCode())) {
+                return userErrorResponse(response, e.getMessage());
+            }
+            String errorMessage = "Error while validating the confirmation code.";
+            LOG.error(errorMessage, e);
+            return errorResponse(response, errorMessage);
+        } catch (UserStoreException e) {
             String errorMessage = "Error while validating the confirmation code.";
             LOG.error(errorMessage, e);
             return errorResponse(response, errorMessage);
@@ -211,6 +219,20 @@ public class ConfirmationCodeValidationExecutor implements Executor {
 
         response.setResult(Constants.ExecutorStatus.STATUS_CLIENT_INPUT_REQUIRED);
         response.setRequiredData(Arrays.asList(fields));
+        return response;
+    }
+
+    /**
+     * Creates a user error response with the provided message.
+     *
+     * @param response ExecutorResponse to be modified with user error details.
+     * @param message  User error message to be set in the response.
+     * @return Modified ExecutorResponse with user error details.
+     */
+    private ExecutorResponse userErrorResponse(ExecutorResponse response, String message) {
+
+        response.setErrorMessage(message);
+        response.setResult(Constants.ExecutorStatus.STATUS_USER_ERROR);
         return response;
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/listener/SelfRegistrationCompletionListener.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/listener/SelfRegistrationCompletionListener.java
@@ -87,8 +87,9 @@ public class SelfRegistrationCompletionListener extends AbstractFlowExecutionLis
     private static final String REGISTRATION_COMPLETION_LISTENER = "registration-completion-listener";
     private static final String TRIGGER_NOTIFICATION = "trigger-notification";
     private static final String FLOW_ID = "flowId";
-    public static final String USER_NAME = "userName";
-    public static final String NOTIFICATION_CHANNEL = "notificationChannel";
+    private static final String USER_NAME = "userName";
+    private static final String NOTIFICATION_CHANNEL = "notificationChannel";
+    private static final String ACCOUNT_LOCKED = "accountLocked";
 
     @Override
     public int getDefaultOrderId() {
@@ -109,8 +110,7 @@ public class SelfRegistrationCompletionListener extends AbstractFlowExecutionLis
     }
 
     @Override
-    public boolean doPostExecute(FlowExecutionStep step, FlowExecutionContext flowExecutionContext)
-            throws FlowEngineException {
+    public boolean doPostExecute(FlowExecutionStep step, FlowExecutionContext flowExecutionContext) {
 
         if (Constants.COMPLETE.equals(step.getFlowStatus()) && REGISTRATION_FLOW_TYPE.equals(flowExecutionContext.getFlowType())) {
 
@@ -146,6 +146,8 @@ public class SelfRegistrationCompletionListener extends AbstractFlowExecutionLis
                         UserStoreManager userStoreManager = getUserStoreManager(tenantDomain, userStoreDomain);
                         lockUserAccount(isAccountLockOnCreation, isEnableConfirmationOnCreation, tenantDomain,
                                 userStoreManager, user.getUsername());
+                        step.setStepType(Constants.StepTypes.VIEW);
+                        step.getData().addAdditionalData(ACCOUNT_LOCKED, Boolean.TRUE.toString());
                     } catch (UserStoreException | IdentityEventException e) {
                         LOG.error("Error while locking the user account from the registration completion listener " +
                                 "in the flow: " + flowExecutionContext.getContextIdentifier(), e);


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25415

This pull request introduces targeted improvements to error handling and user feedback in the confirmation code validation flow, as well as enhancements to the self-registration completion listener. The main changes include more granular error responses for invalid confirmation codes and the addition of account lock status tracking during registration completion.

**Error handling and user feedback improvements:**

* Updated the `execute` method in `ConfirmationCodeValidationExecutor` to handle `IdentityRecoveryException` and `UserStoreException` separately, providing a specific user error response when the confirmation code is invalid and logging other errors appropriately.
* Added a new private method `userErrorResponse` in `ConfirmationCodeValidationExecutor` to generate a user-specific error response with a custom message and status.

**Self-registration completion listener enhancements:**

* Changed the visibility of constants `USER_NAME` and `NOTIFICATION_CHANNEL` from `public` to `private`, and introduced a new constant `ACCOUNT_LOCKED` to track account lock status.
* Removed the `throws FlowEngineException` clause from the `doPostExecute` method signature in `SelfRegistrationCompletionListener` for cleaner exception handling.
* Updated the registration completion flow to set the step type to `VIEW` and add `ACCOUNT_LOCKED` status to step data when the user account is locked on creation.