### PR TITLE
Revert to the self registration previous behaviour.

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImpl.java
@@ -209,20 +209,13 @@ public class ResendCodeApiServiceImpl extends ResendCodeApiService {
                 RecoveryScenarios.SELF_SIGN_UP.equals(userRecoveryData.getRecoveryScenario()) &&
                 RecoverySteps.CONFIRM_SIGN_UP.equals(userRecoveryData.getRecoveryStep())) {
 
-            // This is deprecated and will be removed in a future release.
-            boolean isSelfRegistrationSendOTPInEmailEnabled;
-            // The newly added configuration to send OTP in email for self-registration.
             boolean isSelfRegistrationEmailOTPEnabled;
             String notificationType = IdentityRecoveryConstants.NOTIFICATION_TYPE_RESEND_ACCOUNT_CONFIRM;
             try {
-                isSelfRegistrationSendOTPInEmailEnabled = Boolean.parseBoolean(Utils.getSignUpConfigs(
-                                IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SEND_OTP_IN_EMAIL,
-                                resendCodeRequestDTO.getUser().getTenantDomain()));
                 isSelfRegistrationEmailOTPEnabled = Boolean.parseBoolean(Utils.getSignUpConfigs(
                                 IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_EMAIL_OTP_ENABLE,
                                 resendCodeRequestDTO.getUser().getTenantDomain()));
-                // Temporarily honoring both configs for backward compatibility until the migration is complete.
-                if (isSelfRegistrationSendOTPInEmailEnabled || isSelfRegistrationEmailOTPEnabled) {
+                if (isSelfRegistrationEmailOTPEnabled) {
                     notificationType = IdentityRecoveryConstants.NOTIFICATION_TYPE_ACCOUNT_CONFIRM_EMAIL_OTP;
                 }
             } catch (IdentityRecoveryException e){

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
@@ -279,18 +279,14 @@ public class ResendConfirmationManager {
             notificationChannel = NotificationChannels.EMAIL_CHANNEL.getChannelType();
         }
         properties.put(IdentityEventConstants.EventProperty.NOTIFICATION_CHANNEL, notificationChannel);
-        // Deprecated config.
-        boolean isSelfRegistrationSendOTPInEmailEnabled = Boolean.parseBoolean(Utils.getSignUpConfigs(
-                IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SEND_OTP_IN_EMAIL, user.getTenantDomain()));
-        // New config.
+
         boolean isSelfRegistrationEmailOTPEnabled = Boolean.parseBoolean(Utils.getSignUpConfigs(
                 IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_EMAIL_OTP_ENABLE, user.getTenantDomain()));
         if (StringUtils.isNotBlank(code)) {
             if (NotificationChannels.SMS_CHANNEL.getChannelType().equals(notificationChannel)) {
                 properties.put(IdentityRecoveryConstants.OTP_TOKEN_STRING, code);
             }
-            // Honoring the both configs temporarily until the migration completed.
-            if (isSelfRegistrationSendOTPInEmailEnabled || isSelfRegistrationEmailOTPEnabled) {
+            if (isSelfRegistrationEmailOTPEnabled) {
                 properties.put(IdentityRecoveryConstants.OTP_CODE, code);
             }
             properties.put(IdentityRecoveryConstants.CONFIRMATION_CODE, code);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -1412,15 +1412,11 @@ public class UserSelfRegistrationManager {
                     user.getUserName());
         }
 
-        // Deprecated config.
-        boolean isSelfRegistrationSendOTPInEmailEnabled = Boolean.parseBoolean(Utils.getSignUpConfigs(
-                IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SEND_OTP_IN_EMAIL, user.getTenantDomain()));
-        // New config.
         boolean isSelfRegistrationEmailOTPEnabled = Boolean.parseBoolean(Utils.getSignUpConfigs(
                 IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_EMAIL_OTP_ENABLE, user.getTenantDomain()));
         String templateName = IdentityRecoveryConstants.NOTIFICATION_TYPE_RESEND_ACCOUNT_CONFIRM;
-        // Honoring the both configs temporarily until the migration completed.
-        if (isSelfRegistrationSendOTPInEmailEnabled || isSelfRegistrationEmailOTPEnabled) {
+
+        if (isSelfRegistrationEmailOTPEnabled) {
             templateName = IdentityRecoveryConstants.NOTIFICATION_TYPE_ACCOUNT_CONFIRM_EMAIL_OTP;
         }
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/SelfRegistrationUtils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/SelfRegistrationUtils.java
@@ -302,18 +302,12 @@ public class SelfRegistrationUtils {
             }
         }
 
-        // Deprecated config.
-        boolean isEnableSelfRegistrationOtpInEmail =
-                Boolean.parseBoolean(
-                        Utils.getConnectorConfig(SELF_REGISTRATION_SEND_OTP_IN_EMAIL, user.getTenantDomain()));
-        // New config.
         boolean isSelfRegistrationEmailOTPEnabled = Boolean.parseBoolean(Utils.getSignUpConfigs(
                 IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_EMAIL_OTP_ENABLE, user.getTenantDomain()));
         String emailTemplateName = NOTIFICATION_TYPE_ACCOUNT_CONFIRM_EMAIL_LINK;
 
         if (StringUtils.isNotBlank(code)) {
-            // Honoring the both configs temporarily until the migration completed.
-            if (isEnableSelfRegistrationOtpInEmail || isSelfRegistrationEmailOTPEnabled) {
+            if (isSelfRegistrationEmailOTPEnabled) {
                 properties.put(OTP_CODE, code);
                 emailTemplateName = NOTIFICATION_TYPE_ACCOUNT_CONFIRM_EMAIL_OTP;
             } else {

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandlerTest.java
@@ -51,6 +51,7 @@ import static org.mockito.MockitoAnnotations.openMocks;
 import static org.testng.Assert.assertEquals;
 import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ConnectorConfig.ACCOUNT_LOCK_ON_CREATION;
 import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ConnectorConfig.ENABLE_SELF_SIGNUP;
+import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_EMAIL_OTP_ENABLE;
 import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_SEND_OTP_IN_EMAIL;
 import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE;
 import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.NOTIFICATION_TYPE_ACCOUNT_CONFIRM_EMAIL_LINK;
@@ -128,7 +129,7 @@ public class UserSelfRegistrationHandlerTest {
         utilsMockedStatic.when(() -> Utils.getConnectorConfig(ENABLE_SELF_SIGNUP, TENANT_DOMAIN)).
                 thenReturn(TRUE_STRING);
         if (isEmailOtpEnabled) {
-            utilsMockedStatic.when(() -> Utils.getConnectorConfig(SELF_REGISTRATION_SEND_OTP_IN_EMAIL, TENANT_DOMAIN)).
+            utilsMockedStatic.when(() -> Utils.getSignUpConfigs(SELF_REGISTRATION_EMAIL_OTP_ENABLE, TENANT_DOMAIN)).
                     thenReturn(TRUE_STRING);
         }
         utilsMockedStatic.when(() -> Utils.getConnectorConfig(SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE, TENANT_DOMAIN)).
@@ -164,5 +165,4 @@ public class UserSelfRegistrationHandlerTest {
                 {true, NOTIFICATION_TYPE_ACCOUNT_CONFIRM_EMAIL_OTP}
         };
     }
-
 }


### PR DESCRIPTION
### Purpose
- $subject and now product will behave as previous for the `SelfRegistration.OTP.SendOTPInEmail` configuration.

### Related issues
- https://github.com/wso2/product-is/issues/24326

### Integration test runner
- https://github.com/Malith-19/product-is/actions/runs/17975064758 (passed)