### PR TITLE
[next] Add support for skipping email/mobile verification initiation by privileged users

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -1076,10 +1076,6 @@ public class IdentityRecoveryConstants {
 
         /* State maintained to skip triggering an SMS OTP verification, when the mobile number to be updated is included
         in the verifiedMobileNumbers claim, which has been already verified. */
-        SKIP_ON_ALREADY_VERIFIED_MOBILE_NUMBERS,
-
-        /* State maintained to skip triggering an SMS OTP verification when the update is initiated by an admin and
-        the corresponding connector configuration is enabled. */
-        SKIP_ON_ADMIN_UPDATE
+        SKIP_ON_ALREADY_VERIFIED_MOBILE_NUMBERS
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -729,6 +729,8 @@ public class IdentityRecoveryConstants {
         public static final String ENABLE_EMAIL_VERIFICATION_ON_UPDATE = "UserClaimUpdate.Email." +
                 "EnableVerification";
         public static final String ENABLE_EMAIL_OTP_ON_UPDATE = "UserClaimUpdate.Email.EnableEmailOTP";
+        public static final String ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER =
+                "UserClaimUpdate.Email.EnableSkipInitiatingVerificationByPrivilegedUser";
         public static final String EMAIL_VERIFICATION_ON_UPDATE_SEND_OTP_IN_EMAIL = "UserClaimUpdate.OTP.SendOTPInEmail";
         public static final String EMAIL_VERIFICATION_ON_UPDATE_USE_UPPERCASE_CHARACTERS_IN_OTP = "UserClaimUpdate." +
                 "OTP.UseUppercaseCharactersInOTP";
@@ -746,6 +748,8 @@ public class IdentityRecoveryConstants {
                 "VerificationCode.ExpiryTime";
         public static final String ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER = "UserClaimUpdate.MobileNumber." +
                 "EnableVerificationByPrivilegedUser";
+        public static final String ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER =
+                "UserClaimUpdate.MobileNumber.EnableSkipInitiatingVerificationByPrivilegedUser";
         public static final String USE_VERIFY_CLAIM_ON_UPDATE = "UserClaimUpdate.UseVerifyClaim";
         // This config enables the support to store multiple mobile numbers and email addresses per user.
         public static final String SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER =
@@ -1072,6 +1076,10 @@ public class IdentityRecoveryConstants {
 
         /* State maintained to skip triggering an SMS OTP verification, when the mobile number to be updated is included
         in the verifiedMobileNumbers claim, which has been already verified. */
-        SKIP_ON_ALREADY_VERIFIED_MOBILE_NUMBERS
+        SKIP_ON_ALREADY_VERIFIED_MOBILE_NUMBERS,
+
+        /* State maintained to skip triggering an SMS OTP verification when the update is initiated by an admin and
+        the corresponding connector configuration is enabled. */
+        SKIP_ON_ADMIN_UPDATE
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImpl.java
@@ -51,6 +51,8 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
     private static final String DEFAULT_EMAIL_VERIFICATION_ON_UPDATE_CODE_EXPIRY_TIME = "1440";
     private static final String DEFAULT_ENABLE_VALUE_FOR_EMAIL_VERIFICATION_ON_UPDATE = "false";
     private static final String DEFAULT_ENABLE_VALUE_FOR_EMAIL_OTP_ON_UPDATE = "false";
+    private static final String DEFAULT_ENABLE_VALUE_FOR_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER =
+            "false";
     private static final String DEFAULT_EMAIL_VERIFICATION_ON_UPDATE_SEND_OTP_IN_EMAIL = "false";
     private static final String DEFAULT_EMAIL_VERIFICATION_ON_UPDATE_USE_UPPERCASE_CHARACTERS_IN_OTP = "true";
     private static final String DEFAULT_EMAIL_VERIFICATION_ON_UPDATE_USE_LOWERCASE_CHARACTERS_IN_OTP = "true";
@@ -60,6 +62,8 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
     private static final String DEFAULT_MOBILE_NUM_VERIFICATION_ON_UPDATE_SMS_OTP_EXPIRY_TIME = "5";
     private static final String DEFAULT_ENABLE_VALUE_FOR_MOBILE_NUMBER_VERIFICATION_ON_UPDATE = "false";
     private static final String DEFAULT_MOBILE_NUM_VERIFICATION_BY_PRIVILEGED_USERS = "false";
+    private static final String DEFAULT_ENABLE_VALUE_FOR_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER =
+            "false";
     private static final String USER_CLAIM_UPDATE_ELEMENT = "UserClaimUpdate";
     private static final String ENABLE_ELEMENT = "Enable";
     private static final String SEND_OTP_IN_EMAIL_ELEMENT = "SendOTPInEmail";
@@ -74,10 +78,13 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
     private static final String EXPIRY_TIME_ELEMENT = "ExpiryTime";
     private static final String VERIFICATION_ON_UPDATE_ELEMENT = "VerificationOnUpdate";
     private static final String ENABLE_EMAIL_OTP_ON_UPDATE_ELEMENT = "EnableEmailOTP";
+    private static final String ENABLE_SKIP_INITIATING_VERIFICATION_BY_PRIVILEGED_USER =
+            "EnableSkipInitiatingVerificationByPrivilegedUser";
     private static final String NOTIFICATION_ON_UPDATE_ELEMENT = "NotificationOnUpdate";
     private static final String ENABLE_MOBILE_VERIFICATION_PRIVILEGED_USER = "EnableVerificationByPrivilegedUser";
     private static String enableEmailVerificationOnUpdateProperty = null;
     private static String enableEmailOTPOnUpdateProperty = null;
+    private static String enableSkipInitiatingEmailVerificationByPrivilegedUserProperty = null;
     private static String enableSendOTPInEmailProperty = null;
     private static String useUppercaseCharactersInOTPProperty = null;
     private static String useLowercaseCharactersInOTPProperty = null;
@@ -88,6 +95,7 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
     private static String enableMobileNumVerificationOnUpdateProperty = null;
     private static String mobileNumVerificationOnUpdateCodeExpiryProperty = null;
     private static String mobileNumVerificationByPrivilegedUsersProperty = null;
+    private static String enableSkipInitiatingMobileVerificationByPrivilegedUsersProperty = null;
 
     @Override
     public String getName() {
@@ -127,6 +135,9 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
                 "Enable user email verification on update");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_OTP_ON_UPDATE,
                 "Enable user email OTP verification on update");
+        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig
+                        .ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER,
+                "Enable skipping initiating email verification by privileged users");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_SEND_OTP_IN_EMAIL,
                 "Send OTP in e-mail");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_USE_UPPERCASE_CHARACTERS_IN_OTP,
@@ -145,6 +156,9 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
                 "Enable user mobile number verification on update");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER,
                 "Enable mobile number verification by privileged users");
+        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig
+                        .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER,
+                "Enable skipping initiating mobile verification by privileged users");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME,
                 "Mobile number verification on update SMS OTP expiry time");
         return nameMapping;
@@ -158,6 +172,10 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
                 "Trigger a verification notification when user's email address is updated.");
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_OTP_ON_UPDATE,
                 "Trigger an email OTP verification when user's email address is updated.");
