### PR TITLE
Add masking to error logs

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutor.java
@@ -161,11 +161,10 @@ public class PasswordProvisioningExecutor extends AuthenticationExecutor {
             context.getFlowUser().setUserId(userId);
             return new ExecutorResponse(STATUS_COMPLETE);
         } catch (UserStoreException | IdentityEventException | IdentityRecoveryException e) {
-            String maskedUsername = LoggerUtils
-                    .isLogMaskingEnable ? LoggerUtils
-                    .getMaskedContent(context.getFlowUser().getUsername()) : context.getFlowUser().getUsername();
-            LOG.error("Error while updating password for user: " +
-                    maskedUsername, e);
+            String maskedUsername = LoggerUtils.isLogMaskingEnable
+                    ? LoggerUtils.getMaskedContent(context.getFlowUser().getUsername())
+                    : context.getFlowUser().getUsername();
+            LOG.error("Error while updating password for user: " + maskedUsername, e);
             return errorResponse(new ExecutorResponse(), e.getMessage());
         } finally {
             IdentityContext.getThreadLocalIdentityContext().exitFlow();
@@ -233,12 +232,10 @@ public class PasswordProvisioningExecutor extends AuthenticationExecutor {
             userStoreManager.updateCredentialByAdmin(context.getFlowUser().getUsername(), password);
             return new ExecutorResponse(STATUS_COMPLETE);
         } catch (UserStoreException e) {
-
-            String maskedUsername = LoggerUtils
-                    .isLogMaskingEnable ? LoggerUtils
-                    .getMaskedContent(context.getFlowUser().getUsername()) : context.getFlowUser().getUsername();
-            LOG.error("Error while updating password for user: " +
-                    maskedUsername, e);
+            String maskedUsername = LoggerUtils.isLogMaskingEnable
+                    ? LoggerUtils.getMaskedContent(context.getFlowUser().getUsername())
+                    : context.getFlowUser().getUsername();
+            LOG.error("Error while updating password for user: " + maskedUsername, e);
             return errorResponse(new ExecutorResponse(), e.getMessage());
         }
     }


### PR DESCRIPTION
## Related Issue
- https://github.com/wso2/product-is/issues/25730

## Implementation
This pull request improves logging security in the `PasswordProvisioningExecutor` class by masking sensitive user information in error logs. The main change is the use of `LoggerUtils.getMaskedContent` to prevent logging raw usernames during password update failures.

Security enhancements:

* Updated error logging in both `handleAskPasswordFlow` and `handlePasswordRecoveryFlow` methods to mask the username using `LoggerUtils.getMaskedContent`, reducing the risk of exposing sensitive information in logs. [[1]](diffhunk://#diff-7e8c4ac7eb220a204ea018833047ad231ff23f7ef2a7c678b6212374fcc266beL163-R165) [[2]](diffhunk://#diff-7e8c4ac7eb220a204ea018833047ad231ff23f7ef2a7c678b6212374fcc266beL231-R234)
* Added import for `LoggerUtils` in `PasswordProvisioningExecutor.java` to support the new masking functionality.