### PR TITLE
Fix SMSCaptcha Connector Issue

### DIFF
--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/AbstractOTPCaptchaConnector.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/AbstractOTPCaptchaConnector.java
@@ -174,7 +174,7 @@ public abstract class AbstractOTPCaptchaConnector extends AbstractReCaptchaConne
                 preValidationResponse.setCaptchaValidationRequired(true);
                 preValidationResponse.setOnCaptchaFailRedirectUrls(getFailedUrlList());
 
-                if (isMaxFailedLimitReached && ! (isForcefullyEnabled || isConnectorAlwaysEnabled)) {
+                if (isMaxFailedLimitReached && !(isForcefullyEnabled || isConnectorAlwaysEnabled)) {
                     params.put(RECAPTCHA_PARAM, Boolean.TRUE.toString());
                     preValidationResponse.setMaxFailedLimitReached(true);
                 }

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/LocalSMSOTPCaptchaConnector.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/LocalSMSOTPCaptchaConnector.java
@@ -33,7 +33,6 @@ public class LocalSMSOTPCaptchaConnector extends AbstractOTPCaptchaConnector {
     @Override
     protected boolean isOTPParamPresent(ServletRequest servletRequest) {
 
-
         return servletRequest.getParameter(OTP_PARAM_NAME) != null;
     }
 

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/LocalSMSOTPCaptchaConnector.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/LocalSMSOTPCaptchaConnector.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.captcha.connector.recaptcha;
+
+import javax.servlet.ServletRequest;
+
+public class LocalSMSOTPCaptchaConnector extends AbstractOTPCaptchaConnector {
+
+    private static final String AUTHENTICATOR_NAME = "sms-otp-authenticator";
+    private static final String REDIRECT_CONTEXT_PROPERTY_KEY = "isRedirectToSmsOTP";
+    private static final String OTP_PARAM_NAME = "OTPcode";
+    private static final String RESEND_PARAM_NAME = "resendCode";
+    private static final String FAILED_ATTEMPTS_CLAIM_URI = "http://wso2.org/claims/identity/failedLoginAttempts";
+    private static final String ON_FAIL_REDIRECT_URL = "/authenticationendpoint/login.do";
+    private static final int AUTHENTICATOR_PRIORITY = 30;
+
+    @Override
+    protected boolean isOTPParamPresent(ServletRequest servletRequest) {
+
+
+        return servletRequest.getParameter(OTP_PARAM_NAME) != null;
+    }
+
+    @Override
+    protected String getAuthenticatorName() {
+
+        return AUTHENTICATOR_NAME;
+    }
+
+    @Override
+    protected String getRedirectContextPropertyKey() {
+
+        return REDIRECT_CONTEXT_PROPERTY_KEY;
+    }
+
+    @Override
+    protected String getResendParamName() {
+
+        return RESEND_PARAM_NAME;
+    }
+
+    @Override protected String getFailedAttemptsClaimUri() {
+
+        return FAILED_ATTEMPTS_CLAIM_URI;
+    }
+
+    @Override
+    protected String getOnFailRedirectUrl() {
+
+        return ON_FAIL_REDIRECT_URL;
+    }
+
+    @Override
+    protected int getAuthenticatorPriority() {
+
+        return AUTHENTICATOR_PRIORITY;
+    }
+}
+

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaComponent.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaComponent.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.identity.captcha.connector.recaptcha.SSOLoginReCaptchaCon
 import org.wso2.carbon.identity.captcha.connector.recaptcha.SelfSignUpReCaptchaConnector;
 import org.wso2.carbon.identity.captcha.connector.recaptcha.UsernameRecoveryReCaptchaConnector;
 import org.wso2.carbon.identity.captcha.connector.recaptcha.LocalEmailOTPCaptchaConnector;
+import org.wso2.carbon.identity.captcha.connector.recaptcha.LocalSMSOTPCaptchaConnector;
 import org.wso2.carbon.identity.captcha.listener.CaptchaFlowExecutionListener;
 import org.wso2.carbon.identity.captcha.util.CaptchaUtil;
 import org.wso2.carbon.identity.captcha.validator.FailLoginAttemptValidationHandler;
@@ -103,7 +104,11 @@ public class CaptchaComponent {
             captchaConnector = new LocalEmailOTPCaptchaConnector();
             captchaConnector.init(CaptchaDataHolder.getInstance().getIdentityGovernanceService());
             CaptchaDataHolder.getInstance().addCaptchaConnector(captchaConnector);
+            // Initialize and register LocalSMSOTPCaptchaConnector.
+            captchaConnector = new LocalSMSOTPCaptchaConnector();
+            captchaConnector.init(CaptchaDataHolder.getInstance().getIdentityGovernanceService());
             AuthenticationDataPublisher failedLoginAttemptValidator = new FailLoginAttemptValidator();
+            CaptchaDataHolder.getInstance().addCaptchaConnector(captchaConnector);
             context.getBundleContext().registerService(AuthenticationDataPublisher.class,
                     failedLoginAttemptValidator, null);
             context.getBundleContext().registerService(AbstractEventHandler.class.getName(), new

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaComponent.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaComponent.java
@@ -107,8 +107,8 @@ public class CaptchaComponent {
             // Initialize and register LocalSMSOTPCaptchaConnector.
             captchaConnector = new LocalSMSOTPCaptchaConnector();
             captchaConnector.init(CaptchaDataHolder.getInstance().getIdentityGovernanceService());
-            AuthenticationDataPublisher failedLoginAttemptValidator = new FailLoginAttemptValidator();
             CaptchaDataHolder.getInstance().addCaptchaConnector(captchaConnector);
+            AuthenticationDataPublisher failedLoginAttemptValidator = new FailLoginAttemptValidator();
             context.getBundleContext().registerService(AuthenticationDataPublisher.class,
                     failedLoginAttemptValidator, null);
             context.getBundleContext().registerService(AbstractEventHandler.class.getName(), new


### PR DESCRIPTION
### Proposed changes in this pull request

**Related Issues**

- https://github.com/wso2/product-is/issues/24183

This pull request introduces a new SMS OTP (One-Time Password) captcha connector to the codebase, enhancing support for SMS-based authentication flows. The main changes involve adding the new connector class and registering it during component activation.

**New SMS OTP Captcha Connector Integration:**
* Added a new class `LocalSMSOTPCaptchaConnector` that extends `AbstractOTPCaptchaConnector` to handle captcha logic specific to SMS OTP authentication, including parameter names, claim URIs, and redirect URLs.