+        descriptionMapping.put(
+                IdentityRecoveryConstants.ConnectorConfig
+                        .ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER,
+                "Skip initiating email verification when privileged users update email claims.");
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_SEND_OTP_IN_EMAIL,
                 "Enable to send OTP in verification e-mail instead of confirmation code.");
         descriptionMapping.put(
@@ -181,6 +199,10 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
                 "Validity time of the mobile number confirmation OTP in minutes.");
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER,
                 "Allow privileged users to initiate mobile number verification on update.");
+        descriptionMapping.put(
+                IdentityRecoveryConstants.ConnectorConfig
+                        .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER,
+                "Skip initiating mobile verification when privileged users update mobile claims.");
         return descriptionMapping;
     }
 
@@ -190,6 +212,8 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
         List<String> properties = new ArrayList<>();
         properties.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION_ON_UPDATE);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_OTP_ON_UPDATE);
+        properties.add(IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_SEND_OTP_IN_EMAIL);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_USE_UPPERCASE_CHARACTERS_IN_OTP);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_USE_LOWERCASE_CHARACTERS_IN_OTP);
@@ -200,6 +224,8 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
         properties.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_NUM_VERIFICATION_ON_UPDATE);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER);
+        properties.add(IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER);
         return properties.toArray(new String[0]);
     }
 
@@ -208,6 +234,8 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
 
         String enableEmailVerificationOnUpdate = DEFAULT_ENABLE_VALUE_FOR_EMAIL_VERIFICATION_ON_UPDATE;
         String enableEmailOTPOnUpdate = DEFAULT_ENABLE_VALUE_FOR_EMAIL_OTP_ON_UPDATE;
+        String enableSkipInitiatingEmailVerificationByPrivilegedUser =
+                DEFAULT_ENABLE_VALUE_FOR_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER;
         String enableSendOTPInEmail = DEFAULT_EMAIL_VERIFICATION_ON_UPDATE_SEND_OTP_IN_EMAIL;
         String useUppercaseCharactersInOTP = DEFAULT_EMAIL_VERIFICATION_ON_UPDATE_USE_UPPERCASE_CHARACTERS_IN_OTP;
         String useLowercaseCharactersInOTP = DEFAULT_EMAIL_VERIFICATION_ON_UPDATE_USE_LOWERCASE_CHARACTERS_IN_OTP;
@@ -218,6 +246,8 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
         String enableMobileNumVerificationOnUpdate = DEFAULT_ENABLE_VALUE_FOR_MOBILE_NUMBER_VERIFICATION_ON_UPDATE;
         String mobileNumVerificationOnUpdateCodeExpiry = DEFAULT_MOBILE_NUM_VERIFICATION_ON_UPDATE_SMS_OTP_EXPIRY_TIME;
         String mobileNumVerificationByPrivilegedUsers = DEFAULT_MOBILE_NUM_VERIFICATION_BY_PRIVILEGED_USERS;
+        String enableSkipInitiatingMobileVerificationByPrivilegedUser =
+                DEFAULT_ENABLE_VALUE_FOR_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER;
 
         loadConfigurations();
 
@@ -226,6 +256,10 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
         }
         if (StringUtils.isNotBlank(enableEmailOTPOnUpdateProperty)) {
             enableEmailOTPOnUpdate = enableEmailOTPOnUpdateProperty;
+        }
+        if (StringUtils.isNotBlank(enableSkipInitiatingEmailVerificationByPrivilegedUserProperty)) {
+            enableSkipInitiatingEmailVerificationByPrivilegedUser =
+                    enableSkipInitiatingEmailVerificationByPrivilegedUserProperty;
         }
         if (StringUtils.isNotEmpty(enableSendOTPInEmailProperty)) {
             enableSendOTPInEmail = enableSendOTPInEmailProperty;
@@ -257,12 +291,19 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
         if (StringUtils.isNotBlank(mobileNumVerificationByPrivilegedUsersProperty)) {
             mobileNumVerificationByPrivilegedUsers = mobileNumVerificationByPrivilegedUsersProperty;
         }
+        if (StringUtils.isNotBlank(enableSkipInitiatingMobileVerificationByPrivilegedUsersProperty)) {
+            enableSkipInitiatingMobileVerificationByPrivilegedUser =
+                    enableSkipInitiatingMobileVerificationByPrivilegedUsersProperty;
+        }
 
         Properties properties = new Properties();
         properties.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION_ON_UPDATE,
                 enableEmailVerificationOnUpdate);
         properties.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_OTP_ON_UPDATE,
                 enableEmailOTPOnUpdate);
+        properties.put(IdentityRecoveryConstants.ConnectorConfig
+                        .ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER,
+                enableSkipInitiatingEmailVerificationByPrivilegedUser);
         properties.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_SEND_OTP_IN_EMAIL,
                 enableSendOTPInEmail);
         properties.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_USE_UPPERCASE_CHARACTERS_IN_OTP,
@@ -283,6 +324,9 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
                 mobileNumVerificationOnUpdateCodeExpiry);
         properties.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER,
                 mobileNumVerificationByPrivilegedUsers);
+        properties.put(IdentityRecoveryConstants.ConnectorConfig
+                        .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER,
+                enableSkipInitiatingMobileVerificationByPrivilegedUser);
         return properties;
     }
 
@@ -335,6 +379,13 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
                         if (enableEmailOTPOnUpdate != null) {
                             enableEmailOTPOnUpdateProperty = enableEmailOTPOnUpdate.getText();
                         }
+                        OMElement enableSkipInitiatingEmailVerificationByPrivilegedUser = verificationOnUpdate
+                                .getFirstChildWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                                        ENABLE_SKIP_INITIATING_VERIFICATION_BY_PRIVILEGED_USER));
+                        if (enableSkipInitiatingEmailVerificationByPrivilegedUser != null) {
+                            enableSkipInitiatingEmailVerificationByPrivilegedUserProperty =
+                                    enableSkipInitiatingEmailVerificationByPrivilegedUser.getText();
+                        }
                         OMElement verificationCode = verificationOnUpdate.getFirstChildWithName(new QName
                                 (IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, VERIFICATION_CODE_ELEMENT));
                         if (verificationCode != null) {
@@ -360,6 +411,13 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
                                         ENABLE_MOBILE_VERIFICATION_PRIVILEGED_USER));
                         if (privilegeUserMobileVerification != null) {
                             mobileNumVerificationByPrivilegedUsersProperty = privilegeUserMobileVerification.getText();
+                        }
+                        OMElement enableSkipInitiatingMobileVerificationByPrivilegedUsers = verificationOnUpdate
+                                .getFirstChildWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                                        ENABLE_SKIP_INITIATING_VERIFICATION_BY_PRIVILEGED_USER));
+                        if (enableSkipInitiatingMobileVerificationByPrivilegedUsers != null) {
+                            enableSkipInitiatingMobileVerificationByPrivilegedUsersProperty =
+                                    enableSkipInitiatingMobileVerificationByPrivilegedUsers.getText();
                         }
                         OMElement verificationCode = verificationOnUpdate.getFirstChildWithName(new QName
                                 (IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, VERIFICATION_CODE_ELEMENT));
