### PR TITLE
Fix Emails not sent in invited user registration flow.

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AskPasswordBasedPasswordSetupHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AskPasswordBasedPasswordSetupHandler.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.identity.recovery.handler;
 
-import org.apache.axis2.description.Flow;
 import org.apache.commons.lang3.StringUtils;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.common.model.User;
@@ -28,6 +27,7 @@ import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.flow.mgt.Constants;
 import org.wso2.carbon.identity.flow.mgt.exception.FlowMgtServerException;
+import org.wso2.carbon.identity.flow.mgt.model.FlowConfigDTO;
 import org.wso2.carbon.identity.flow.mgt.utils.FlowMgtConfigUtils;
 import org.wso2.carbon.identity.governance.IdentityMgtConstants;
 import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
@@ -73,8 +73,15 @@ public class AskPasswordBasedPasswordSetupHandler extends AdminForcedPasswordRes
 
         boolean isInviteUserRegistrationFlowEnabled;
         try {
-            isInviteUserRegistrationFlowEnabled = FlowMgtConfigUtils.getFlowConfig(
-                    Constants.FlowTypes.INVITED_USER_REGISTRATION.getType(), tenantDomainProperty).getIsEnabled();
+            FlowConfigDTO flowConfigDTO = FlowMgtConfigUtils.getFlowConfig(
+                    Constants.FlowTypes.INVITED_USER_REGISTRATION.getType(), tenantDomainProperty);
+            // A null flow configuration indicates that the Invited User Registration flow is not configured for the
+            // tenant; therefore, invited user registration is not enabled.
+            if (flowConfigDTO != null) {
+                isInviteUserRegistrationFlowEnabled = flowConfigDTO.getIsEnabled();
+            } else {
+                isInviteUserRegistrationFlowEnabled = false;
+            }
         } catch (FlowMgtServerException e) {
             throw new IdentityEventException(
                     "Error while checking the invite user registration flow enablement for tenant: " +

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AskPasswordBasedPasswordSetupHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AskPasswordBasedPasswordSetupHandler.java
@@ -71,26 +71,8 @@ public class AskPasswordBasedPasswordSetupHandler extends AdminForcedPasswordRes
         Map<String, Object> eventProperties = event.getEventProperties();
         String tenantDomainProperty = (String) eventProperties.get(TENANT_DOMAIN);
 
-        boolean isInviteUserRegistrationFlowEnabled;
-        try {
-            FlowConfigDTO flowConfigDTO = FlowMgtConfigUtils.getFlowConfig(
-                    Constants.FlowTypes.INVITED_USER_REGISTRATION.getType(), tenantDomainProperty);
-            // A null flow configuration indicates that the Invited User Registration flow is not configured for the
-            // tenant; therefore, invited user registration is not enabled.
-            if (flowConfigDTO != null) {
-                isInviteUserRegistrationFlowEnabled = flowConfigDTO.getIsEnabled();
-            } else {
-                isInviteUserRegistrationFlowEnabled = false;
-            }
-        } catch (FlowMgtServerException e) {
-            throw new IdentityEventException(
-                    "Error while checking the invite user registration flow enablement for tenant: " +
-                            tenantDomainProperty, e
-            );
-        }
-
         if (!isAskPasswordBasedPasswordSetupHandlerEnabled(tenantDomainProperty)
-                && !isInviteUserRegistrationFlowEnabled) {
+                && !isInviteUserRegistrationFlowEnabled(tenantDomainProperty)) {
             return;
         }
 
@@ -259,5 +241,25 @@ public class AskPasswordBasedPasswordSetupHandler extends AdminForcedPasswordRes
         // checking email verification enablement.
         return Boolean.parseBoolean(Utils.getConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
                 .ENABLE_EMAIL_VERIFICATION, tenantDomain));
+    }
+
+    private static boolean isInviteUserRegistrationFlowEnabled(String tenantDomain) throws IdentityEventException {
+
+        try {
+            FlowConfigDTO flowConfigDTO = FlowMgtConfigUtils.getFlowConfig(
+                    Constants.FlowTypes.INVITED_USER_REGISTRATION.getType(), tenantDomain);
+            // A null flow configuration indicates that the Invited User Registration flow is not configured for the
+            // tenant; therefore, invited user registration is not enabled.
+            if (flowConfigDTO != null) {
+                return flowConfigDTO.getIsEnabled();
+            } else {
+                return false;
+            }
+        } catch (FlowMgtServerException e) {
+            throw new IdentityEventException(
+                    "Error while checking the invite user registration flow enablement for tenant: " +
+                            tenantDomain, e
+            );
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/AskPasswordBasedPasswordSetupHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/AskPasswordBasedPasswordSetupHandlerTest.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.flow.mgt.Constants;
 import org.wso2.carbon.identity.flow.mgt.model.FlowConfigDTO;
 import org.wso2.carbon.identity.flow.mgt.utils.FlowMgtConfigUtils;
 import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
@@ -345,8 +346,12 @@ public class AskPasswordBasedPasswordSetupHandlerTest {
         Event event = createEvent(IdentityEventConstants.Event.POST_ADD_USER, IdentityRecoveryConstants.FALSE,
                 null, null, null);
         event.getEventProperties().put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, "");
+        FlowConfigDTO mockFlowConfig = mock(FlowConfigDTO.class);
+        when(mockFlowConfig.getIsEnabled()).thenReturn(false);
+        mockedFlowMgtUtils.when(() -> FlowMgtConfigUtils.getFlowConfig(
+                        eq(Constants.FlowTypes.INVITED_USER_REGISTRATION.getType()), anyString()))
+                .thenReturn(mockFlowConfig);
         mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION, false);
-
         askPasswordBasedPasswordSetupHandler.handleEvent(event);
 
         // verify that no further actions were taken when the handler is disabled.

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/AskPasswordBasedPasswordSetupHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/AskPasswordBasedPasswordSetupHandlerTest.java
@@ -358,6 +358,42 @@ public class AskPasswordBasedPasswordSetupHandlerTest {
         mockedUtils.verify(() -> Utils.publishRecoveryEvent(any(), any(), any()), org.mockito.Mockito.never());
     }
 
+    @Test
+    public void testAskPasswordSetupHandlerDisabledWithNullFlowConfig() throws IdentityEventException {
+
+        Event event = createEvent(IdentityEventConstants.Event.POST_ADD_USER, IdentityRecoveryConstants.FALSE,
+                null, null, null);
+        event.getEventProperties().put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, "");
+        mockedFlowMgtUtils.when(() -> FlowMgtConfigUtils.getFlowConfig(
+                        eq(Constants.FlowTypes.INVITED_USER_REGISTRATION.getType()), anyString()))
+                .thenReturn(null);
+        mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION, false);
+        askPasswordBasedPasswordSetupHandler.handleEvent(event);
+
+        // verify that no further actions were taken when the handler is disabled.
+        mockedUtils.verify(() -> Utils.publishRecoveryEvent(any(), any(), any()), org.mockito.Mockito.never());
+    }
+
+    @Test(expectedExceptions = IdentityEventException.class,
+          expectedExceptionsMessageRegExp = "Error while checking the invite user registration flow enablement " +
+                  "for tenant: .*")
+    public void testHandleEventThrowsIdentityEventExceptionWhenFlowMgtServerExceptionOccurs() throws Exception {
+
+        Event event = createEvent(IdentityEventConstants.Event.POST_ADD_USER, IdentityRecoveryConstants.FALSE,
+                null, null, null);
+        String testTenantDomain = "test-tenant.com";
+        event.getEventProperties().put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, testTenantDomain);
+
+        // Mock FlowMgtConfigUtils to throw FlowMgtServerException
+        mockedFlowMgtUtils.when(() -> FlowMgtConfigUtils.getFlowConfig(
+                        eq(Constants.FlowTypes.INVITED_USER_REGISTRATION.getType()), eq(testTenantDomain)))
+                .thenThrow(new org.wso2.carbon.identity.flow.mgt.exception.FlowMgtServerException(
+                        "Flow management server error"));
+
+        // This should throw IdentityEventException with the expected message
+        askPasswordBasedPasswordSetupHandler.handleEvent(event);
+    }
+
     private void mockGetConnectorConfig(String connectorConfig, boolean value) {
 
         mockedUtils.when(() -> Utils.getConnectorConfig(eq(connectorConfig), anyString()))


### PR DESCRIPTION
**Related Issues**

- [x] https://github.com/wso2/product-is/issues/26506

This pull request updates the `AskPasswordBasedPasswordSetupHandler` to enhance its enablement checks by also considering the status of the "Invite User Registration" flow, and updates the corresponding tests to mock this new logic. The main goal is to ensure that the handler can be triggered if either the handler itself or the invite user registration flow is enabled.

**Enhancements to handler enablement logic:**

* Updated `AskPasswordBasedPasswordSetupHandler` to check if the "Invite User Registration" flow is enabled using `FlowMgtConfigUtils.getFlowConfig`, and to proceed if either the handler or the flow is enabled.
* Improved error handling by throwing an `IdentityEventException` if there is an error checking the invite user registration flow enablement.

**Test improvements:**

* Updated the test `testAskPasswordSetupHandlerDisabled` to mock the "Invite User Registration" flow configuration and ensure the handler behaves correctly when both the handler and the flow are disabled.
* Added necessary imports in both the implementation and test files to support the new flow management logic. [[1]](diffhunk://#diff-b16ded6ab49e1cca9cbed0e19c5587ab2479bdd4741dd289a5b82c5381f8ef75R21-R31) [[2]](diffhunk://#diff-48f9a3d35a64ad7577e81fd2596ef273053f2f8af153b5f6802649763344c0caR36)