### PR TITLE
Update pom.xml to exclude specific dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -380,6 +380,16 @@
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-jaxrs</artifactId>
                 <version>${swagger-jaxrs.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>javax.ws.rs</groupId>
@@ -619,7 +629,7 @@
         </httpcomponents-httpclient.imp.pkg.version.range>
         <com.google.code.gson.version>2.9.0</com.google.code.gson.version>
         <com.google.code.gson.osgi.version.range>[2.3.1,3.0.0)</com.google.code.gson.osgi.version.range>
-        <commons-codec.version>1.14.0.wso2v1</commons-codec.version>
+        <commons-codec.version>1.16.0.wso2v1</commons-codec.version>
         <commons-codec.wso2.osgi.version.range>[1.4.0,2.0.0)</commons-codec.wso2.osgi.version.range>
         <commons-io.wso2.version>2.4.0.wso2v1</commons-io.wso2.version>
         <commons.io.wso2.osgi.version.range>[2.4.0,3.0.0)</commons.io.wso2.osgi.version.range>


### PR DESCRIPTION
This pull request updates dependency management in the `pom.xml` file to improve build control and keep libraries up to date. The main changes are the exclusion of unnecessary transitive dependencies from the Swagger JAX-RS dependency and the upgrade of the Commons Codec library version.

Dependency management improvements:

* Excluded `slf4j-api` and `commons-lang3` from the `swagger-jaxrs` dependency to prevent unwanted transitive dependencies and potential conflicts.
* Upgraded `commons-codec` version from `1.14.0.wso2v1` to `1.16.0.wso2v1` for improved security and bug fixes.