@@ -397,6 +455,10 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_OTP_ON_UPDATE,
                 getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
+        meta.put(IdentityRecoveryConstants.ConnectorConfig
+                        .ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
         meta.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_SEND_OTP_IN_EMAIL,
                 getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
@@ -423,6 +485,10 @@ public class UserClaimUpdateConfigImpl implements IdentityConnectorConfig {
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME,
                 getPropertyObject(IdentityMgtConstants.DataTypes.INTEGER.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig
+                        .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         return meta;
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
@@ -28,6 +28,8 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Flow;
 import org.wso2.carbon.identity.core.handler.InitConfig;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventClientException;
@@ -622,8 +624,54 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
      */
     private boolean isMobileVerificationOnUpdateEnabled(String userTenantDomain) throws IdentityEventException {
 
+        boolean isMobileVerificationEnabled = Boolean.parseBoolean(Utils.getConnectorConfig(
+                IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_NUM_VERIFICATION_ON_UPDATE,
+                userTenantDomain));
+        if (log.isDebugEnabled()) {
+            log.debug("Mobile number verification on update config value is: " + isMobileVerificationEnabled +
+                    " for tenant: " + userTenantDomain);
+        }
+
+        if (!isMobileVerificationEnabled) {
+            return false;
+        }
+
+        boolean isAdminInitiatedFlow = isAdminInitiatedFlow();
+        boolean isSkipInitiatingVerificationForPrivilegedUserEnabled = isSkipInitiatingMobileVerificationByPrivilegedUserEnabled(userTenantDomain);
+        if (log.isDebugEnabled()) {
+            log.debug("Is admin-initiated flow: " + isAdminInitiatedFlow +
+                    " Privileged-user skip-initiation config value is: " + isSkipInitiatingVerificationForPrivilegedUserEnabled + ".");
+        }
+
+        return !(isAdminInitiatedFlow && isSkipInitiatingVerificationForPrivilegedUserEnabled);
+    }
+
+    /**
+     * Check whether skipping mobile verification initiation is enabled for privileged-user initiated updates.
+     *
+     * @param tenantDomain Tenant domain.
+     * @return true if skipping verification initiation is enabled, false otherwise.
+     * @throws IdentityEventException If an error occurs while reading connector configuration.
+     */
+    private boolean isSkipInitiatingMobileVerificationByPrivilegedUserEnabled(String tenantDomain)
+            throws IdentityEventException {
+
         return Boolean.parseBoolean(Utils.getConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
-                .ENABLE_MOBILE_NUM_VERIFICATION_ON_UPDATE, userTenantDomain));
+                .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER, tenantDomain));
+    }
+
+    /**
+     * Check whether the current flow is initiated by an admin persona.
+     *
+     * @return true if the current flow exists and the initiating persona is ADMIN, false otherwise.
+     */
+    private boolean isAdminInitiatedFlow() {
+
+        Flow currentFlow = IdentityContext.getThreadLocalIdentityContext().getCurrentFlow();
+        if (currentFlow == null || currentFlow.getInitiatingPersona() == null) {
+            return false;
+        }
+        return Flow.InitiatingPersona.ADMIN.equals(currentFlow.getInitiatingPersona());
     }
 
     /**

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
@@ -646,9 +646,11 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
             log.debug("Is admin-initiated flow: " + isAdminInitiatedFlow);
         }
         if (isAdminInitiatedFlow) {
-            boolean isSkipInitiatingVerificationForPrivilegedUserEnabled = isSkipInitiatingMobileVerificationByPrivilegedUserEnabled(userTenantDomain);
+            boolean isSkipInitiatingVerificationForPrivilegedUserEnabled =
+                    isSkipInitiatingMobileVerificationByPrivilegedUserEnabled(userTenantDomain);
             if (log.isDebugEnabled()) {
-                log.debug("Admin-initiated flow to update mobile number. Privileged-user skip-initiation config value is: " +
+                log.debug("Admin-initiated flow to update mobile number. " +
+                        "Privileged-user skip-initiation config value is: " +
                         isSkipInitiatingVerificationForPrivilegedUserEnabled);
             }
             return !isSkipInitiatingVerificationForPrivilegedUserEnabled;

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
@@ -616,11 +616,17 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
     }
 
     /**
-     * Check whether mobile verification on update feature is enabled via connector configuration.
+     * Determine whether mobile verification on update should run for the current context.
+     * <p>
+     * Verification is enabled only when:
+     * <ul>
+     *     <li>The tenant-level {@code EnableVerification} config is enabled.</li>
+     *     <li>The request is not an admin-initiated flow with privileged-user skip enabled.</li>
+     * </ul>
      *
      * @param userTenantDomain Tenant domain of the user.
-     * @return True if the feature is enabled, false otherwise.
-     * @throws IdentityEventException
+     * @return {@code true} if mobile verification on update should be triggered; {@code false} otherwise.
+     * @throws IdentityEventException If an error occurs while reading connector configuration.
      */
     private boolean isMobileVerificationOnUpdateEnabled(String userTenantDomain) throws IdentityEventException {
 
@@ -631,19 +637,23 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
             log.debug("Mobile number verification on update config value is: " + isMobileVerificationEnabled +
                     " for tenant: " + userTenantDomain);
         }
-
         if (!isMobileVerificationEnabled) {
             return false;
         }
 
         boolean isAdminInitiatedFlow = isAdminInitiatedFlow();
-        boolean isSkipInitiatingVerificationForPrivilegedUserEnabled = isSkipInitiatingMobileVerificationByPrivilegedUserEnabled(userTenantDomain);
         if (log.isDebugEnabled()) {
-            log.debug("Is admin-initiated flow: " + isAdminInitiatedFlow +
-                    " Privileged-user skip-initiation config value is: " + isSkipInitiatingVerificationForPrivilegedUserEnabled + ".");
+            log.debug("Is admin-initiated flow: " + isAdminInitiatedFlow);
         }
-
-        return !(isAdminInitiatedFlow && isSkipInitiatingVerificationForPrivilegedUserEnabled);
+        if (isAdminInitiatedFlow) {
+            boolean isSkipInitiatingVerificationForPrivilegedUserEnabled = isSkipInitiatingMobileVerificationByPrivilegedUserEnabled(userTenantDomain);
+            if (log.isDebugEnabled()) {
+                log.debug("Admin-initiated flow to update mobile number. Privileged-user skip-initiation config value is: " +
+                        isSkipInitiatingVerificationForPrivilegedUserEnabled);
+            }
+            return !isSkipInitiatingVerificationForPrivilegedUserEnabled;
+        }
+        return true;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -272,16 +272,41 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
         }
     }
 
