### PR TITLE
Refactor multi mobile and email check to check only end user and admi…

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
@@ -120,7 +120,7 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
         }
 
         boolean supportMultipleMobileNumbers =
-                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
+                Utils.isMultiMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
 
         boolean enable = isMobileVerificationOnUpdateEnabled(user.getTenantDomain());
 
@@ -348,7 +348,7 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
         }
 
         boolean supportMultipleMobileNumbers =
-                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
+                Utils.isMultiMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
 
         // Update multiple mobile numbers only if they’re in the claims map.
         // This avoids issues with updating the primary mobile number due to user store limitations on multiple

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -122,7 +122,7 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
         }
 
         boolean supportMultipleEmails =
-                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
+                Utils.isMultiEmailsPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
 
         boolean enable = false;
 
@@ -552,7 +552,7 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
         }
 
         boolean supportMultipleEmails =
-                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
+                Utils.isMultiEmailsPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
         // Update multiple email address related claims only if they’re in the claims map.
         // This avoids issues with updating the primary email address due to user store limitations on multiple
         // email addresses.

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -841,8 +841,10 @@ public class UserSelfRegistrationManager {
         HashMap<String, String> userClaims = getClaimsListToUpdate(user, verifiedChannelType,
                 externallyVerifiedClaim, recoveryData.getRecoveryScenario().toString());
 
-        boolean supportMultipleEmailsAndMobileNumbers =
-                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
+        boolean supportMultipleEmails =
+                Utils.isMultiEmailsPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
+        boolean supportMultipleMobileNumbers =
+                Utils.isMultiMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
         Map<String, String> userClaimsToBeAdded = new HashMap<>();
         Map<String, String> userClaimsToBeModified = new HashMap<>();
@@ -868,7 +870,7 @@ public class UserSelfRegistrationManager {
                 // Only update verified email addresses claim if the recovery scenario is
                 // EMAIL_VERIFICATION_ON_VERIFIED_LIST_UPDATE.
                 if (RecoveryScenarios.EMAIL_VERIFICATION_ON_VERIFIED_LIST_UPDATE.equals(
-                        recoveryData.getRecoveryScenario()) && supportMultipleEmailsAndMobileNumbers) {
+                        recoveryData.getRecoveryScenario()) && supportMultipleEmails) {
                     try {
                         List<String> verifiedEmails = Utils.getMultiValuedClaim(userStoreManager, user,
                                 IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM);
@@ -937,7 +939,7 @@ public class UserSelfRegistrationManager {
                             recoveryData.getRecoveryScenario())
                             || RecoveryScenarios.PROGRESSIVE_PROFILE_MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE
                             .equals(recoveryData.getRecoveryScenario()))
-                        && supportMultipleEmailsAndMobileNumbers) {
+                        && supportMultipleMobileNumbers) {
                     try {
                         List<String> existingVerifiedMobileNumbersList = Utils.getMultiValuedClaim(userStoreManager,
                                 user, IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM);
@@ -1203,8 +1205,8 @@ public class UserSelfRegistrationManager {
         Map<String, String> userClaimsToBeModified = new HashMap<>();
         Map<String, String> userClaimsToBeDeleted = new HashMap<>();
 
-        boolean supportMultipleEmailsAndMobileNumbers =
-                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
+        boolean supportMultipleMobileNumbers =
+                Utils.isMultiMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
 
         String pendingMobileNumberClaimValue = recoveryData.getRemainingSetIds();
         String primaryMobile = null;
@@ -1224,7 +1226,7 @@ public class UserSelfRegistrationManager {
             */
             if ((RecoveryScenarios.MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE.equals(recoveryData.getRecoveryScenario()
                     ) || RecoveryScenarios.PROGRESSIVE_PROFILE_MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE.equals(
-                    recoveryData.getRecoveryScenario())) && supportMultipleEmailsAndMobileNumbers) {
+                    recoveryData.getRecoveryScenario())) && supportMultipleMobileNumbers) {
                 try {
                     String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
                     List<String> existingVerifiedMobileNumbersList = Utils.getMultiValuedClaim(userStoreManager,

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -1527,13 +1527,13 @@ public class Utils {
     }
 
     /**
-     * Check whether the supporting multiple email addresses and mobile numbers per user feature is enabled.
+     * Check whether supporting multiple email addresses per user is enabled.
      *
-     * @param tenantDomain   Tenant domain.
+     * @param tenantDomain    Tenant domain.
      * @param userStoreDomain User store domain.
      * @return True if the config is set to true, false otherwise.
      */
-    public static boolean isMultiEmailsAndMobileNumbersPerUserEnabled(String tenantDomain, String userStoreDomain) {
+    public static boolean isMultiEmailsPerUserEnabled(String tenantDomain, String userStoreDomain) {
 
         if (!Boolean.parseBoolean(IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER))) {
@@ -1550,16 +1550,48 @@ public class Utils {
                             .getLocalClaims(tenantDomain);
 
             List<String> requiredClaims = Arrays.asList(
-                    IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM,
-                    IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM,
                     IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM,
                     IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM);
 
-            // Check if all required claims are valid for the user store.
             return requiredClaims.stream().allMatch(claimUri ->
                             isClaimSupportedForUserStore(localClaims, claimUri, userStoreDomain));
         } catch (ClaimMetadataException e) {
-            log.error("Error while retrieving multiple emails and mobiles config.", e);
+            log.error("Error while retrieving multiple emails config.", e);
+            return false;
+        }
+    }
+
+    /**
+     * Check whether supporting multiple mobile numbers per user is enabled.
+     *
+     * @param tenantDomain    Tenant domain.
+     * @param userStoreDomain User store domain.
+     * @return True if the config is set to true, false otherwise.
+     */
+    public static boolean isMultiMobileNumbersPerUserEnabled(String tenantDomain, String userStoreDomain) {
+
+        if (!Boolean.parseBoolean(IdentityUtil.getProperty(
+                IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER))) {
+            return false;
+        }
+
+        if (StringUtils.isBlank(tenantDomain) || StringUtils.isBlank(userStoreDomain)) {
+            return false;
+        }
+
+        try {
+            List<LocalClaim> localClaims =
+                    IdentityRecoveryServiceDataHolder.getInstance().getClaimMetadataManagementService()
+                            .getLocalClaims(tenantDomain);
+
+            List<String> requiredClaims = Arrays.asList(
+                    IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM,
+                    IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM);
+
+            return requiredClaims.stream().allMatch(claimUri ->
+                            isClaimSupportedForUserStore(localClaims, claimUri, userStoreDomain));
+        } catch (ClaimMetadataException e) {
+            log.error("Error while retrieving multiple mobile numbers config.", e);
             return false;
         }
     }
@@ -1580,10 +1612,8 @@ public class Utils {
             .anyMatch(claim -> {
                 Map<String, String> properties = claim.getClaimProperties();
 
-                // Check if claim is supported by default.
-                boolean isSupported = Boolean.parseBoolean(
-                        properties.getOrDefault(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY,
-                                Boolean.FALSE.toString()));
+                // Check if claim is supported by default, considering profile-specific values.
+                boolean isSupported = isClaimSupportedByDefaultWithProfiles(properties);
 
                 // Check if user store is not in excluded list.
                 String excludedUserStoreDomains = properties.get(ClaimConstants.EXCLUDED_USER_STORES_PROPERTY);
@@ -1593,6 +1623,41 @@ public class Utils {
 
                 return isSupported && isNotExcluded;
             });
+    }
+
+    /**
+     * Determines if a claim is supported by default by checking profile-specific values first.
+     *
+     * @param claimProperties The claim properties map.
+     * @return True if the claim is supported by default considering profiles.
+     */
+    private static boolean isClaimSupportedByDefaultWithProfiles(Map<String, String> claimProperties) {
+
+        boolean globalValue = Boolean.parseBoolean(
+                claimProperties.getOrDefault(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY,
+                        Boolean.FALSE.toString()));
+
+        String consoleValue = claimProperties.get(buildProfileSupportedByDefaultKey(
+                ClaimConstants.DefaultAllowedClaimProfile.CONSOLE.getProfileName()));
+        String endUserValue = claimProperties.get(buildProfileSupportedByDefaultKey(
+                ClaimConstants.DefaultAllowedClaimProfile.END_USER.getProfileName()));
+
+        // Use profile value if defined, otherwise fall back to global value.
+        boolean consoleSupported = consoleValue != null ? Boolean.parseBoolean(consoleValue) : globalValue;
+        boolean endUserSupported = endUserValue != null ? Boolean.parseBoolean(endUserValue) : globalValue;
+        return consoleSupported && endUserSupported;
+    }
+
+    /**
+     * Builds the profile-specific SupportedByDefault property key.
+     *
+     * @param profileName The profile name.
+     * @return The profile-specific SupportedByDefault property key.
+     */
+    private static String buildProfileSupportedByDefaultKey(String profileName) {
+
+        return ClaimConstants.PROFILES_CLAIM_PROPERTY_PREFIX + profileName
+                + ClaimConstants.CLAIM_PROFILE_PROPERTY_DELIMITER + ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandlerTest.java
@@ -684,7 +684,7 @@ public class MobileNumberVerificationHandlerTest {
     private void mockUtilMethods(boolean mobileVerificationEnabled, boolean multiAttributeEnabled,
                                  boolean useVerifyClaimEnabled) {
 
-        mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
+        mockedUtils.when(() -> Utils.isMultiMobileNumbersPerUserEnabled(anyString(), anyString()))
                 .thenReturn(multiAttributeEnabled);
         mockedUtils.when(Utils::isUseVerifyClaimEnabled).thenReturn(useVerifyClaimEnabled);
         mockedUtils.when(() -> Utils.getConnectorConfig(

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandlerTest.java
@@ -810,7 +810,7 @@ public class UserEmailVerificationHandlerTest {
     private void mockUtilMethods(boolean emailVerificationEnabled, boolean multiAttributeEnabled,
                                  boolean userVerifyClaimEnabled, boolean notificationOnEmailUpdate) {
 
-        mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
+        mockedUtils.when(() -> Utils.isMultiEmailsPerUserEnabled(anyString(), anyString()))
                 .thenReturn(multiAttributeEnabled);
         mockedUtils.when(Utils::isUseVerifyClaimEnabled).thenReturn(userVerifyClaimEnabled);
         mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION_ON_UPDATE,

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManagerTest.java
@@ -1032,7 +1032,7 @@ public class UserSelfRegistrationManagerTest {
         when(identityGovernanceService.getConfiguration(any(), anyString())).thenReturn(testProperties);
 
         try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class)) {
-            mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
+            mockedUtils.when(() -> Utils.isMultiMobileNumbersPerUserEnabled(anyString(), anyString()))
                     .thenReturn(true);
             mockedUtils.when(() -> Utils.getConnectorConfig(
                             eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER),
@@ -1062,7 +1062,7 @@ public class UserSelfRegistrationManagerTest {
         // Case 2: External Verified Channel type.
         verifiedChannelType = NotificationChannels.EXTERNAL_CHANNEL.getChannelType();
         try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class)) {
-            mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
+            mockedUtils.when(() -> Utils.isMultiMobileNumbersPerUserEnabled(anyString(), anyString()))
                     .thenReturn(true);
             mockedUtils.when(() -> Utils.getConnectorConfig(
                             eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER),
@@ -1085,7 +1085,7 @@ public class UserSelfRegistrationManagerTest {
 
         // Case 3: Throws user store exception while getting user claim values.
         try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class)) {
-            mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
+            mockedUtils.when(() -> Utils.isMultiMobileNumbersPerUserEnabled(anyString(), anyString()))
                     .thenReturn(true);
             mockedUtils.when(() -> Utils.getConnectorConfig(
                             eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER),
@@ -1110,7 +1110,7 @@ public class UserSelfRegistrationManagerTest {
         verifiedChannelType = NotificationChannels.SMS_CHANNEL.getChannelType();
         verifiedChannelClaim = "http://wso2.org/claims/invalid";
         try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class)) {
-            mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
+            mockedUtils.when(() -> Utils.isMultiMobileNumbersPerUserEnabled(anyString(), anyString()))
                     .thenReturn(true);
             mockedUtils.when(() -> Utils.getConnectorConfig(
                             eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER),
@@ -1157,7 +1157,7 @@ public class UserSelfRegistrationManagerTest {
         when(identityGovernanceService.getConfiguration(any(), anyString())).thenReturn(testProperties);
 
         try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class)) {
-            mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
+            mockedUtils.when(() -> Utils.isMultiMobileNumbersPerUserEnabled(anyString(), anyString()))
                     .thenReturn(true);
             mockedUtils.when(() -> Utils.getConnectorConfig(
                             eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER),

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/util/UtilsTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/util/UtilsTest.java
@@ -1439,7 +1439,7 @@ public class UtilsTest {
     }
 
     @Test
-    public void testIsMultiEmailsAndMobileNumbersPerUserEnabled() throws Exception {
+    public void testIsMultiEmailsPerUserEnabled() throws Exception {
 
         // Mock ClaimMetadataManagementService
         ClaimMetadataManagementService claimMetadataManagementService = mock(ClaimMetadataManagementService.class);
@@ -1451,7 +1451,7 @@ public class UtilsTest {
                         IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER))
                 .thenReturn("false");
 
-        boolean isEnabled = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
+        boolean isEnabled = Utils.isMultiEmailsPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
         assertFalse(isEnabled);
 
         // Case 2: When support_multi_emails_and_mobile_numbers_per_user config is true.
@@ -1464,7 +1464,7 @@ public class UtilsTest {
         when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN)).thenReturn(
                 returnMultiEmailAndMobileRelatedLocalClaims(claimProperties2));
 
-        isEnabled = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
+        isEnabled = Utils.isMultiEmailsPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
         assertTrue(isEnabled);
 
         // Case 3: When support by default is disabled for feature related claims.
@@ -1473,7 +1473,7 @@ public class UtilsTest {
         when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN)).thenReturn(
                 returnMultiEmailAndMobileRelatedLocalClaims(claimProperties3));
 
-        isEnabled = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
+        isEnabled = Utils.isMultiEmailsPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
         assertFalse(isEnabled);
 
         // Case 4: When user store domain is excluded for feature related claims.
@@ -1483,14 +1483,70 @@ public class UtilsTest {
         when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN)).thenReturn(
                 returnMultiEmailAndMobileRelatedLocalClaims(claimProperties4));
 
-        isEnabled = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
+        isEnabled = Utils.isMultiEmailsPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
         assertFalse(isEnabled);
 
         // Case 5: When ClaimMetadataException is thrown.
         when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN))
                 .thenThrow(new ClaimMetadataException("Test exception"));
 
-        isEnabled = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
+        isEnabled = Utils.isMultiEmailsPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
+        assertFalse(isEnabled);
+    }
+
+    @Test
+    public void testIsMultiMobileNumbersPerUserEnabled() throws Exception {
+
+        // Mock ClaimMetadataManagementService
+        ClaimMetadataManagementService claimMetadataManagementService = mock(ClaimMetadataManagementService.class);
+        when(identityRecoveryServiceDataHolder.getClaimMetadataManagementService())
+                .thenReturn(claimMetadataManagementService);
+
+        // Case 1: When support_multi_emails_and_mobile_numbers_per_user config is false.
+        mockedStaticIdentityUtil.when(() -> IdentityUtil.getProperty(
+                        IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER))
+                .thenReturn("false");
+
+        boolean isEnabled = Utils.isMultiMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
+        assertFalse(isEnabled);
+
+        // Case 2: When support_multi_emails_and_mobile_numbers_per_user config is true.
+        mockedStaticIdentityUtil.when(() -> IdentityUtil.getProperty(
+                        IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER))
+                .thenReturn("true");
+
+        Map<String, String> claimProperties2 = new HashMap<>();
+        claimProperties2.put(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY, Boolean.TRUE.toString());
+        when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN)).thenReturn(
+                returnMultiEmailAndMobileRelatedLocalClaims(claimProperties2));
+
+        isEnabled = Utils.isMultiMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
+        assertTrue(isEnabled);
+
+        // Case 3: When support by default is disabled for feature related claims.
+        Map<String, String> claimProperties3 = new HashMap<>();
+        claimProperties3.put(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY, Boolean.FALSE.toString());
+        when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN)).thenReturn(
+                returnMultiEmailAndMobileRelatedLocalClaims(claimProperties3));
+
+        isEnabled = Utils.isMultiMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
+        assertFalse(isEnabled);
+
+        // Case 4: When user store domain is excluded for feature related claims.
+        Map<String, String> claimProperties4 = new HashMap<>();
+        claimProperties4.put(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY, Boolean.TRUE.toString());
+        claimProperties4.put(ClaimConstants.EXCLUDED_USER_STORES_PROPERTY, USER_STORE_DOMAIN);
+        when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN)).thenReturn(
+                returnMultiEmailAndMobileRelatedLocalClaims(claimProperties4));
+
+        isEnabled = Utils.isMultiMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
+        assertFalse(isEnabled);
+
+        // Case 5: When ClaimMetadataException is thrown.
+        when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN))
+                .thenThrow(new ClaimMetadataException("Test exception"));
+
+        isEnabled = Utils.isMultiMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
         assertFalse(isEnabled);
     }
 


### PR DESCRIPTION
This pull request refactors the way support for multiple email addresses and mobile numbers per user is determined throughout the identity recovery codebase. Instead of using a combined check for both emails and mobile numbers, it introduces separate utility methods for each, leading to clearer logic and improved maintainability. Additionally, the pull request enhances claim support checks by considering profile-specific values.

**Separation of multi-value support checks:**

* Replaced `Utils.isMultiEmailsAndMobileNumbersPerUserEnabled` with `Utils.isMultiEmailsPerUserEnabled` and `Utils.isMultiMobileNumbersPerUserEnabled` in `MobileNumberVerificationHandler`, `UserEmailVerificationHandler`, and `UserSelfRegistrationManager`, ensuring more precise checks for each claim type. [[1]](diffhunk://#diff-a3020f0e614e3e8156422df806e7f9181b040bff14a515ce181e0dbfb2650a9cL123-R123) [[2]](diffhunk://#diff-a3020f0e614e3e8156422df806e7f9181b040bff14a515ce181e0dbfb2650a9cL351-R351) [[3]](diffhunk://#diff-d9563798eea549a0b0451cfb68c0a7a588b10038ae656cd6fc29ef12df4a5745L125-R125) [[4]](diffhunk://#diff-d9563798eea549a0b0451cfb68c0a7a588b10038ae656cd6fc29ef12df4a5745L555-R555) [[5]](diffhunk://#diff-2d6464e51a37ccddbc57324c279309b49e5f4a211bbad5932080fc9670118aa7L844-R847) [[6]](diffhunk://#diff-2d6464e51a37ccddbc57324c279309b49e5f4a211bbad5932080fc9670118aa7L871-R873) [[7]](diffhunk://#diff-2d6464e51a37ccddbc57324c279309b49e5f4a211bbad5932080fc9670118aa7L940-R942) [[8]](diffhunk://#diff-2d6464e51a37ccddbc57324c279309b49e5f4a211bbad5932080fc9670118aa7L1206-R1209) [[9]](diffhunk://#diff-2d6464e51a37ccddbc57324c279309b49e5f4a211bbad5932080fc9670118aa7L1227-R1229)

**Utility method enhancements:**

* Split the combined method `isMultiEmailsAndMobileNumbersPerUserEnabled` into two distinct methods: `isMultiEmailsPerUserEnabled` and `isMultiMobileNumbersPerUserEnabled` in `Utils.java`, each checking for their respective claims and logging errors separately. [[1]](diffhunk://#diff-b91ad497cd9239f9fdfbd32c9e99ee972ff66c4f0b6c9b09f84b98ffe1edc815L1530-R1536) [[2]](diffhunk://#diff-b91ad497cd9239f9fdfbd32c9e99ee972ff66c4f0b6c9b09f84b98ffe1edc815L1553-R1594)

**Claim support improvements:**

* Updated claim support logic in `isClaimSupportedForUserStore` to use a new helper method `isClaimSupportedByDefaultWithProfiles`, which checks profile-specific values for claim support, increasing accuracy in determining whether claims are supported. [[1]](diffhunk://#diff-b91ad497cd9239f9fdfbd32c9e99ee972ff66c4f0b6c9b09f84b98ffe1edc815L1583-R1616) [[2]](diffhunk://#diff-b91ad497cd9239f9fdfbd32c9e99ee972ff66c4f0b6c9b09f84b98ffe1edc815R1628-R1662)

These changes improve code clarity, make configuration checks more granular, and ensure claim support is determined in a profile-aware manner.

### Related Issues
- https://github.com/wso2/product-is/issues/27156