### PR TITLE
Revert "[bug-fix] When retrieving the user profile JSON for a user in My Account, the username attribute is missing"

### DIFF
--- a/components/org.wso2.carbon.identity.user.export.core/src/main/java/org/wso2/carbon/identity/user/export/core/service/impl/UserProfileInformationProvider.java
+++ b/components/org.wso2.carbon.identity.user.export.core/src/main/java/org/wso2/carbon/identity/user/export/core/service/impl/UserProfileInformationProvider.java
@@ -44,7 +44,6 @@ public class UserProfileInformationProvider extends AbstractUserInformationProvi
 
     private static final Log LOG = LogFactory.getLog(UserProfileInformationProvider.class);
     private static final String ROLES_URIS_CLAIM = "roles";
-    private static final String PROFILE_ATTRIBUTE_USERNAME = "username";
 
     @Override
     public UserInformationDTO getRetainedUserInformation(String username, String userStoreDomain, int tenantId)
@@ -64,8 +63,6 @@ public class UserProfileInformationProvider extends AbstractUserInformationProvi
         }
 
         Map<String, String> userProfileAttributes = new HashMap<>();
-        // Adding username as a default attribute under profile.
-        userProfileAttributes.put(PROFILE_ATTRIBUTE_USERNAME, username);
         List<String> claimsToInclude = getClaimsToInclude(tenantId);
         List<String> claimsToExclude = Utils.getRestrictedClaims();
         for (Claim claim : userClaimValues) {


### PR DESCRIPTION
Reverts wso2-extensions/identity-governance#1042