+    /**
+     * Determine whether email verification on update should run for the current context.
+     * <p>
+     * Verification is enabled only when:
+     * <ul>
+     *     <li>The tenant-level {@code EnableVerification} config is enabled.</li>
+     *     <li>The request is not an admin-initiated flow with privileged-user skip enabled.</li>
+     * </ul>
+     *
+     * @param tenantDomain Tenant domain.
+     * @return {@code true} if email verification on update should be triggered; {@code false} otherwise.
+     * @throws IdentityEventException If an error occurs while reading connector configuration.
+     */
     private boolean isEmailVerificationOnUpdateEnabled(String tenantDomain) throws IdentityEventException {
 
         boolean enableEmailVerificationOnUpdate = Boolean.parseBoolean(Utils.getConnectorConfig(
                 IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION_ON_UPDATE, tenantDomain));
 
+        if (log.isDebugEnabled()) {
+            log.debug("Email verification on update config value is: " + enableEmailVerificationOnUpdate +
+                    " for tenant: " + tenantDomain);
+        }
+
         if (!enableEmailVerificationOnUpdate) {
             return false;
         }
 
-        return !(isAdminInitiatedFlow() && isSkipInitiatingEmailVerificationByPrivilegedUserEnabled(tenantDomain));
+        boolean adminInitiatedFlow = isAdminInitiatedFlow();
+        boolean skipInitiatingVerificationForPrivilegedUser = isSkipInitiatingEmailVerificationByPrivilegedUserEnabled(tenantDomain);
+        if (log.isDebugEnabled()) {
+            log.debug("Current flow is admin-initiated: " + adminInitiatedFlow +
+                    "Privileged-user skip-initiation config value is: " + skipInitiatingVerificationForPrivilegedUser + ".");
+        }
+
+        return !(adminInitiatedFlow && skipInitiatingVerificationForPrivilegedUser);
     }
 
     private boolean isEmailOTPOnUpdateEnabled(String tenantDomain) throws IdentityEventException {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -287,26 +287,26 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
      */
     private boolean isEmailVerificationOnUpdateEnabled(String tenantDomain) throws IdentityEventException {
 
-        boolean enableEmailVerificationOnUpdate = Boolean.parseBoolean(Utils.getConnectorConfig(
+        boolean isEmailVerificationEnabled = Boolean.parseBoolean(Utils.getConnectorConfig(
                 IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION_ON_UPDATE, tenantDomain));
 
         if (log.isDebugEnabled()) {
-            log.debug("Email verification on update config value is: " + enableEmailVerificationOnUpdate +
+            log.debug("Email verification on update config value is: " + isEmailVerificationEnabled +
                     " for tenant: " + tenantDomain);
         }
 
-        if (!enableEmailVerificationOnUpdate) {
+        if (!isEmailVerificationEnabled) {
             return false;
         }
 
-        boolean adminInitiatedFlow = isAdminInitiatedFlow();
-        boolean skipInitiatingVerificationForPrivilegedUser = isSkipInitiatingEmailVerificationByPrivilegedUserEnabled(tenantDomain);
+        boolean isAdminInitiatedFlow = isAdminInitiatedFlow();
+        boolean isSkipInitiatingVerificationForPrivilegedUserEnabled = isSkipInitiatingEmailVerificationByPrivilegedUserEnabled(tenantDomain);
         if (log.isDebugEnabled()) {
-            log.debug("Current flow is admin-initiated: " + adminInitiatedFlow +
-                    "Privileged-user skip-initiation config value is: " + skipInitiatingVerificationForPrivilegedUser + ".");
+            log.debug("Is admin-initiated flow: " + isAdminInitiatedFlow +
+                    " Privileged-user skip-initiation config value is: " + isSkipInitiatingVerificationForPrivilegedUserEnabled + ".");
         }
 
-        return !(adminInitiatedFlow && skipInitiatingVerificationForPrivilegedUser);
+        return !(isAdminInitiatedFlow && isSkipInitiatingVerificationForPrivilegedUserEnabled);
     }
 
     private boolean isEmailOTPOnUpdateEnabled(String tenantDomain) throws IdentityEventException {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -294,19 +294,24 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
             log.debug("Email verification on update config value is: " + isEmailVerificationEnabled +
                     " for tenant: " + tenantDomain);
         }
-
         if (!isEmailVerificationEnabled) {
             return false;
         }
 
         boolean isAdminInitiatedFlow = isAdminInitiatedFlow();
-        boolean isSkipInitiatingVerificationForPrivilegedUserEnabled = isSkipInitiatingEmailVerificationByPrivilegedUserEnabled(tenantDomain);
         if (log.isDebugEnabled()) {
-            log.debug("Is admin-initiated flow: " + isAdminInitiatedFlow +
-                    " Privileged-user skip-initiation config value is: " + isSkipInitiatingVerificationForPrivilegedUserEnabled + ".");
+            log.debug("Is admin-initiated flow: " + isAdminInitiatedFlow);
         }
 
-        return !(isAdminInitiatedFlow && isSkipInitiatingVerificationForPrivilegedUserEnabled);
+        if (isAdminInitiatedFlow) {
+            boolean isSkipInitiatingVerificationForPrivilegedUserEnabled = isSkipInitiatingEmailVerificationByPrivilegedUserEnabled(tenantDomain);
+            if (log.isDebugEnabled()) {
+                log.debug("Admin-initiated flow to update email. Privileged-user skip-initiation config value is: " +
+                        isSkipInitiatingVerificationForPrivilegedUserEnabled + ".");
+            }
+            return !isSkipInitiatingVerificationForPrivilegedUserEnabled;
+        }
+        return true;
     }
 
     private boolean isEmailOTPOnUpdateEnabled(String tenantDomain) throws IdentityEventException {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
+import org.wso2.carbon.identity.core.context.IdentityContext;
 import org.wso2.carbon.identity.core.context.model.Flow;
 import org.wso2.carbon.identity.core.handler.InitConfig;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -273,14 +274,50 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
 
     private boolean isEmailVerificationOnUpdateEnabled(String tenantDomain) throws IdentityEventException {
 
-        return Boolean.parseBoolean(Utils.getConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
-                .ENABLE_EMAIL_VERIFICATION_ON_UPDATE, tenantDomain));
+        boolean enableEmailVerificationOnUpdate = Boolean.parseBoolean(Utils.getConnectorConfig(
+                IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION_ON_UPDATE, tenantDomain));
+
+        if (!enableEmailVerificationOnUpdate) {
+            return false;
+        }
+
+        return !(isAdminInitiatedFlow() && isSkipInitiatingEmailVerificationByPrivilegedUserEnabled(tenantDomain));
     }
 
     private boolean isEmailOTPOnUpdateEnabled(String tenantDomain) throws IdentityEventException {
 
         return Boolean.parseBoolean(Utils.getConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
                 .ENABLE_EMAIL_OTP_ON_UPDATE, tenantDomain));
+    }
+
+    /**
+     * Check whether skipping email verification initiation is enabled for privileged-user initiated updates.
+     *
+     * @param tenantDomain Tenant domain.
+     * @return true if skipping verification initiation is enabled, false otherwise.
+     * @throws IdentityEventException If an error occurs while reading connector configuration.
+     */
+    private boolean isSkipInitiatingEmailVerificationByPrivilegedUserEnabled(String tenantDomain)
+            throws IdentityEventException {
+
+        return Boolean.parseBoolean(Utils.getConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER, tenantDomain));
+    }
+
+    /**
+     * Check whether the current flow is initiated by an admin persona.
+     *
+     * @return true if the current flow exists and the initiating persona is ADMIN, false otherwise.
+     */
+    private boolean isAdminInitiatedFlow() {
+
+        Flow currentFlow = IdentityContext.getThreadLocalIdentityContext().getCurrentFlow();
+        if (currentFlow == null || currentFlow.getInitiatingPersona() == null) {
+            return false;
+        }
+
+        Flow.InitiatingPersona initiatingPersona = currentFlow.getInitiatingPersona();
+        return Flow.InitiatingPersona.ADMIN.equals(initiatingPersona);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -304,7 +304,8 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
         }
 
         if (isAdminInitiatedFlow) {
-            boolean isSkipInitiatingVerificationForPrivilegedUserEnabled = isSkipInitiatingEmailVerificationByPrivilegedUserEnabled(tenantDomain);
+            boolean isSkipInitiatingVerificationForPrivilegedUserEnabled
+                    = isSkipInitiatingEmailVerificationByPrivilegedUserEnabled(tenantDomain);
             if (log.isDebugEnabled()) {
                 log.debug("Admin-initiated flow to update email. Privileged-user skip-initiation config value is: " +
                         isSkipInitiatingVerificationForPrivilegedUserEnabled + ".");

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/UserClaimUpdateConfigImplTest.java
@@ -64,6 +64,8 @@ public class UserClaimUpdateConfigImplTest {
     private static final String VERIFICATION_CODE_ELEMENT = "VerificationCode";
     private static final String EXPIRY_TIME_ELEMENT = "ExpiryTime";
     private static final String VERIFICATION_ON_UPDATE_ELEMENT = "VerificationOnUpdate";
+    private static final String ENABLE_SKIP_INITIATING_VERIFICATION_BY_PRIVILEGED_USER_ELEMENT =
+            "EnableSkipInitiatingVerificationByPrivilegedUser";
     private static final String ENABLE_MULTIPLE_EMAILS_AND_MOBILE_NUMBERS_ELEMENT =
             "EnableMultipleEmailsAndMobileNumbers";
     private MockedStatic<IdentityConfigParser> mockedIdentityConfigParser;
@@ -124,6 +126,9 @@ public class UserClaimUpdateConfigImplTest {
                 "Enable user email verification on update");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_OTP_ON_UPDATE,
                 "Enable user email OTP verification on update");
+        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.
+                        ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER,
+                "Enable skipping initiating email verification by privileged users");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_SEND_OTP_IN_EMAIL,
                 "Send OTP in e-mail");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_USE_UPPERCASE_CHARACTERS_IN_OTP,
@@ -144,6 +149,9 @@ public class UserClaimUpdateConfigImplTest {
                 "Mobile number verification on update SMS OTP expiry time");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER,
                 "Enable mobile number verification by privileged users");
+        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig
+                        .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER,
+                "Enable skipping initiating mobile verification by privileged users");
         Map<String, String> nameMapping = userClaimUpdateConfig.getPropertyNameMapping();
         assertEquals(nameMapping, nameMappingExpected, "Maps are not equal.");
     }
