### PR TITLE
Use username to get username without domain

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
@@ -22,6 +22,7 @@ import org.wso2.carbon.identity.recovery.endpoint.dto.RecoveryInitiatingRequestD
 import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
 import org.wso2.carbon.identity.recovery.password.NotificationPasswordRecoveryManager;
 import org.wso2.carbon.identity.recovery.util.Utils;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,7 +67,8 @@ public class RecoverPasswordApiServiceImpl extends RecoverPasswordApiService {
                 if (resolvedUserResult != null && ResolvedUserResult.UserResolvedStatus.SUCCESS.
                         equals(resolvedUserResult.getResolvedStatus())) {
                     User resolvedUser = new User();
-                    resolvedUser.setUserName(resolvedUserResult.getUser().getPreferredUsername());
+                    resolvedUser.setUserName(
+                            UserCoreUtil.removeDomainFromName(resolvedUserResult.getUser().getUsername()));
                     if (StringUtils.isBlank(user.getRealm())) {
                         resolvedUser.setUserStoreDomain(resolvedUserResult.getUser().getUserStoreDomain());
                     } else {


### PR DESCRIPTION
### Description

$subject

> During[1] to get the username without the user domain, the preferred username has been used. However, the non-unique JDBC user stores doesn't set a value to preferred username. To fix this, the implementation will get fallback to the previous implementation where username is set using the username, but domain removed.

[1] https://github.com/wso2-extensions/identity-governance/pull/913

Resolves https://github.com/wso2/product-is/issues/25611