### PR TITLE
Fix user provisioning error handling for existing usernames

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
@@ -201,10 +201,13 @@ public class UserProvisioningExecutor implements Executor {
             }
             boolean displayClaimAvailability = Boolean.parseBoolean(
                     IdentityUtil.getProperty(DISPLAY_CLAIM_AVAILABILITY_CONFIG));
-            if (displayClaimAvailability && e.getMessage().contains(USER_ALREADY_EXISTING_USERNAME)) {
-                return userErrorResponse(response, ERROR_CODE_USERNAME_ALREADY_EXISTS, context.getTenantDomain());
-            } else if (e.getMessage().contains(USER_ALREADY_EXISTING_USERNAME)) {
-                return userErrorResponse(response, ERROR_CODE_USER_PROVISIONING_FAILURE, context.getTenantDomain());
+            if (e.getMessage().contains(USER_ALREADY_EXISTING_USERNAME)) {
+                if (displayClaimAvailability) {
+                    return userErrorResponse(response, ERROR_CODE_USERNAME_ALREADY_EXISTS, context.getTenantDomain());
+                } else  {
+                    return userErrorResponse(response, ERROR_CODE_USER_PROVISIONING_FAILURE,
+                            context.getContextIdentifier());
+                }
             }
             if (e instanceof UserStoreClientException) {
                 UserStoreClientException exception = (UserStoreClientException) e;

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
@@ -203,6 +203,8 @@ public class UserProvisioningExecutor implements Executor {
                     IdentityUtil.getProperty(DISPLAY_CLAIM_AVAILABILITY_CONFIG));
             if (displayClaimAvailability && e.getMessage().contains(USER_ALREADY_EXISTING_USERNAME)) {
                 return userErrorResponse(response, ERROR_CODE_USERNAME_ALREADY_EXISTS, context.getTenantDomain());
+            } else if (e.getMessage().contains(USER_ALREADY_EXISTING_USERNAME)) {
+                return userErrorResponse(response, ERROR_CODE_USER_PROVISIONING_FAILURE, context.getTenantDomain());
             }
             if (e instanceof UserStoreClientException) {
                 UserStoreClientException exception = (UserStoreClientException) e;


### PR DESCRIPTION
**Related Issues**

- https://github.com/wso2/product-is/issues/25960

This pull request updates the user provisioning flow to improve error handling when a username already exists, and adds comprehensive unit tests to cover both scenarios: when display claim availability is enabled or disabled. The changes ensure that the correct error codes are returned based on configuration, and that the code is better tested and organized.

**Error handling improvements:**
* Updated `UserProvisioningExecutor` to return a specific error code (`ERROR_CODE_USER_PROVISIONING_FAILURE`) when a username already exists and display claim availability is disabled, ensuring more accurate error reporting.

**Unit test enhancements:**
* Refactored and expanded unit tests in `UserProvisioningExecutorTest` to separately test the cases where display claim availability is enabled and disabled, verifying that the correct error codes are returned in both scenarios. [[1]](diffhunk://#diff-0520d3faa42d73ec8e82b28d0905acebb48ce99309b2d9e2618b9e7114025e05L332-R334) [[2]](diffhunk://#diff-0520d3faa42d73ec8e82b28d0905acebb48ce99309b2d9e2618b9e7114025e05R345-R380)
* Cleaned up imports and static references in the test file for clarity and maintainability. [[1]](diffhunk://#diff-0520d3faa42d73ec8e82b28d0905acebb48ce99309b2d9e2618b9e7114025e05L43-R43) [[2]](diffhunk://#diff-0520d3faa42d73ec8e82b28d0905acebb48ce99309b2d9e2618b9e7114025e05L68-R74)