@@ -156,6 +164,9 @@ public class UserClaimUpdateConfigImplTest {
                 "Trigger a verification notification when user's email address is updated.");
         descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_OTP_ON_UPDATE,
                 "Trigger an email OTP verification when user's email address is updated.");
+        descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.
+                        ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER,
+                "Skip initiating email verification when privileged users update email claims.");
         descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_SEND_OTP_IN_EMAIL,
                 "Enable to send OTP in verification e-mail instead of confirmation code.");
         descriptionMappingExpected.put(
@@ -180,6 +191,10 @@ public class UserClaimUpdateConfigImplTest {
                 "Validity time of the mobile number confirmation OTP in minutes.");
         descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER,
                 "Allow privileged users to initiate mobile number verification on update.");
+        descriptionMappingExpected.put(
+                IdentityRecoveryConstants.ConnectorConfig
+                        .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER,
+                "Skip initiating mobile verification when privileged users update mobile claims.");
         Map<String, String> descriptionMapping = userClaimUpdateConfig.getPropertyDescriptionMapping();
         assertEquals(descriptionMapping, descriptionMappingExpected, "Maps are not equal.");
     }
@@ -190,6 +205,8 @@ public class UserClaimUpdateConfigImplTest {
         List<String> propertiesExpected = new ArrayList<>();
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION_ON_UPDATE);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_OTP_ON_UPDATE);
+        propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_SEND_OTP_IN_EMAIL);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_USE_UPPERCASE_CHARACTERS_IN_OTP);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_ON_UPDATE_USE_LOWERCASE_CHARACTERS_IN_OTP);
@@ -200,6 +217,8 @@ public class UserClaimUpdateConfigImplTest {
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_NUM_VERIFICATION_ON_UPDATE);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER);
+        propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER);
         String[] propertiesArrayExpected = propertiesExpected.toArray(new String[0]);
 
         String[] properties = userClaimUpdateConfig.getPropertyNames();
@@ -240,11 +259,15 @@ public class UserClaimUpdateConfigImplTest {
         assertNotNull(defaultPropertyValues.getProperty(IdentityRecoveryConstants.ConnectorConfig
                 .ENABLE_EMAIL_OTP_ON_UPDATE));
         assertNotNull(defaultPropertyValues.getProperty(IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER));
+        assertNotNull(defaultPropertyValues.getProperty(IdentityRecoveryConstants.ConnectorConfig
                 .EMAIL_VERIFICATION_ON_UPDATE_EXPIRY_TIME));
         assertNotNull(defaultPropertyValues.getProperty(IdentityRecoveryConstants.ConnectorConfig
                 .ENABLE_MOBILE_NUM_VERIFICATION_ON_UPDATE));
         assertNotNull(defaultPropertyValues.getProperty(IdentityRecoveryConstants.ConnectorConfig
                 .MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME));
+        assertNotNull(defaultPropertyValues.getProperty(IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER));
     }
 
     @Test
