### PR TITLE
Return accountStatus field instead of multiple different ones

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/listener/SelfRegistrationCompletionListener.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/listener/SelfRegistrationCompletionListener.java
@@ -92,8 +92,9 @@ public class SelfRegistrationCompletionListener extends AbstractFlowExecutionLis
     private static final String FLOW_ID = "flowId";
     private static final String USER_NAME = "userName";
     private static final String NOTIFICATION_CHANNEL = "notificationChannel";
-    private static final String ACCOUNT_LOCKED = "accountLocked";
-    private static final String PENDING_APPROVAL = "pendingApproval";
+    private static final String ACCOUNT_LOCKED = "ACCOUNT_LOCKED";
+    private static final String PENDING_APPROVAL = "PENDING_APPROVAL";
+    private static final String ACCOUNT_STATUS = "accountStatus";
     private static final String SELF_REGISTER_USER_EVENT = "SELF_REGISTER_USER";
     private static final String WORKFLOW_USER_ENTITY_TYPE = "USER";
 
@@ -139,7 +140,7 @@ public class SelfRegistrationCompletionListener extends AbstractFlowExecutionLis
                                 SelfRegistrationUtils.maskIfRequired(user.getUsername()), tenantDomain));
                     }
                     step.setStepType(Constants.StepTypes.VIEW);
-                    step.getData().addAdditionalData(PENDING_APPROVAL, Boolean.TRUE.toString());
+                    step.getData().addAdditionalData(ACCOUNT_STATUS, PENDING_APPROVAL);
                     return true;
                 }
 
@@ -170,7 +171,7 @@ public class SelfRegistrationCompletionListener extends AbstractFlowExecutionLis
                         lockUserAccount(isAccountLockOnCreation, isEnableConfirmationOnCreation, tenantDomain,
                                 userStoreManager, user.getUsername());
                         step.setStepType(Constants.StepTypes.VIEW);
-                        step.getData().addAdditionalData(ACCOUNT_LOCKED, Boolean.TRUE.toString());
+                        step.getData().addAdditionalData(ACCOUNT_STATUS, ACCOUNT_LOCKED);
                     } catch (UserStoreException | IdentityEventException e) {
                         LOG.error("Error while locking the user account from the registration completion listener " +
                                 "in the flow: " + flowExecutionContext.getContextIdentifier(), e);

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/listener/SelfRegistrationCompletionListenerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/listener/SelfRegistrationCompletionListenerTest.java
@@ -570,7 +570,7 @@ public class SelfRegistrationCompletionListenerTest {
         assertEquals(Constants.StepTypes.VIEW, step.getStepType());
 
         // Verify that PENDING_APPROVAL data is added when workflow is pending.
-        assertEquals("true", step.getData().getAdditionalData().get("pendingApproval"));
+        assertEquals("PENDING_APPROVAL", step.getData().getAdditionalData().get("accountStatus"));
 
         // Verify that no further processing occurs when workflow is pending.
         selfRegistrationUtilsMockedStatic.verify(() -> SelfRegistrationUtils.lockUserAccount(


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25612

This pull request updates how user account status is tracked and reported during self-registration flows. The main change is the introduction of a unified `accountStatus` field to replace separate flags for pending approval and account lock status, which simplifies the handling and testing of these states.

**Refactoring of Account Status Handling:**

* Replaced the separate `pendingApproval` and `accountLocked` flags with a single `accountStatus` field in `SelfRegistrationCompletionListener.java`, using the values `PENDING_APPROVAL` and `ACCOUNT_LOCKED` for clarity and consistency.

**Logic Updates for Status Assignment:**

* Updated the logic in `doPostExecute` to set `accountStatus` to `PENDING_APPROVAL` when a workflow is pending, instead of using the old flag.
* Updated the logic in `doPostExecute` to set `accountStatus` to `ACCOUNT_LOCKED` when an account is locked on creation, replacing the previous flag.

**Test Adjustments:**

* Modified the test case in `SelfRegistrationCompletionListenerTest.java` to check for `accountStatus` with values `PENDING_APPROVAL` instead of the old `pendingApproval` flag, ensuring tests match the new logic.