### PR TITLE
Handle claim availability

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/ExecutorConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/ExecutorConstants.java
@@ -23,6 +23,13 @@ package org.wso2.carbon.identity.recovery.executor;
  */
 public class ExecutorConstants {
 
+    public static final String USER_ALREADY_EXISTING_USERNAME = "UserAlreadyExistingUsername";
+    public static final String DUPLICATE_CLAIM_ERROR_CODE = "UCM-60001";
+    public static final String DUPLICATE_CLAIMS_ERROR_CODE = "UCM-60002";
+    public static final String DISPLAY_CLAIM_AVAILABILITY_CONFIG = "FlowExecution.Registration" +
+            ".DisplayClaimAvailability";
+    public static final String REGISTRATION_DEFAULT_USER_STORE_CONFIG = "FlowExecution.Registration.DefaultUserStore";
+
     /**
      * Enum for error messages.
      */
@@ -37,6 +44,12 @@ public class ExecutorConstants {
         ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_VALIDATION_FAILURE("60003",
                 "%s",
                 "%s"),
+        ERROR_CODE_USER_CLAIM_ALREADY_EXISTS("60004",
+                "Duplicate claim value.",
+                "%s"),
+        ERROR_CODE_USER_PROVISIONING_FAILURE("60005",
+                "Error while provisioning user.",
+                "Error occurred while provisioning user in the request of flow id: %s"),
         ERROR_CODE_USER_ONBOARD_FAILURE("65001",
                 "Error while onboarding user.",
                 "Error occurred while onboarding user: %s in the request of flow id: %s"),

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutorTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutorTest.java
@@ -368,7 +368,8 @@ public class UserProvisioningExecutorTest {
         when(context.getProperty("isUsernamePatternValidationSkipped")).thenReturn(null);
 
         AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
-        UserStoreClientException clientException = new UserStoreClientException(
+        UserActionExecutionClientException clientException = new UserActionExecutionClientException(
+                "USER-ACTION-PRE-UPDATE-PASSWORD-60001",
                 "PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED",
                 "Action failed");
         doThrow(clientException).when(userStoreManager).addUser(anyString(), anyString(),
@@ -376,7 +377,7 @@ public class UserProvisioningExecutorTest {
 
         ExecutorResponse response = executor.execute(context);
 
-        assertEquals(response.getResult(), STATUS_ERROR);
+        assertEquals(response.getResult(), STATUS_USER_ERROR);
         assertNotNull(response.getErrorCode());
     }
 


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25801

This pull request enhances error handling and configuration flexibility in the user provisioning flow, particularly for duplicate claim scenarios and user store domain resolution. The main changes include new error codes and configuration constants, improved error response logic based on configuration, and updates to related tests.

**Error handling improvements:**

* Added new error codes and messages for duplicate claim values and user provisioning failures to `ExecutorConstants` and its `ExecutorErrorMessages` enum. [[1]](diffhunk://#diff-64c7badd151f75468b07a4a0dd95820ce408d84b9a3c38de6bb3c439fbbf1606R26-R32) [[2]](diffhunk://#diff-64c7badd151f75468b07a4a0dd95820ce408d84b9a3c38de6bb3c439fbbf1606R47-R52)
* Updated `UserProvisioningExecutor` to return user-friendly error responses when duplicate claims are detected, based on the new configuration property `DISPLAY_CLAIM_AVAILABILITY_CONFIG`. [[1]](diffhunk://#diff-64368beba049a0e47408569fe425113401b0b4453eeed746d5c656970cc37b41R140-R151) [[2]](diffhunk://#diff-64368beba049a0e47408569fe425113401b0b4453eeed746d5c656970cc37b41L187-R216)

**Configuration and code refactoring:**

* Introduced new configuration constants (`DISPLAY_CLAIM_AVAILABILITY_CONFIG`, `REGISTRATION_DEFAULT_USER_STORE_CONFIG`) and replaced hardcoded or outdated references in `UserProvisioningExecutor`. [[1]](diffhunk://#diff-64c7badd151f75468b07a4a0dd95820ce408d84b9a3c38de6bb3c439fbbf1606R26-R32) [[2]](diffhunk://#diff-64368beba049a0e47408569fe425113401b0b4453eeed746d5c656970cc37b41L70-R86) [[3]](diffhunk://#diff-64368beba049a0e47408569fe425113401b0b4453eeed746d5c656970cc37b41L281-R308)
* Refactored imports and static constants usage in `UserProvisioningExecutor` for better clarity and maintainability. [[1]](diffhunk://#diff-64368beba049a0e47408569fe425113401b0b4453eeed746d5c656970cc37b41R43-L50) [[2]](diffhunk://#diff-64368beba049a0e47408569fe425113401b0b4453eeed746d5c656970cc37b41L70-R86)

**Testing updates:**

* Updated the test `testExecuteWithPreUpdatePasswordActionFailure` to expect the new error result (`STATUS_USER_ERROR`) and to use the appropriate exception type.