@@ -252,6 +275,8 @@ public class UserClaimUpdateConfigImplTest {
 
         String[] propertyNames = new String[]{IdentityRecoveryConstants.ConnectorConfig
                 .ENABLE_EMAIL_VERIFICATION_ON_UPDATE, IdentityRecoveryConstants.ConnectorConfig.
+                ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER,
+                IdentityRecoveryConstants.ConnectorConfig.
                 EMAIL_VERIFICATION_ON_UPDATE_SEND_OTP_IN_EMAIL, IdentityRecoveryConstants.ConnectorConfig.
                 EMAIL_VERIFICATION_ON_UPDATE_USE_UPPERCASE_CHARACTERS_IN_OTP, IdentityRecoveryConstants.ConnectorConfig.
                 EMAIL_VERIFICATION_ON_UPDATE_USE_LOWERCASE_CHARACTERS_IN_OTP, IdentityRecoveryConstants.ConnectorConfig.
@@ -259,7 +284,8 @@ public class UserClaimUpdateConfigImplTest {
                 EMAIL_VERIFICATION_ON_UPDATE_OTP_LENGTH, IdentityRecoveryConstants.ConnectorConfig
                 .EMAIL_VERIFICATION_ON_UPDATE_EXPIRY_TIME, IdentityRecoveryConstants.ConnectorConfig
                 .ENABLE_MOBILE_NUM_VERIFICATION_ON_UPDATE, IdentityRecoveryConstants.ConnectorConfig
-                .MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME, "testproperty"};
+                .MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME, IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER, "testproperty"};
 
         IdentityConfigParser mockConfigParser = mock(IdentityConfigParser.class);
         mockedIdentityConfigParser.when(IdentityConfigParser::getInstance).thenReturn(mockConfigParser);
@@ -270,9 +296,99 @@ public class UserClaimUpdateConfigImplTest {
     }
 
     @Test
+    public void testGetDefaultPropertyValuesWithSkipInitiatingEmailVerificationByPrivilegedUserFromIdentityXML()
+            throws IdentityGovernanceException {
+
+        IdentityConfigParser mockConfigParser = mock(IdentityConfigParser.class);
+        mockedIdentityConfigParser.when(IdentityConfigParser::getInstance).thenReturn(mockConfigParser);
+
+        OMElement userClaimUpdateElement = mock(OMElement.class);
+        OMElement emailClaimElement = mock(OMElement.class);
+        OMElement verificationOnUpdateElement = mock(OMElement.class);
+        OMElement enableElement = mock(OMElement.class);
+        OMElement enableSkipInitiatingVerificationByPrivilegedUserElement = mock(OMElement.class);
+        OMElement verificationCodeElement = mock(OMElement.class);
+        OMElement expiryTimeElement = mock(OMElement.class);
+
+        when(mockConfigParser.getConfigElement(USER_CLAIM_UPDATE_ELEMENT)).thenReturn(userClaimUpdateElement);
+        when(userClaimUpdateElement.getChildrenWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                CLAIM_ELEMENT))).thenReturn(List.of(emailClaimElement).iterator());
+        when(emailClaimElement.getAttributeValue(new QName(CLAIM_URI)))
+                .thenReturn(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM);
+        when(emailClaimElement.getFirstChildWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                VERIFICATION_ON_UPDATE_ELEMENT))).thenReturn(verificationOnUpdateElement);
+
+        when(verificationOnUpdateElement.getFirstChildWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                ENABLE_ELEMENT))).thenReturn(enableElement);
+        when(enableElement.getText()).thenReturn("true");
+        when(verificationOnUpdateElement.getFirstChildWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                ENABLE_SKIP_INITIATING_VERIFICATION_BY_PRIVILEGED_USER_ELEMENT)))
+                .thenReturn(enableSkipInitiatingVerificationByPrivilegedUserElement);
+        when(enableSkipInitiatingVerificationByPrivilegedUserElement.getText()).thenReturn("true");
+
+        when(verificationOnUpdateElement.getFirstChildWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                VERIFICATION_CODE_ELEMENT))).thenReturn(verificationCodeElement);
+        when(verificationCodeElement.getFirstChildWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                EXPIRY_TIME_ELEMENT))).thenReturn(expiryTimeElement);
+        when(expiryTimeElement.getText()).thenReturn("1440");
+
+        Properties defaultPropertyValues = userClaimUpdateConfig.getDefaultPropertyValues(TENANT_DOMAIN);
+        assertEquals(defaultPropertyValues.getProperty(IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER), "true");
+    }
+
+    @Test
+    public void testGetDefaultPropertyValuesWithSkipInitiatingMobileVerificationByPrivilegedUserFromIdentityXML()
+            throws IdentityGovernanceException {
+
+        IdentityConfigParser mockConfigParser = mock(IdentityConfigParser.class);
+        mockedIdentityConfigParser.when(IdentityConfigParser::getInstance).thenReturn(mockConfigParser);
+
+        OMElement userClaimUpdateElement = mock(OMElement.class);
+        OMElement mobileClaimElement = mock(OMElement.class);
+        OMElement verificationOnUpdateElement = mock(OMElement.class);
+        OMElement enableElement = mock(OMElement.class);
+        OMElement enableVerificationByPrivilegedUserElement = mock(OMElement.class);
+        OMElement enableSkipInitiatingVerificationByPrivilegedUserElement = mock(OMElement.class);
+        OMElement verificationCodeElement = mock(OMElement.class);
+        OMElement expiryTimeElement = mock(OMElement.class);
+
+        when(mockConfigParser.getConfigElement(USER_CLAIM_UPDATE_ELEMENT)).thenReturn(userClaimUpdateElement);
+        when(userClaimUpdateElement.getChildrenWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                CLAIM_ELEMENT))).thenReturn(List.of(mobileClaimElement).iterator());
+        when(mobileClaimElement.getAttributeValue(new QName(CLAIM_URI)))
+                .thenReturn(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM);
+        when(mobileClaimElement.getFirstChildWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                VERIFICATION_ON_UPDATE_ELEMENT))).thenReturn(verificationOnUpdateElement);
+
+        when(verificationOnUpdateElement.getFirstChildWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                ENABLE_ELEMENT))).thenReturn(enableElement);
+        when(enableElement.getText()).thenReturn("true");
+        when(verificationOnUpdateElement.getFirstChildWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                "EnableVerificationByPrivilegedUser"))).thenReturn(enableVerificationByPrivilegedUserElement);
+        when(enableVerificationByPrivilegedUserElement.getText()).thenReturn("false");
+        when(verificationOnUpdateElement.getFirstChildWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                ENABLE_SKIP_INITIATING_VERIFICATION_BY_PRIVILEGED_USER_ELEMENT)))
+                .thenReturn(enableSkipInitiatingVerificationByPrivilegedUserElement);
+        when(enableSkipInitiatingVerificationByPrivilegedUserElement.getText()).thenReturn("true");
+
+        when(verificationOnUpdateElement.getFirstChildWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                VERIFICATION_CODE_ELEMENT))).thenReturn(verificationCodeElement);
+        when(verificationCodeElement.getFirstChildWithName(new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE,
+                EXPIRY_TIME_ELEMENT))).thenReturn(expiryTimeElement);
+        when(expiryTimeElement.getText()).thenReturn("5");
+
+        Properties defaultPropertyValues = userClaimUpdateConfig.getDefaultPropertyValues(TENANT_DOMAIN);
+        assertEquals(defaultPropertyValues.getProperty(IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER), "true");
+    }
+
+    @Test
     public void testGetMetaData() {
 
         Map<String, Property> metaData = userClaimUpdateConfig.getMetaData();
-        Assert.assertEquals(metaData.size(), 11);
+        Assert.assertEquals(metaData.size(), 13);
+        assertNotNull(metaData.get(IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER));
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandlerTest.java
@@ -668,7 +668,8 @@ public class MobileNumberVerificationHandlerTest {
         Map<String, String> userClaims = getUserClaimsFromEvent(event);
         Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM));
         Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM), NEW_MOBILE_NUMBER);
-        Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.MOBILE_VERIFIED_CLAIM), Boolean.TRUE.toString());
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.MOBILE_VERIFIED_CLAIM));
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.VERIFY_MOBILE_CLAIM));
     }
 
     @Test
