### PR TITLE
[bug-fix] The account confirmation re-trigger from the authentication portal is not avaialble when the self registration is disabled in the connector

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/FlowRegistrationCompletionHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/FlowRegistrationCompletionHandler.java
@@ -172,6 +172,9 @@ public class FlowRegistrationCompletionHandler extends AbstractEventHandler {
             if (isAccountLockOnCreation && isEnableConfirmationOnCreation) {
                 lockUserAccount(true, true, tenantDomain,
                         userStoreManager, userName);
+            } else if (isEnableConfirmationOnCreation) {
+                lockUserAccount(false, true, tenantDomain,
+                        userStoreManager, userName);
             }
 
             // If notifications are externally managed, no notification needs to be sent.

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/AccountConfirmationValidationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/AccountConfirmationValidationHandlerTest.java
@@ -29,6 +29,8 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.flow.mgt.model.FlowConfigDTO;
+import org.wso2.carbon.identity.flow.mgt.utils.FlowMgtConfigUtils;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.RecoveryScenarios;
@@ -48,11 +50,7 @@ import java.util.Map;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.openMocks;
 import static org.testng.Assert.assertEquals;
 
@@ -85,6 +83,7 @@ public class AccountConfirmationValidationHandlerTest {
     private MockedStatic<JDBCRecoveryDataStore> jdbcRecoveryDataStoreMockedStatic;
     private MockedStatic<UserSelfRegistrationManager> userSelfRegistrationManagerMockedStatic;
     private MockedStatic<IdentityUtil> identityUtilMockedStatic;
+    private FlowConfigDTO mockedFlowConfigDTO;
 
     private AccountConfirmationValidationHandler handler;
 
@@ -97,6 +96,9 @@ public class AccountConfirmationValidationHandlerTest {
         jdbcRecoveryDataStoreMockedStatic = mockStatic(JDBCRecoveryDataStore.class);
         userSelfRegistrationManagerMockedStatic = mockStatic(UserSelfRegistrationManager.class);
         identityUtilMockedStatic = mockStatic(IdentityUtil.class);
+        mockedFlowConfigDTO = mock(FlowConfigDTO.class);
+
+        when(mockedFlowConfigDTO.getIsEnabled()).thenReturn(false);
     }
 
     @AfterMethod
@@ -136,10 +138,14 @@ public class AccountConfirmationValidationHandlerTest {
                 .thenReturn("false");
 
         // When
-        handler.handleEvent(event);
+        try (MockedStatic<FlowMgtConfigUtils> mockedStatic = mockStatic(FlowMgtConfigUtils.class)) {
+            mockedStatic.when(() -> FlowMgtConfigUtils.getFlowConfig(any(), any()))
+                    .thenReturn(mockedFlowConfigDTO);
+            handler.handleEvent(event);
 
-        // Then - should return early without processing
-        verify(userStoreManager, never()).getUserClaimValues(anyString(), any(String[].class), anyString());
+            // Then - should return early without processing
+            verify(userStoreManager, never()).getUserClaimValues(anyString(), any(String[].class), anyString());
+        }
     }
 
     @Test
@@ -151,7 +157,11 @@ public class AccountConfirmationValidationHandlerTest {
         setupAccountLocked(false);
 
         // When
-        handler.handleEvent(event);
+        try (MockedStatic<FlowMgtConfigUtils> mockedStatic = mockStatic(FlowMgtConfigUtils.class)) {
+            mockedStatic.when(() -> FlowMgtConfigUtils.getFlowConfig(any(), any()))
+                    .thenReturn(mockedFlowConfigDTO);
+            handler.handleEvent(event);
+        }
 
         // Then - should return early since account is unlocked
         // No exceptions should be thrown
@@ -176,8 +186,11 @@ public class AccountConfirmationValidationHandlerTest {
                 .thenReturn(recoveryData);
 
         // When
-        handler.handleEvent(event);
-
+        try (MockedStatic<FlowMgtConfigUtils> mockedStatic = mockStatic(FlowMgtConfigUtils.class)) {
+            mockedStatic.when(() -> FlowMgtConfigUtils.getFlowConfig(any(), any()))
+                    .thenReturn(mockedFlowConfigDTO);
+            handler.handleEvent(event);
+        }
         // Then - should not throw exception since user is confirmed
     }
 
@@ -194,7 +207,11 @@ public class AccountConfirmationValidationHandlerTest {
         setupUserConfirmed(false);
 
         // When
-        handler.handleEvent(event);
+        try (MockedStatic<FlowMgtConfigUtils> mockedStatic = mockStatic(FlowMgtConfigUtils.class)) {
+            mockedStatic.when(() -> FlowMgtConfigUtils.getFlowConfig(any(), any()))
+                    .thenReturn(mockedFlowConfigDTO);
+            handler.handleEvent(event);
+        }
     }
 
     @Test(expectedExceptions = IdentityEventException.class,
@@ -210,7 +227,11 @@ public class AccountConfirmationValidationHandlerTest {
         setupUserConfirmed(false);
 
         // When
-        handler.handleEvent(event);
+        try (MockedStatic<FlowMgtConfigUtils> mockedStatic = mockStatic(FlowMgtConfigUtils.class)) {
+            mockedStatic.when(() -> FlowMgtConfigUtils.getFlowConfig(any(), any()))
+                    .thenReturn(mockedFlowConfigDTO);
+            handler.handleEvent(event);
+        }
     }
 
     @Test(expectedExceptions = IdentityEventException.class,
@@ -227,7 +248,11 @@ public class AccountConfirmationValidationHandlerTest {
         setupEmailVerificationScenario();
 
         // When
-        handler.handleEvent(event);
+        try (MockedStatic<FlowMgtConfigUtils> mockedStatic = mockStatic(FlowMgtConfigUtils.class)) {
+            mockedStatic.when(() -> FlowMgtConfigUtils.getFlowConfig(any(), any()))
+                    .thenReturn(mockedFlowConfigDTO);
+            handler.handleEvent(event);
+        }
     }
 
     @Test(expectedExceptions = IdentityEventException.class,
@@ -243,7 +268,11 @@ public class AccountConfirmationValidationHandlerTest {
         setupSelfRegisteredUser();
 
         // When
-        handler.handleEvent(event);
+        try (MockedStatic<FlowMgtConfigUtils> mockedStatic = mockStatic(FlowMgtConfigUtils.class)) {
+            mockedStatic.when(() -> FlowMgtConfigUtils.getFlowConfig(any(), any()))
+                    .thenReturn(mockedFlowConfigDTO);
+            handler.handleEvent(event);
+        }
     }
 
     @Test
@@ -258,10 +287,14 @@ public class AccountConfirmationValidationHandlerTest {
                 .thenReturn("true");
 
         // When
-        handler.handleEvent(event);
+        try (MockedStatic<FlowMgtConfigUtils> mockedStatic = mockStatic(FlowMgtConfigUtils.class)) {
+            mockedStatic.when(() -> FlowMgtConfigUtils.getFlowConfig(any(), any()))
+                    .thenReturn(mockedFlowConfigDTO);
+            handler.handleEvent(event);
 
-        // Then
-        verify(userStoreManager, never()).getUserClaimValues(anyString(), any(String[].class), anyString());
+            // Then
+            verify(userStoreManager, never()).getUserClaimValues(anyString(), any(String[].class), anyString());
+        }
     }
 
     @Test
@@ -272,10 +305,14 @@ public class AccountConfirmationValidationHandlerTest {
         setupEnabledFeatures(true, false);
 
         // When
-        handler.handleEvent(event);
+        try (MockedStatic<FlowMgtConfigUtils> mockedStatic = mockStatic(FlowMgtConfigUtils.class)) {
+            mockedStatic.when(() -> FlowMgtConfigUtils.getFlowConfig(any(), any()))
+                    .thenReturn(mockedFlowConfigDTO);
+            handler.handleEvent(event);
 
-        // Then - should return early for non-POST_AUTHENTICATION events
-        verify(userStoreManager, never()).getUserClaimValues(anyString(), any(String[].class), anyString());
+            // Then - should return early for non-POST_AUTHENTICATION events
+            verify(userStoreManager, never()).getUserClaimValues(anyString(), any(String[].class), anyString());
+        }
     }
 
     @Test
@@ -291,21 +328,30 @@ public class AccountConfirmationValidationHandlerTest {
         
         User user = createUser();
         UserRecoveryData recoveryData = new UserRecoveryData(user, "12345", RecoveryScenarios.EMAIL_VERIFICATION);
-        
-        jdbcRecoveryDataStoreMockedStatic.when(JDBCRecoveryDataStore::getInstance)
-                .thenReturn(userRecoveryDataStore);
-        when(userRecoveryDataStore.loadWithoutCodeExpiryValidation(any(User.class)))
-                .thenReturn(recoveryData);
 
-        // When & Then - this should throw an exception since the email is not verified
-        try {
-            handler.handleEvent(event);
-        } catch (IdentityEventException e) {
-            // Expected exception for email not verified scenario
+        try (MockedStatic<FlowMgtConfigUtils> flowConfigMockedStatic = mockStatic(FlowMgtConfigUtils.class)){
+            jdbcRecoveryDataStoreMockedStatic.when(JDBCRecoveryDataStore::getInstance)
+                    .thenReturn(userRecoveryDataStore);
+
+            when(userRecoveryDataStore.loadWithoutCodeExpiryValidation(any(User.class)))
+                    .thenReturn(recoveryData);
+
+            // FlowMgtConfigUtils mock
+            flowConfigMockedStatic.when(() ->
+                            FlowMgtConfigUtils.getFlowConfig(anyString(), anyString()))
+                    .thenReturn(mockedFlowConfigDTO);
+
+            // When & Then - this should throw an exception since the email is not verified
+            try {
+                handler.handleEvent(event);
+            } catch (IdentityEventException e) {
+                // Expected exception for email not verified scenario
+            }
+
+            // Verify the recovery data store was called
+            verify(userRecoveryDataStore, times(1))
+                    .loadWithoutCodeExpiryValidation(any(User.class));
         }
-        
-        // Verify the recovery data store was called
-        verify(userRecoveryDataStore, times(1)).loadWithoutCodeExpiryValidation(any(User.class));
     }
 
     @Test
@@ -321,20 +367,28 @@ public class AccountConfirmationValidationHandlerTest {
         User user = createUser();
         UserRecoveryData recoveryData = new UserRecoveryData(user, "12345", RecoveryScenarios.SELF_SIGN_UP);
         
-        jdbcRecoveryDataStoreMockedStatic.when(JDBCRecoveryDataStore::getInstance)
-                .thenReturn(userRecoveryDataStore);
-        when(userRecoveryDataStore.loadWithoutCodeExpiryValidation(any(User.class)))
-                .thenReturn(recoveryData);
+        try (MockedStatic<FlowMgtConfigUtils> flowConfigMockedStatic = mockStatic(FlowMgtConfigUtils.class)){
+            jdbcRecoveryDataStoreMockedStatic.when(JDBCRecoveryDataStore::getInstance)
+                    .thenReturn(userRecoveryDataStore);
+            when(userRecoveryDataStore.loadWithoutCodeExpiryValidation(any(User.class)))
+                    .thenReturn(recoveryData);
 
-        // When & Then - this should throw an exception for invalid credentials
-        try {
-            handler.handleEvent(event);
-        } catch (IdentityEventException e) {
-            // Expected exception for invalid credentials scenario
+            // FlowMgtConfigUtils mock
+            flowConfigMockedStatic.when(() ->
+                            FlowMgtConfigUtils.getFlowConfig(anyString(), anyString()))
+                    .thenReturn(mockedFlowConfigDTO);
+
+            // When & Then - this should throw an exception for invalid credentials
+            try {
+                handler.handleEvent(event);
+            } catch (IdentityEventException e) {
+                // Expected exception for invalid credentials scenario
+            }
+
+            // Verify the recovery data store was called
+            verify(userRecoveryDataStore, times(1))
+                    .loadWithoutCodeExpiryValidation(any(User.class));
         }
-        
-        // Verify the recovery data store was called
-        verify(userRecoveryDataStore, times(1)).loadWithoutCodeExpiryValidation(any(User.class));
     }
 
     @Test(expectedExceptions = IdentityEventException.class,
@@ -349,7 +403,11 @@ public class AccountConfirmationValidationHandlerTest {
                 .thenThrow(new UserStoreException("UserStore error"));
 
         // When
-        handler.handleEvent(event);
+        try (MockedStatic<FlowMgtConfigUtils> mockedStatic = mockStatic(FlowMgtConfigUtils.class)) {
+            mockedStatic.when(() -> FlowMgtConfigUtils.getFlowConfig(any(), any()))
+                    .thenReturn(mockedFlowConfigDTO);
+            handler.handleEvent(event);
+        }
     }
 
     @Test(expectedExceptions = IdentityEventException.class,
@@ -369,7 +427,11 @@ public class AccountConfirmationValidationHandlerTest {
                 .thenThrow(new IdentityRecoveryException("Recovery error"));
 
         // When
-        handler.handleEvent(event);
+        try (MockedStatic<FlowMgtConfigUtils> mockedStatic = mockStatic(FlowMgtConfigUtils.class)) {
+            mockedStatic.when(() -> FlowMgtConfigUtils.getFlowConfig(any(), any()))
+                    .thenReturn(mockedFlowConfigDTO);
+            handler.handleEvent(event);
+        }
     }
 
     // Helper methods


### PR DESCRIPTION
### Proposed changes in this pull request

Now self registration flow can be enabled without the previous self registration governance connector enabling. But account confirmation and resend confirmation code relies on connector configs. This change add the flow configs consideration as well.

### Related Issues
- https://github.com/wso2/product-is/issues/25934

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
