### PR TITLE
Refactor cache operations to use read-safe methods for concurrent environments

### DIFF
--- a/components/org.wso2.carbon.identity.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.governance/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>org.wso2.carbon.tenant.mgt</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>javax.cache.wso2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.axis2.wso2</groupId>
             <artifactId>axis2</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStore.java
@@ -145,7 +145,7 @@ public class InMemoryIdentityDataStore extends UserIdentityDataStore {
                     cachedUserIdentityDTO.getUserIdentityDataMap().putAll(userIdentityDTO.getUserIdentityDataMap());
                     identityDataStoreCache.addToCacheOnRead(key, cachedUserIdentityDTO, tenantId);
                 } else {
-                    identityDataStoreCache.addToCacheOnRead(key, userIdentityDTO, tenantId);
+                    identityDataStoreCache.addToCache(key, userIdentityDTO, tenantId);
                 }
             }
         } catch (UserStoreException e) {

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStore.java
@@ -136,7 +136,9 @@ public class InMemoryIdentityDataStore extends UserIdentityDataStore {
                 }
 
                 org.wso2.carbon.user.core.UserStoreManager store = (org.wso2.carbon.user.core.UserStoreManager) userStoreManager;
-                String domainName = store.getRealmConfiguration().getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
+                String domainName = store.getRealmConfiguration().getUserStoreProperty(
+                    UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME
+                );
 
                 IdentityDataStoreCacheKey key = new IdentityDataStoreCacheKey(domainName, userName);
                 int tenantId = userStoreManager.getTenantId();

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStore.java
@@ -97,6 +97,63 @@ public class InMemoryIdentityDataStore extends UserIdentityDataStore {
     }
 
     @Override
+    public void storeOnRead(UserIdentityClaim userIdentityDTO, UserStoreManager userStoreManager)
+            throws IdentityException {
+
+        try {
+            if (userIdentityDTO != null && userIdentityDTO.getUserName() != null) {
+                String userName = UserCoreUtil.removeDomainFromName(userIdentityDTO.getUserName());
+                if (userStoreManager instanceof org.wso2.carbon.user.core.UserStoreManager) {
+                    if (!IdentityUtil.isUserStoreCaseSensitive((org.wso2.carbon.user.core.UserStoreManager)
+                            userStoreManager)) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Case insensitive user store found. Changing username from : " + userName +
+                                    " to : " + userName.toLowerCase(Locale.ENGLISH));
+                        }
+                        userName = userName.toLowerCase(Locale.ENGLISH);
+                    } else if (!IdentityUtil.isUseCaseSensitiveUsernameForCacheKeys(
+                            (org.wso2.carbon.user.core.UserStoreManager) userStoreManager)) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Case insensitive username for cache key is used. Changing username from : "
+                                    + userName + " to : " + userName.toLowerCase(Locale.ENGLISH));
+                        }
+                        userName = userName.toLowerCase(Locale.ENGLISH);
+                    }
+                }
+
+                if (log.isDebugEnabled()) {
+                    StringBuilder data = new StringBuilder("{");
+                    if (userIdentityDTO.getUserIdentityDataMap() != null) {
+                        for (Map.Entry<String, String> entry : userIdentityDTO.getUserIdentityDataMap().entrySet()) {
+                            data.append("[").append(entry.getKey()).append(" = ").append(entry.getValue()).append("], ");
+                        }
+                    }
+                    if (data.indexOf(",") >= 0) {
+                        data.deleteCharAt(data.lastIndexOf(","));
+                    }
+                    data.append("}");
+                    log.debug("Storing UserIdentityClaimsDO to cache for user: " + userName + " with claims: " + data);
+                }
+
+                org.wso2.carbon.user.core.UserStoreManager store = (org.wso2.carbon.user.core.UserStoreManager) userStoreManager;
+                String domainName = store.getRealmConfiguration().getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
+
+                IdentityDataStoreCacheKey key = new IdentityDataStoreCacheKey(domainName, userName);
+                int tenantId = userStoreManager.getTenantId();
+                UserIdentityClaim cachedUserIdentityDTO = identityDataStoreCache.getValueFromCache(key, tenantId);
+                if (cachedUserIdentityDTO != null) {
+                    cachedUserIdentityDTO.getUserIdentityDataMap().putAll(userIdentityDTO.getUserIdentityDataMap());
+                    identityDataStoreCache.addToCacheOnRead(key, cachedUserIdentityDTO, tenantId);
+                } else {
+                    identityDataStoreCache.addToCacheOnRead(key, userIdentityDTO, tenantId);
+                }
+            }
+        } catch (UserStoreException e) {
+            log.error("Error while obtaining tenant ID from user store manager", e);
+        }
+    }
+
+    @Override
     public UserIdentityClaim load(String userName, UserStoreManager userStoreManager) {
 
         try {

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/JDBCIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/JDBCIdentityDataStore.java
@@ -231,7 +231,7 @@ public class JDBCIdentityDataStore extends InMemoryIdentityDataStore {
             dto = new UserIdentityClaim(userName, data);
             dto.setTenantId(tenantId);
             try {
-                super.store(dto, userStoreManager);
+                super.storeOnRead(dto, userStoreManager);
             } catch (IdentityException e) {
                 log.error("Error while reading user identity data", e);
             }

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/UserIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/UserIdentityDataStore.java
@@ -65,6 +65,17 @@ public abstract class UserIdentityDataStore {
             throws IdentityException;
 
     /**
+     * Stores data during a READ operation.
+     *
+     * @param userIdentityDTO
+     * @param userStoreManager
+     */
+    public void storeOnRead(UserIdentityClaim userIdentityDTO, UserStoreManager userStoreManager)
+            throws IdentityException {
+        // By default, do nothing. Subclasses may override this method if needed.
+    }
+
+    /**
      * Loads
      *
      * @param userName

--- a/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStoreTest.java
+++ b/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStoreTest.java
@@ -75,6 +75,10 @@ public class InMemoryIdentityDataStoreTest {
     @BeforeMethod
     public void setUp() {
 
+        // CarbonContext's static initializer reads CARBON_HOME; set it before any static mock so
+        // PrivilegedCarbonContext can be instrumented without triggering a class-init failure.
+        System.setProperty(CarbonBaseConstants.CARBON_HOME,
+                Paths.get(System.getProperty("user.dir"), "target").toString());
         MockitoAnnotations.openMocks(this);
         mockedIdentityUtil = Mockito.mockStatic(IdentityUtil.class);
         mockedUserCoreUtil = Mockito.mockStatic(UserCoreUtil.class);
@@ -101,6 +105,11 @@ public class InMemoryIdentityDataStoreTest {
         identityClaimsMap.put("keyOne", "valueOne");
         identityClaimsMap.put("keyTwo", "valueTwo");
 
+        // Stub getThreadLocalCarbonContext before initPrivilegedCarbonContext() is called, otherwise the
+        // static mock returns null and the init helper throws an NPE.
+        mockedPrivilegedCarbonContext.when(PrivilegedCarbonContext::getThreadLocalCarbonContext)
+                .thenReturn(privilegedCarbonContext);
+
         initPrivilegedCarbonContext();
 
         Map<String, String> identityClaimsMapClone = new HashMap<>(identityClaimsMap);
@@ -109,12 +118,13 @@ public class InMemoryIdentityDataStoreTest {
         userIdentityClaim = mock(UserIdentityClaim.class);
         realmConfiguration = mock(RealmConfiguration.class);
         userIdentityDataStore = mock(InMemoryIdentityDataStore.class);
-        privilegedCarbonContext = mock(PrivilegedCarbonContext.class);
+
+        IdentityDataStoreCache mockCache = mock(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache);
 
         mockedIdentityUtil.when(() -> IdentityUtil.isUserStoreCaseSensitive(userStoreManager)).thenReturn(true);
         mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName("gayashan")).thenReturn("gayashan");
-        mockedPrivilegedCarbonContext.when(PrivilegedCarbonContext::getThreadLocalCarbonContext)
-                .thenReturn(privilegedCarbonContext);
 
         Mockito.when(userStoreManager.getTenantId()).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
         Mockito.when(userIdentityClaim.getUserName()).thenReturn("gayashan");

--- a/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStoreTest.java
+++ b/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStoreTest.java
@@ -199,9 +199,9 @@ public class InMemoryIdentityDataStoreTest {
 
         new InMemoryIdentityDataStore().storeOnRead(dto, usm);
 
-        verify(mockCache).addToCacheOnRead(any(IdentityDataStoreCacheKey.class), any(UserIdentityClaim.class),
+        verify(mockCache).addToCache(any(IdentityDataStoreCacheKey.class), any(UserIdentityClaim.class),
                 anyInt());
-        verify(mockCache, never()).addToCache(any(), any(), anyInt());
+        verify(mockCache, never()).addToCacheOnRead(any(), any(), anyInt());
     }
 
     @Test(description = "storeOnRead should merge claims with the cached entry and call addToCacheOnRead.")
@@ -270,7 +270,7 @@ public class InMemoryIdentityDataStoreTest {
 
         // Verify cache was called with the lowercased key.
         IdentityDataStoreCacheKey expectedKey = new IdentityDataStoreCacheKey("PRIMARY", "charlie");
-        verify(mockCache).addToCacheOnRead(
+        verify(mockCache).addToCache(
                 Mockito.eq(expectedKey),
                 any(UserIdentityClaim.class), anyInt());
     }
@@ -302,17 +302,19 @@ public class InMemoryIdentityDataStoreTest {
         new InMemoryIdentityDataStore().storeOnRead(dto, usm);
 
         IdentityDataStoreCacheKey expectedKey = new IdentityDataStoreCacheKey("PRIMARY", "dave");
-        verify(mockCache).addToCacheOnRead(
+        verify(mockCache).addToCache(
                 Mockito.eq(expectedKey),
                 any(UserIdentityClaim.class), anyInt());
     }
 
-    @Test(description = "storeOnRead should NOT call addToCache — only addToCacheOnRead is allowed.")
-    public void testStoreOnRead_neverCallsAddToCache() throws Exception {
+    @Test(description = "addToCache and addToCacheOnRead are mutually exclusive: " +
+            "no cached entry uses addToCache only; existing cached entry uses addToCacheOnRead only.")
+    public void testStoreOnRead_cacheMethods_areMutuallyExclusive() throws Exception {
 
-        IdentityDataStoreCache mockCache = mock(IdentityDataStoreCache.class);
+        // Branch 1: no cached entry — addToCache is called, addToCacheOnRead is never called.
+        IdentityDataStoreCache mockCache1 = mock(IdentityDataStoreCache.class);
         mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
-        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache1);
 
         JDBCUserStoreManager usm = mock(JDBCUserStoreManager.class);
         RealmConfiguration rc = mock(RealmConfiguration.class);
@@ -329,18 +331,29 @@ public class InMemoryIdentityDataStoreTest {
         when(usm.getRealmConfiguration()).thenReturn(rc);
         when(usm.getTenantId()).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
         when(rc.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME)).thenReturn("PRIMARY");
+        when(mockCache1.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(null);
 
-        // Test both branches: no cached entry, and with cached entry.
-        when(mockCache.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(null);
         new InMemoryIdentityDataStore().storeOnRead(dto, usm);
-        verify(mockCache, never()).addToCache(any(), any(), anyInt());
+
+        verify(mockCache1).addToCache(any(), any(), anyInt());
+        verify(mockCache1, never()).addToCacheOnRead(any(), any(), anyInt());
+
+        mockedIdentityDataStoreCache.close();
+
+        // Branch 2: cached entry exists — addToCacheOnRead is called, addToCache is never called.
+        IdentityDataStoreCache mockCache2 = mock(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache2);
 
         Map<String, String> cachedClaims = new HashMap<>();
         UserIdentityClaim cachedDto = mock(UserIdentityClaim.class);
         when(cachedDto.getUserIdentityDataMap()).thenReturn(cachedClaims);
-        when(mockCache.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(cachedDto);
+        when(mockCache2.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(cachedDto);
+
         new InMemoryIdentityDataStore().storeOnRead(dto, usm);
-        verify(mockCache, never()).addToCache(any(), any(), anyInt());
+
+        verify(mockCache2).addToCacheOnRead(any(), any(), anyInt());
+        verify(mockCache2, never()).addToCache(any(), any(), anyInt());
     }
 
     @Test(description = "The default storeOnRead in UserIdentityDataStore should be a no-op with no exception.")

--- a/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStoreTest.java
+++ b/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStoreTest.java
@@ -28,6 +28,8 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.governance.internal.cache.IdentityDataStoreCache;
+import org.wso2.carbon.identity.governance.internal.cache.IdentityDataStoreCacheKey;
 import org.wso2.carbon.identity.governance.model.UserIdentityClaim;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.UserCoreConstants;
@@ -40,7 +42,12 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 public class InMemoryIdentityDataStoreTest {
@@ -63,6 +70,7 @@ public class InMemoryIdentityDataStoreTest {
     MockedStatic<IdentityUtil> mockedIdentityUtil;
     MockedStatic<UserCoreUtil> mockedUserCoreUtil;
     MockedStatic<PrivilegedCarbonContext> mockedPrivilegedCarbonContext;
+    MockedStatic<IdentityDataStoreCache> mockedIdentityDataStoreCache;
 
     @BeforeMethod
     public void setUp() {
@@ -79,6 +87,10 @@ public class InMemoryIdentityDataStoreTest {
         mockedIdentityUtil.close();
         mockedUserCoreUtil.close();
         mockedPrivilegedCarbonContext.close();
+        if (mockedIdentityDataStoreCache != null) {
+            mockedIdentityDataStoreCache.close();
+            mockedIdentityDataStoreCache = null;
+        }
     }
 
     @Test(testName = "testStore", description = "Test whether the map in UserIdentityClaim object containing " +
@@ -117,6 +129,232 @@ public class InMemoryIdentityDataStoreTest {
                 "object has been modified.");
 
     }
+
+    // ── storeOnRead tests ─────────────────────────────────────────────────────
+
+    @Test(description = "storeOnRead should silently do nothing when the DTO is null.")
+    public void testStoreOnRead_withNullDTO_doesNothing() throws Exception {
+
+        IdentityDataStoreCache mockCache = mock(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache);
+
+        InMemoryIdentityDataStore store = new InMemoryIdentityDataStore();
+        store.storeOnRead(null, mock(JDBCUserStoreManager.class));
+
+        verify(mockCache, never()).addToCacheOnRead(any(), any(), anyInt());
+        verify(mockCache, never()).addToCache(any(), any(), anyInt());
+    }
+
+    @Test(description = "storeOnRead should silently do nothing when the userName inside the DTO is null.")
+    public void testStoreOnRead_withNullUserName_doesNothing() throws Exception {
+
+        IdentityDataStoreCache mockCache = mock(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache);
+
+        UserIdentityClaim dto = mock(UserIdentityClaim.class);
+        when(dto.getUserName()).thenReturn(null);
+
+        InMemoryIdentityDataStore store = new InMemoryIdentityDataStore();
+        store.storeOnRead(dto, mock(JDBCUserStoreManager.class));
+
+        verify(mockCache, never()).addToCacheOnRead(any(), any(), anyInt());
+        verify(mockCache, never()).addToCache(any(), any(), anyInt());
+    }
+
+    @Test(description = "storeOnRead should store directly via addToCacheOnRead when no entry exists in cache.")
+    public void testStoreOnRead_noCachedEntry_storesDirectly() throws Exception {
+
+        IdentityDataStoreCache mockCache = mock(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache);
+
+        JDBCUserStoreManager usm = mock(JDBCUserStoreManager.class);
+        RealmConfiguration rc = mock(RealmConfiguration.class);
+        UserIdentityClaim dto = mock(UserIdentityClaim.class);
+        Map<String, String> claims = new HashMap<>();
+        claims.put("claimKey", "claimVal");
+
+        mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName("alice")).thenReturn("alice");
+        mockedIdentityUtil.when(() -> IdentityUtil.isUserStoreCaseSensitive(usm)).thenReturn(true);
+        mockedIdentityUtil.when(() -> IdentityUtil.isUseCaseSensitiveUsernameForCacheKeys(usm)).thenReturn(true);
+
+        when(dto.getUserName()).thenReturn("alice");
+        when(dto.getUserIdentityDataMap()).thenReturn(claims);
+        when(usm.getRealmConfiguration()).thenReturn(rc);
+        when(usm.getTenantId()).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+        when(rc.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME)).thenReturn("PRIMARY");
+        when(mockCache.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(null);
+
+        new InMemoryIdentityDataStore().storeOnRead(dto, usm);
+
+        verify(mockCache).addToCacheOnRead(any(IdentityDataStoreCacheKey.class), any(UserIdentityClaim.class),
+                anyInt());
+        verify(mockCache, never()).addToCache(any(), any(), anyInt());
+    }
+
+    @Test(description = "storeOnRead should merge claims with the cached entry and call addToCacheOnRead.")
+    public void testStoreOnRead_existingCachedEntry_mergesAndCallsAddToCacheOnRead() throws Exception {
+
+        IdentityDataStoreCache mockCache = mock(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache);
+
+        JDBCUserStoreManager usm = mock(JDBCUserStoreManager.class);
+        RealmConfiguration rc = mock(RealmConfiguration.class);
+
+        Map<String, String> newClaims = new HashMap<>();
+        newClaims.put("newKey", "newVal");
+        UserIdentityClaim dto = mock(UserIdentityClaim.class);
+        when(dto.getUserName()).thenReturn("bob");
+        when(dto.getUserIdentityDataMap()).thenReturn(newClaims);
+
+        Map<String, String> existingClaims = new HashMap<>();
+        existingClaims.put("existingKey", "existingVal");
+        UserIdentityClaim cachedDto = mock(UserIdentityClaim.class);
+        when(cachedDto.getUserIdentityDataMap()).thenReturn(existingClaims);
+
+        mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName("bob")).thenReturn("bob");
+        mockedIdentityUtil.when(() -> IdentityUtil.isUserStoreCaseSensitive(usm)).thenReturn(true);
+        mockedIdentityUtil.when(() -> IdentityUtil.isUseCaseSensitiveUsernameForCacheKeys(usm)).thenReturn(true);
+
+        when(usm.getRealmConfiguration()).thenReturn(rc);
+        when(usm.getTenantId()).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+        when(rc.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME)).thenReturn("PRIMARY");
+        when(mockCache.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(cachedDto);
+
+        new InMemoryIdentityDataStore().storeOnRead(dto, usm);
+
+        // Existing map should have had newClaims merged in.
+        assertEquals(existingClaims.get("newKey"), "newVal");
+        verify(mockCache).addToCacheOnRead(any(IdentityDataStoreCacheKey.class), any(UserIdentityClaim.class),
+                anyInt());
+        verify(mockCache, never()).addToCache(any(), any(), anyInt());
+    }
+
+    @Test(description = "storeOnRead should lowercase the username when the user store is case-insensitive.")
+    public void testStoreOnRead_caseInsensitiveUserStore_lowercasesUsername() throws Exception {
+
+        IdentityDataStoreCache mockCache = mock(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache);
+
+        JDBCUserStoreManager usm = mock(JDBCUserStoreManager.class);
+        RealmConfiguration rc = mock(RealmConfiguration.class);
+        UserIdentityClaim dto = mock(UserIdentityClaim.class);
+        Map<String, String> claims = new HashMap<>();
+
+        mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName("Charlie")).thenReturn("Charlie");
+        // Case-insensitive store: isUserStoreCaseSensitive returns false.
+        mockedIdentityUtil.when(() -> IdentityUtil.isUserStoreCaseSensitive(usm)).thenReturn(false);
+
+        when(dto.getUserName()).thenReturn("Charlie");
+        when(dto.getUserIdentityDataMap()).thenReturn(claims);
+        when(usm.getRealmConfiguration()).thenReturn(rc);
+        when(usm.getTenantId()).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+        when(rc.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME)).thenReturn("PRIMARY");
+        when(mockCache.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(null);
+
+        new InMemoryIdentityDataStore().storeOnRead(dto, usm);
+
+        // Verify cache was called with the lowercased key.
+        IdentityDataStoreCacheKey expectedKey = new IdentityDataStoreCacheKey("PRIMARY", "charlie");
+        verify(mockCache).addToCacheOnRead(
+                Mockito.eq(expectedKey),
+                any(UserIdentityClaim.class), anyInt());
+    }
+
+    @Test(description = "storeOnRead should lowercase the username when case-sensitive cache keys are disabled.")
+    public void testStoreOnRead_caseInsensitiveCacheKey_lowercasesUsername() throws Exception {
+
+        IdentityDataStoreCache mockCache = mock(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache);
+
+        JDBCUserStoreManager usm = mock(JDBCUserStoreManager.class);
+        RealmConfiguration rc = mock(RealmConfiguration.class);
+        UserIdentityClaim dto = mock(UserIdentityClaim.class);
+        Map<String, String> claims = new HashMap<>();
+
+        mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName("Dave")).thenReturn("Dave");
+        // Store is case-sensitive, but cache key is not.
+        mockedIdentityUtil.when(() -> IdentityUtil.isUserStoreCaseSensitive(usm)).thenReturn(true);
+        mockedIdentityUtil.when(() -> IdentityUtil.isUseCaseSensitiveUsernameForCacheKeys(usm)).thenReturn(false);
+
+        when(dto.getUserName()).thenReturn("Dave");
+        when(dto.getUserIdentityDataMap()).thenReturn(claims);
+        when(usm.getRealmConfiguration()).thenReturn(rc);
+        when(usm.getTenantId()).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+        when(rc.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME)).thenReturn("PRIMARY");
+        when(mockCache.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(null);
+
+        new InMemoryIdentityDataStore().storeOnRead(dto, usm);
+
+        IdentityDataStoreCacheKey expectedKey = new IdentityDataStoreCacheKey("PRIMARY", "dave");
+        verify(mockCache).addToCacheOnRead(
+                Mockito.eq(expectedKey),
+                any(UserIdentityClaim.class), anyInt());
+    }
+
+    @Test(description = "storeOnRead should NOT call addToCache — only addToCacheOnRead is allowed.")
+    public void testStoreOnRead_neverCallsAddToCache() throws Exception {
+
+        IdentityDataStoreCache mockCache = mock(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache);
+
+        JDBCUserStoreManager usm = mock(JDBCUserStoreManager.class);
+        RealmConfiguration rc = mock(RealmConfiguration.class);
+        UserIdentityClaim dto = mock(UserIdentityClaim.class);
+        Map<String, String> claims = new HashMap<>();
+        claims.put("k", "v");
+
+        mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName("eve")).thenReturn("eve");
+        mockedIdentityUtil.when(() -> IdentityUtil.isUserStoreCaseSensitive(usm)).thenReturn(true);
+        mockedIdentityUtil.when(() -> IdentityUtil.isUseCaseSensitiveUsernameForCacheKeys(usm)).thenReturn(true);
+
+        when(dto.getUserName()).thenReturn("eve");
+        when(dto.getUserIdentityDataMap()).thenReturn(claims);
+        when(usm.getRealmConfiguration()).thenReturn(rc);
+        when(usm.getTenantId()).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+        when(rc.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME)).thenReturn("PRIMARY");
+
+        // Test both branches: no cached entry, and with cached entry.
+        when(mockCache.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(null);
+        new InMemoryIdentityDataStore().storeOnRead(dto, usm);
+        verify(mockCache, never()).addToCache(any(), any(), anyInt());
+
+        Map<String, String> cachedClaims = new HashMap<>();
+        UserIdentityClaim cachedDto = mock(UserIdentityClaim.class);
+        when(cachedDto.getUserIdentityDataMap()).thenReturn(cachedClaims);
+        when(mockCache.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(cachedDto);
+        new InMemoryIdentityDataStore().storeOnRead(dto, usm);
+        verify(mockCache, never()).addToCache(any(), any(), anyInt());
+    }
+
+    @Test(description = "The default storeOnRead in UserIdentityDataStore should be a no-op with no exception.")
+    public void testDefaultStoreOnRead_inBaseClass_doesNothing() throws Exception {
+
+        // Concrete minimal subclass to test the base default.
+        UserIdentityDataStore baseStore = new UserIdentityDataStore() {
+            @Override
+            public void store(UserIdentityClaim dto, org.wso2.carbon.user.api.UserStoreManager usm)
+                    throws org.wso2.carbon.identity.base.IdentityException { }
+            @Override
+            public UserIdentityClaim load(String userName, org.wso2.carbon.user.api.UserStoreManager usm) {
+                return null;
+            }
+            @Override
+            public void remove(String userName, org.wso2.carbon.user.api.UserStoreManager usm)
+                    throws org.wso2.carbon.identity.base.IdentityException { }
+        };
+
+        // Should complete without throwing.
+        baseStore.storeOnRead(mock(UserIdentityClaim.class), mock(UserStoreManager.class));
+    }
+
+    // ── store tests ───────────────────────────────────────────────────────────
 
     public static void initPrivilegedCarbonContext(String tenantDomain, int tenantID, String userName) throws Exception {
         String carbonHome = Paths.get(System.getProperty("user.dir"), "target").toString();

--- a/components/org.wso2.carbon.identity.governance/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.governance/src/test/resources/testng.xml
@@ -27,6 +27,7 @@
             <class name="org.wso2.carbon.identity.governance.listener.IdentityMgtEventListenerTest"/>
             <class name="org.wso2.carbon.identity.governance.listener.IdentityStoreEventListenerTest"/>
             <class name="org.wso2.carbon.identity.governance.util.IdentityDataStoreUtilTest"/>
+            <class name="org.wso2.carbon.identity.governance.store.InMemoryIdentityDataStoreTest"/>
             <class name="org.wso2.carbon.identity.governance.store.JDBCIdentityDataStoreTest"/>
             <class name="org.wso2.carbon.identity.governance.listener.NotificationTemplateManagerTest"></class>
             <class name="org.wso2.carbon.identity.governance.internal.service.impl.notification.DefaultNotificationChannelManagerTest"/>

--- a/pom.xml
+++ b/pom.xml
@@ -738,14 +738,14 @@
         <identity.branding.preference.management.version>1.1.29</identity.branding.preference.management.version>
 
         <!--Carbon Kernel Version-->
-        <carbon.kernel.version>4.12.17-SNAPSHOT</carbon.kernel.version>
+        <carbon.kernel.version>4.12.15</carbon.kernel.version>
         <carbon.kernel.feature.version>4.9.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.10.99-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.106</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,12 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.wso2.carbon</groupId>
+                <artifactId>javax.cache.wso2</artifactId>
+                <version>${carbon.kernel.version}</version>
+            </dependency>
+
             <!--Orbit Dependencies-->
             <dependency>
                 <groupId>org.apache.axis2.wso2</groupId>
@@ -732,14 +738,14 @@
         <identity.branding.preference.management.version>1.1.29</identity.branding.preference.management.version>
 
         <!--Carbon Kernel Version-->
-        <carbon.kernel.version>4.10.67</carbon.kernel.version>
+        <carbon.kernel.version>4.12.17-SNAPSHOT</carbon.kernel.version>
         <carbon.kernel.feature.version>4.9.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.10.82</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.99-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,6 @@
                 <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>javax.cache.wso2</artifactId>


### PR DESCRIPTION
Related issue: https://github.com/wso2/product-is/issues/26225