@@ -688,14 +689,10 @@ public class MobileNumberVerificationHandlerTest {
         mobileNumberVerificationHandler.handleEvent(event);
         Map<String, String> userClaims = getUserClaimsFromEvent(event);
         Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM));
-        Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM),
-                EXISTING_NUMBER_1 + "," + NEW_MOBILE_NUMBER);
-        Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM),
-                NEW_MOBILE_NUMBER);
-        Assert.assertNotEquals(userClaims.get(IdentityRecoveryConstants.MOBILE_VERIFIED_CLAIM),
-                Boolean.TRUE.toString());
-        mockedUtils.verify(() -> Utils.setThreadLocalToSkipSendingSmsOtpVerificationOnUpdate(
-                IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates.SKIP_ON_ADMIN_UPDATE.toString()));
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM));
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM));
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.MOBILE_VERIFIED_CLAIM));
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.VERIFY_MOBILE_CLAIM));
     }
 
     @Test
@@ -716,20 +713,6 @@ public class MobileNumberVerificationHandlerTest {
         Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM),
                 NEW_MOBILE_NUMBER);
         Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM));
-    }
-
-    @Test
-    public void testHandleEventPostSetUserClaimsSkipVerificationOnAdminUpdateState()
-            throws IdentityEventException {
-
-        Event event = createEvent(IdentityEventConstants.Event.POST_SET_USER_CLAIMS, null,
-                null, null, null);
-        mockUtilMethods(true, true, false);
-        mockedUtils.when(Utils::getThreadLocalToSkipSendingSmsOtpVerificationOnUpdate).thenReturn(
-                IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates.SKIP_ON_ADMIN_UPDATE.toString());
-
-        mobileNumberVerificationHandler.handleEvent(event);
-        verify(identityEventService, never()).handleEvent(any());
     }
 
     private void mockExistingPrimaryMobileNumber(String mobileNumber) throws UserStoreException {

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandlerTest.java
@@ -28,6 +28,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Flow;
 import org.wso2.carbon.identity.event.IdentityEventClientException;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
@@ -154,6 +156,9 @@ public class MobileNumberVerificationHandlerTest {
     @AfterMethod
     public void tearDown() {
 
+        if (IdentityContext.getThreadLocalIdentityContext().getCurrentFlow() != null) {
+            IdentityContext.getThreadLocalIdentityContext().exitFlow();
+        }
         mockedJDBCRecoveryDataStore.close();
         mockedUtils.close();
         mockedIdentityRecoveryServiceDataHolder.close();
@@ -161,7 +166,7 @@ public class MobileNumberVerificationHandlerTest {
         Utils.unsetThreadLocalIsOnlyVerifiedEmailAddressesUpdated();
         Utils.unsetThreadLocalIsOnlyVerifiedMobileNumbersUpdated();
         Utils.unsetThreadLocalToSkipSendingEmailVerificationOnUpdate();
-        Utils.unsetThreadLocalIsOnlyVerifiedMobileNumbersUpdated();
+        Utils.unsetThreadLocalToSkipSendingSmsOtpVerificationOnUpdate();
     }
 
     @Test
@@ -647,6 +652,86 @@ public class MobileNumberVerificationHandlerTest {
                 "'phoneVerified' claim should be cleared (empty string) when primary mobile is set to empty string.");
     }
 
+    @Test
+    public void testHandleEventPreSetUserClaimsSkipVerificationOnAdminPrimaryMobileUpdate()
+            throws IdentityEventException, UserStoreException {
+
+        Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
+                null, null, NEW_MOBILE_NUMBER);
+        mockUtilMethods(true, false, false);
+        mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER, true);
+        mockExistingPrimaryMobileNumber(EXISTING_NUMBER_1);
+        enterAdminInitiatedFlow();
+
+        mobileNumberVerificationHandler.handleEvent(event);
+        Map<String, String> userClaims = getUserClaimsFromEvent(event);
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM));
+        Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM), NEW_MOBILE_NUMBER);
+        Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.MOBILE_VERIFIED_CLAIM), Boolean.TRUE.toString());
+    }
+
+    @Test
+    public void testHandleEventPreSetUserClaimsSkipVerificationOnAdminVerifiedMobileListUpdate()
+            throws IdentityEventException, UserStoreException {
+
+        Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
+                NEW_MOBILE_NUMBER, null, null);
+        mockUtilMethods(true, true, false);
+        mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER, true);
+        mockExistingPrimaryMobileNumber(EXISTING_NUMBER_1);
+        mockExistingNumbersList(new ArrayList<>(Arrays.asList(EXISTING_NUMBER_1)));
+        mockExistingVerifiedNumbersList(new ArrayList<>(Arrays.asList(EXISTING_NUMBER_1)));
+        enterAdminInitiatedFlow();
+
+        mobileNumberVerificationHandler.handleEvent(event);
+        Map<String, String> userClaims = getUserClaimsFromEvent(event);
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM));
+        Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM),
+                EXISTING_NUMBER_1 + "," + NEW_MOBILE_NUMBER);
+        Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM),
+                NEW_MOBILE_NUMBER);
+        Assert.assertNotEquals(userClaims.get(IdentityRecoveryConstants.MOBILE_VERIFIED_CLAIM),
+                Boolean.TRUE.toString());
+        mockedUtils.verify(() -> Utils.setThreadLocalToSkipSendingSmsOtpVerificationOnUpdate(
+                IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates.SKIP_ON_ADMIN_UPDATE.toString()));
+    }
+
+    @Test
+    public void testHandleEventPreSetUserClaimsDoesNotSkipVerificationOnUserPersona()
+            throws IdentityEventException, UserStoreException {
+
+        Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
+                null, null, NEW_MOBILE_NUMBER);
+        mockUtilMethods(true, false, false);
+        mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER, true);
+        mockVerificationPendingMobileNumber();
+        mockExistingPrimaryMobileNumber(EXISTING_NUMBER_1);
+        enterUserInitiatedFlow();
+
+        mobileNumberVerificationHandler.handleEvent(event);
+        Map<String, String> userClaims = getUserClaimsFromEvent(event);
+        Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM),
+                NEW_MOBILE_NUMBER);
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM));
+    }
+
+    @Test
+    public void testHandleEventPostSetUserClaimsSkipVerificationOnAdminUpdateState()
+            throws IdentityEventException {
+
+        Event event = createEvent(IdentityEventConstants.Event.POST_SET_USER_CLAIMS, null,
+                null, null, null);
+        mockUtilMethods(true, true, false);
+        mockedUtils.when(Utils::getThreadLocalToSkipSendingSmsOtpVerificationOnUpdate).thenReturn(
+                IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates.SKIP_ON_ADMIN_UPDATE.toString());
+
+        mobileNumberVerificationHandler.handleEvent(event);
+        verify(identityEventService, never()).handleEvent(any());
+    }
+
     private void mockExistingPrimaryMobileNumber(String mobileNumber) throws UserStoreException {
 
         when(userStoreManager.getUserClaimValue(anyString(),
@@ -687,10 +772,36 @@ public class MobileNumberVerificationHandlerTest {
         mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
                 .thenReturn(multiAttributeEnabled);
         mockedUtils.when(Utils::isUseVerifyClaimEnabled).thenReturn(useVerifyClaimEnabled);
-        mockedUtils.when(() -> Utils.getConnectorConfig(
-                        eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_NUM_VERIFICATION_ON_UPDATE),
-                        anyString()))
-                .thenReturn(String.valueOf(mobileVerificationEnabled));
+        mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_NUM_VERIFICATION_ON_UPDATE,
+                mobileVerificationEnabled);
+        mockGetConnectorConfig(
+                IdentityRecoveryConstants.ConnectorConfig
+                        .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER,
+                false);
+    }
+
+    private void mockGetConnectorConfig(String connectorConfig, boolean value) {
+
+        mockedUtils.when(() -> Utils.getConnectorConfig(eq(connectorConfig), anyString()))
+                .thenReturn(String.valueOf(value));
+    }
+
+    private void enterAdminInitiatedFlow() {
+
+        Flow flow = new Flow.Builder()
+                .name(Flow.Name.PROFILE_UPDATE)
+                .initiatingPersona(Flow.InitiatingPersona.ADMIN)
+                .build();
+        IdentityContext.getThreadLocalIdentityContext().enterFlow(flow);
+    }
+
+    private void enterUserInitiatedFlow() {
+
+        Flow flow = new Flow.Builder()
+                .name(Flow.Name.PROFILE_UPDATE)
+                .initiatingPersona(Flow.InitiatingPersona.USER)
+                .build();
+        IdentityContext.getThreadLocalIdentityContext().enterFlow(flow);
     }
 
     private void mockVerificationPendingMobileNumber() throws UserStoreException {

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandlerTest.java
@@ -32,6 +32,8 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Flow;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventClientException;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
@@ -114,6 +116,9 @@ public class UserEmailVerificationHandlerTest {
     @AfterMethod
     public void close() {
 
+        if (IdentityContext.getThreadLocalIdentityContext().getCurrentFlow() != null) {
+            IdentityContext.getThreadLocalIdentityContext().exitFlow();
+        }
         mockedJDBCRecoveryDataStore.close();
         mockedUtils.close();
         mockedIdentityRecoveryServiceDataHolder.close();
@@ -818,11 +823,123 @@ public class UserEmailVerificationHandlerTest {
                 "'emailVerified' claim should be cleared (empty string) when primary email is set to empty string.");
     }
 
+    @Test
+    public void testHandleEventPreSetUserClaimsSkipVerificationOnAdminPrimaryEmailUpdate()
+            throws IdentityEventException {
+
+        Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
+                null, null, NEW_EMAIL);
+        mockUtilMethods(true, false, false, false);
+        mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER, true);
+        enterAdminInitiatedFlow();
+
+        userEmailVerificationHandler.handleEvent(event);
+        Map<String, String> userClaims = getUserClaimsFromEvent(event);
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM));
+        Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM), NEW_EMAIL);
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.VERIFY_EMAIL_CLIAM));
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.EMAIL_VERIFIED_CLAIM));
+    }
+
+    @Test
+    public void testHandleEventPreSetUserClaimsSkipVerificationOnAdminVerifiedEmailListUpdate()
+            throws IdentityEventException {
+
+        Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
+                NEW_EMAIL, null, null);
+        mockUtilMethods(true, true, false, false);
+        mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER, true);
+        enterAdminInitiatedFlow();
+
+        userEmailVerificationHandler.handleEvent(event);
+        Map<String, String> userClaims = getUserClaimsFromEvent(event);
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM));
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM));
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM));
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.VERIFY_EMAIL_CLIAM));
+        Assert.assertNotEquals(userClaims.get(IdentityRecoveryConstants.EMAIL_VERIFIED_CLAIM),
+                Boolean.TRUE.toString());
+    }
+
+    @Test
+    public void testHandleEventPreSetUserClaimsDoesNotSkipVerificationOnUserPersona()
+            throws IdentityEventException {
+
+        Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
+                null, null, NEW_EMAIL);
+        mockUtilMethods(true, false, false, false);
+        mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER, true);
+        enterUserInitiatedFlow();
+
+        userEmailVerificationHandler.handleEvent(event);
+        Map<String, String> userClaims = getUserClaimsFromEvent(event);
+        Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM), NEW_EMAIL);
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM));
+    }
+
+    @Test
+    public void testHandleEventPreSetUserClaimsDoesNotSkipVerificationWithoutFlow()
+            throws IdentityEventException {
+
+        Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
+                null, null, NEW_EMAIL);
+        mockUtilMethods(true, false, false, false);
+        mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER, true);
+
+        userEmailVerificationHandler.handleEvent(event);
+        Map<String, String> userClaims = getUserClaimsFromEvent(event);
+        Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM), NEW_EMAIL);
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM));
+        Assert.assertNotEquals(userClaims.get(IdentityRecoveryConstants.EMAIL_VERIFIED_CLAIM),
+                Boolean.TRUE.toString());
+    }
+
+    @Test
+    public void testHandleEventPreSetUserClaimsDoesNotSkipVerificationWhenConfigDisabledForAdminPersona()
+            throws IdentityEventException {
+
+        Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
+                null, null, NEW_EMAIL);
+        mockUtilMethods(true, false, false, false);
+        mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
+                .ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER, false);
+        enterAdminInitiatedFlow();
+
+        userEmailVerificationHandler.handleEvent(event);
+        Map<String, String> userClaims = getUserClaimsFromEvent(event);
+        Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM), NEW_EMAIL);
+        Assert.assertFalse(userClaims.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM));
+        Assert.assertNotEquals(userClaims.get(IdentityRecoveryConstants.EMAIL_VERIFIED_CLAIM),
+                Boolean.TRUE.toString());
+    }
+
     private void mockExistingEmailAddressesList(List<String> existingEmails) {
 
         mockedUtils.when(() -> Utils.getMultiValuedClaim(any(), any(),
                         eq(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM)))
                 .thenReturn(existingEmails);
+    }
+
+    private void enterAdminInitiatedFlow() {
+
+        Flow flow = new Flow.Builder()
+                .name(Flow.Name.PROFILE_UPDATE)
+                .initiatingPersona(Flow.InitiatingPersona.ADMIN)
+                .build();
+        IdentityContext.getThreadLocalIdentityContext().enterFlow(flow);
+    }
+
+    private void enterUserInitiatedFlow() {
+
+        Flow flow = new Flow.Builder()
+                .name(Flow.Name.PROFILE_UPDATE)
+                .initiatingPersona(Flow.InitiatingPersona.USER)
+                .build();
+        IdentityContext.getThreadLocalIdentityContext().enterFlow(flow);
     }
 
     private void mockExistingVerifiedEmailAddressesList(List<String> existingVerifiedEmails) {


### PR DESCRIPTION
$subject



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Administrators can now skip email verification initiation when updating user email claims through new configuration options
  * Administrators can now skip mobile number verification initiation when updating user mobile number claims through new configuration options

* **Tests**
  * Added comprehensive test coverage for verification skip configurations across various user flow scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->