### PR TITLE
Remove checking mutliple email addresses mobile numbers feature disabled

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
@@ -119,17 +119,7 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
             claims = new HashMap<>();
         }
 
-        boolean supportMultipleMobileNumbers =
-                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
-
         boolean enable = isMobileVerificationOnUpdateEnabled(user.getTenantDomain());
-
-        if (!supportMultipleMobileNumbers) {
-            // Multiple mobile numbers per user support is disabled.
-            log.debug("Supporting multiple mobile numbers per user is disabled.");
-            claims.remove(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM);
-            claims.remove(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM);
-        }
 
         if (!enable) {
             // Mobile Number Verification feature is disabled.
@@ -150,7 +140,7 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
 
         if (IdentityEventConstants.Event.PRE_SET_USER_CLAIMS.equals(eventName)) {
             Utils.unsetThreadLocalIsOnlyVerifiedMobileNumbersUpdated();
-            if (supportMultipleMobileNumbers && !claims.containsKey(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM)) {
+            if (!claims.containsKey(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM)) {
                 Utils.setThreadLocalIsOnlyVerifiedMobileNumbersUpdated(true);
             }
             preSetUserClaimOnMobileNumberUpdate(claims, userStoreManager, user);
@@ -347,9 +337,6 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
             Utils.unsetThreadLocalToSkipSendingSmsOtpVerificationOnUpdate();
         }
 
-        boolean supportMultipleMobileNumbers =
-                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
-
         // Update multiple mobile numbers only if they’re in the claims map.
         // This avoids issues with updating the primary mobile number due to user store limitations on multiple
         // mobile numbers.
@@ -372,53 +359,47 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
         List<String> updatedVerifiedNumbersList = new ArrayList<>();
         List<String> updatedAllNumbersList;
 
-        if (supportMultipleMobileNumbers) {
-            List<String> exisitingVerifiedNumbersList = Utils.getMultiValuedClaim(userStoreManager, user,
-                    IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM);
-            updatedVerifiedNumbersList = claims.containsKey(IdentityRecoveryConstants.
-                    VERIFIED_MOBILE_NUMBERS_CLAIM) ? getListOfMobileNumbersFromString(claims.get(
-                    IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM)) : exisitingVerifiedNumbersList;
+        List<String> exisitingVerifiedNumbersList = Utils.getMultiValuedClaim(userStoreManager, user,
+                IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM);
+        updatedVerifiedNumbersList = claims.containsKey(IdentityRecoveryConstants.
+                VERIFIED_MOBILE_NUMBERS_CLAIM) ? getListOfMobileNumbersFromString(claims.get(
+                IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM)) : exisitingVerifiedNumbersList;
 
-            List<String> exisitingAllNumbersList = Utils.getMultiValuedClaim(userStoreManager, user,
-                    IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM);
-            updatedAllNumbersList = claims.containsKey(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM) ?
-                    getListOfMobileNumbersFromString(claims.get(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM)) :
-                    exisitingAllNumbersList;
+        List<String> exisitingAllNumbersList = Utils.getMultiValuedClaim(userStoreManager, user,
+                IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM);
+        updatedAllNumbersList = claims.containsKey(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM) ?
+                getListOfMobileNumbersFromString(claims.get(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM)) :
+                exisitingAllNumbersList;
 
             /*
             Finds the verification pending mobile number and remove it from the verified numbers list in the payload.
             */
-            if (mobileNumber == null && CollectionUtils.isNotEmpty(updatedVerifiedNumbersList)) {
-                mobileNumber = getVerificationPendingMobileNumber(exisitingVerifiedNumbersList,
-                        updatedVerifiedNumbersList);
-                updatedVerifiedNumbersList.remove(mobileNumber);
-            } else {
-                /*
-                 * When both primary mobile number and verified mobile numbers are provided, give the primary‑mobile
-                 * number change the precedence; leave the updated verified‑mobile numbers list exactly as it exists
-                 * in the user store.
-                 */
-                updatedVerifiedNumbersList = exisitingVerifiedNumbersList;
-            }
+        if (mobileNumber == null && CollectionUtils.isNotEmpty(updatedVerifiedNumbersList)) {
+            mobileNumber = getVerificationPendingMobileNumber(exisitingVerifiedNumbersList,
+                    updatedVerifiedNumbersList);
+            updatedVerifiedNumbersList.remove(mobileNumber);
+        } else {
+            /*
+             * When both primary mobile number and verified mobile numbers are provided, give the primary‑mobile
+             * number change the precedence; leave the updated verified‑mobile numbers list exactly as it exists
+             * in the user store.
+             */
+            updatedVerifiedNumbersList = exisitingVerifiedNumbersList;
+        }
 
             /*
             Finds the removed numbers from the existing mobile numbers list and remove them from the verified numbers
             list. As verified numbers list should not contain numbers that are not in the mobile numbers list.
             */
-            if (updatedAllNumbersList != null) {
-                updatedVerifiedNumbersList.removeIf(number -> !updatedAllNumbersList.contains(number));
-            }
+        if (updatedAllNumbersList != null) {
+            updatedVerifiedNumbersList.removeIf(number -> !updatedAllNumbersList.contains(number));
+        }
 
-            if (shouldUpdateMultiMobilesRelatedClaims) {
-                claims.put(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM,
-                        String.join(multiAttributeSeparator, updatedAllNumbersList));
-                claims.put(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM,
-                        String.join(multiAttributeSeparator, updatedVerifiedNumbersList));
-            }
-        } else {
-            updatedAllNumbersList = new ArrayList<>();
-            claims.remove(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM);
-            claims.remove(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM);
+        if (shouldUpdateMultiMobilesRelatedClaims) {
+            claims.put(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM,
+                    String.join(multiAttributeSeparator, updatedAllNumbersList));
+            claims.put(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM,
+                    String.join(multiAttributeSeparator, updatedVerifiedNumbersList));
         }
 
         if (StringUtils.isBlank(mobileNumber)) {
@@ -438,7 +419,7 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
             throw new IdentityEventException(error, e);
         }
 
-        if (supportMultipleMobileNumbers && updatedVerifiedNumbersList.contains(mobileNumber)) {
+        if (updatedVerifiedNumbersList.contains(mobileNumber)) {
             Utils.setThreadLocalToSkipSendingSmsOtpVerificationOnUpdate(
                     IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates
                             .SKIP_ON_ALREADY_VERIFIED_MOBILE_NUMBERS.toString());
@@ -449,7 +430,7 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
 
         if (StringUtils.equals(mobileNumber, existingMobileNumber)) {
 
-            if (supportMultipleMobileNumbers && shouldUpdateMultiMobilesRelatedClaims &&
+            if (shouldUpdateMultiMobilesRelatedClaims &&
                     !updatedAllNumbersList.contains(existingMobileNumber)) {
                 updatedAllNumbersList.add(existingMobileNumber);
                 claims.put(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM,
@@ -467,7 +448,7 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
                         .SkipMobileNumberVerificationOnUpdateStates.SKIP_ON_EXISTING_MOBILE_NUM.toString());
                 invalidatePendingMobileVerification(user, userStoreManager, claims);
 
-                if (supportMultipleMobileNumbers && shouldUpdateMultiMobilesRelatedClaims &&
+                if (shouldUpdateMultiMobilesRelatedClaims &&
                         !updatedVerifiedNumbersList.contains(existingMobileNumber)) {
                     updatedVerifiedNumbersList.add(existingMobileNumber);
                     claims.put(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM,

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -121,9 +121,6 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
             claims = new HashMap<>();
         }
 
-        boolean supportMultipleEmails =
-                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
-
         boolean enable = false;
 
         if (IdentityEventConstants.Event.PRE_ADD_USER.equals(eventName) ||
@@ -134,14 +131,6 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
                 IdentityEventConstants.Event.POST_SET_USER_CLAIMS.equals(eventName)) {
 
             enable = isEmailVerificationOnUpdateEnabled(user.getTenantDomain());
-
-            if (!supportMultipleEmails) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Supporting multiple email addresses per user is disabled.");
-                }
-                claims.remove(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM);
-                claims.remove(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM);
-            }
 
             if (!enable) {
                 /* We need to empty 'EMAIL_ADDRESS_PENDING_VALUE_CLAIM' because having a value in that claim implies
@@ -258,7 +247,7 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
 
         if (IdentityEventConstants.Event.PRE_SET_USER_CLAIMS.equals(eventName)) {
             Utils.unsetThreadLocalIsOnlyVerifiedEmailAddressesUpdated();
-            if (supportMultipleEmails && !claims.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM)) {
+            if (!claims.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM)) {
                 Utils.setThreadLocalIsOnlyVerifiedEmailAddressesUpdated(true);
             }
             preSetUserClaimsOnEmailUpdate(claims, userStoreManager, user);
@@ -551,8 +540,6 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
             Utils.unsetThreadLocalToSkipSendingEmailVerificationOnUpdate();
         }
 
-        boolean supportMultipleEmails =
-                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
         // Update multiple email address related claims only if they’re in the claims map.
         // This avoids issues with updating the primary email address due to user store limitations on multiple
         // email addresses.
@@ -578,74 +565,64 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
         String primaryEmail = getEmailClaimValue(user, userStoreManager);
 
         // Handle email addresses and verified email addresses claims.
-        if (supportMultipleEmails) {
-            List<String> existingVerifiedEmailAddresses = Utils.getMultiValuedClaim(userStoreManager, user,
+        List<String> existingVerifiedEmailAddresses = Utils.getMultiValuedClaim(userStoreManager, user,
                 IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM);
-            List<String> existingAllEmailAddresses = Utils.getMultiValuedClaim(userStoreManager, user,
-                    IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM);
+        List<String> existingAllEmailAddresses = Utils.getMultiValuedClaim(userStoreManager, user,
+                IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM);
 
-            if (isPrimaryEmailVerified(userStoreManager, user)) {
-                // Add primary email address to verifiedEmailAddress claim if not available.
-                if (existingAllEmailAddresses.contains(primaryEmail) &&
-                        !existingVerifiedEmailAddresses.contains(primaryEmail)) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Added primary email to verifiedEmailAddresses claim for user: " +
-                                maskIfRequired(user.getUserName()));
-                    }
-                    existingVerifiedEmailAddresses.add(primaryEmail);
+        if (isPrimaryEmailVerified(userStoreManager, user)) {
+            // Add primary email address to verifiedEmailAddress claim if not available.
+            if (existingAllEmailAddresses.contains(primaryEmail) &&
+                    !existingVerifiedEmailAddresses.contains(primaryEmail)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Added primary email to verifiedEmailAddresses claim for user: " +
+                            maskIfRequired(user.getUserName()));
                 }
+                existingVerifiedEmailAddresses.add(primaryEmail);
             }
+        }
 
-            updatedVerifiedEmailAddresses = claims.containsKey(IdentityRecoveryConstants.
-                    VERIFIED_EMAIL_ADDRESSES_CLAIM) ? getListOfEmailAddressesFromString(claims.get(
-                    IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM)) : existingVerifiedEmailAddresses;
-            updatedAllEmailAddresses = claims.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM) ?
-                    getListOfEmailAddressesFromString(claims.get(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM)) :
-                    existingAllEmailAddresses;
+        updatedVerifiedEmailAddresses = claims.containsKey(IdentityRecoveryConstants.
+                VERIFIED_EMAIL_ADDRESSES_CLAIM) ? getListOfEmailAddressesFromString(claims.get(
+                IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM)) : existingVerifiedEmailAddresses;
+        updatedAllEmailAddresses = claims.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM) ?
+                getListOfEmailAddressesFromString(claims.get(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM)) :
+                existingAllEmailAddresses;
 
-            if (updatedAllEmailAddresses == null) {
-                updatedAllEmailAddresses = new ArrayList<>();
-            }
-            if (updatedVerifiedEmailAddresses == null) {
-                updatedVerifiedEmailAddresses = new ArrayList<>();
-            }
+        if (updatedAllEmailAddresses == null) {
+            updatedAllEmailAddresses = new ArrayList<>();
+        }
+        if (updatedVerifiedEmailAddresses == null) {
+            updatedVerifiedEmailAddresses = new ArrayList<>();
+        }
 
-            // Find the verification pending email address and remove it from verified email addresses in the payload.
-            if (emailAddress == null && CollectionUtils.isNotEmpty(updatedVerifiedEmailAddresses)) {
-                emailAddress = getVerificationPendingEmailAddress(existingVerifiedEmailAddresses,
-                        updatedVerifiedEmailAddresses);
-                updatedVerifiedEmailAddresses.remove(emailAddress);
-            } else {
-                /*
-                 * When both primary email address and verified email addresses are provided, give the primary‑email
-                 * change the precedence; leave the updated verified‑emails list exactly as it exists in the
-                 * user store.
-                 */
-                updatedVerifiedEmailAddresses = existingVerifiedEmailAddresses;
-            }
+        // Find the verification pending email address and remove it from verified email addresses in the payload.
+        if (emailAddress == null && CollectionUtils.isNotEmpty(updatedVerifiedEmailAddresses)) {
+            emailAddress = getVerificationPendingEmailAddress(existingVerifiedEmailAddresses,
+                    updatedVerifiedEmailAddresses);
+            updatedVerifiedEmailAddresses.remove(emailAddress);
+        } else {
+            /*
+             * When both primary email address and verified email addresses are provided, give the primary‑email
+             * change the precedence; leave the updated verified‑emails list exactly as it exists in the
+             * user store.
+             */
+            updatedVerifiedEmailAddresses = existingVerifiedEmailAddresses;
+        }
 
             /*
             Find the removed numbers from the existing email addresses list and remove them from the verified email
             addresses list, as verified email addresses list should not contain email addresses that are not in the
             email addresses list.
             */
-            final List<String> tempUpdatedAllEmailAddresses = new ArrayList<>(updatedAllEmailAddresses);
-            updatedVerifiedEmailAddresses.removeIf(number -> !tempUpdatedAllEmailAddresses.contains(number));
+        final List<String> tempUpdatedAllEmailAddresses = new ArrayList<>(updatedAllEmailAddresses);
+        updatedVerifiedEmailAddresses.removeIf(number -> !tempUpdatedAllEmailAddresses.contains(number));
 
-            if (shouldUpdateMultiMobilesRelatedClaims) {
-                claims.put(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM,
-                        StringUtils.join(updatedVerifiedEmailAddresses, multiAttributeSeparator));
-                claims.put(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM,
-                        StringUtils.join(updatedAllEmailAddresses, multiAttributeSeparator));
-            }
-        } else {
-            /*
-            email addresses and verified email addresses should not be updated when support for multiple email
-            addresses is disabled.
-             */
-            claims.remove(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM);
-            claims.remove(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM);
-            updatedAllEmailAddresses = new ArrayList<>();
+        if (shouldUpdateMultiMobilesRelatedClaims) {
+            claims.put(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM,
+                    StringUtils.join(updatedVerifiedEmailAddresses, multiAttributeSeparator));
+            claims.put(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM,
+                    StringUtils.join(updatedAllEmailAddresses, multiAttributeSeparator));
         }
 
         if (StringUtils.isBlank(emailAddress)) {
@@ -654,7 +631,7 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
             return;
         }
 
-        if (supportMultipleEmails && updatedVerifiedEmailAddresses.contains(emailAddress)) {
+        if (updatedVerifiedEmailAddresses.contains(emailAddress)) {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("The email address to be updated: %s is already verified and contains" +
                         " in the verified email addresses list for user: %s in domain %s. Hence an email " +
@@ -670,7 +647,7 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
 
         if (emailAddress.equals(primaryEmail)) {
 
-            if (supportMultipleEmails && shouldUpdateMultiMobilesRelatedClaims &&
+            if (shouldUpdateMultiMobilesRelatedClaims &&
                     !updatedAllEmailAddresses.contains(primaryEmail)) {
                 updatedAllEmailAddresses.add(primaryEmail);
                 claims.put(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM,
@@ -688,7 +665,7 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
                         .SkipEmailVerificationOnUpdateStates.SKIP_ON_EXISTING_EMAIL.toString());
                 invalidatePendingEmailVerification(user, userStoreManager, claims);
 
-                if (supportMultipleEmails && shouldUpdateMultiMobilesRelatedClaims &&
+                if (shouldUpdateMultiMobilesRelatedClaims &&
                         !updatedVerifiedEmailAddresses.contains(primaryEmail)) {
                     updatedVerifiedEmailAddresses.add(primaryEmail);
                     claims.put(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM,

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -841,8 +841,6 @@ public class UserSelfRegistrationManager {
         HashMap<String, String> userClaims = getClaimsListToUpdate(user, verifiedChannelType,
                 externallyVerifiedClaim, recoveryData.getRecoveryScenario().toString());
 
-        boolean supportMultipleEmailsAndMobileNumbers =
-                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
         Map<String, String> userClaimsToBeAdded = new HashMap<>();
         Map<String, String> userClaimsToBeModified = new HashMap<>();
@@ -883,7 +881,7 @@ public class UserSelfRegistrationManager {
                 // Only update verified email addresses claim if the recovery scenario is
                 // EMAIL_VERIFICATION_ON_VERIFIED_LIST_UPDATE.
                 if (RecoveryScenarios.EMAIL_VERIFICATION_ON_VERIFIED_LIST_UPDATE.equals(
-                        recoveryData.getRecoveryScenario()) && supportMultipleEmailsAndMobileNumbers) {
+                        recoveryData.getRecoveryScenario())) {
                     try {
                         List<String> verifiedEmails = Utils.getMultiValuedClaim(userStoreManager, user,
                                 IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM);
@@ -951,8 +949,7 @@ public class UserSelfRegistrationManager {
                 if ((RecoveryScenarios.MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE.equals(
                             recoveryData.getRecoveryScenario())
                             || RecoveryScenarios.PROGRESSIVE_PROFILE_MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE
-                            .equals(recoveryData.getRecoveryScenario()))
-                        && supportMultipleEmailsAndMobileNumbers) {
+                            .equals(recoveryData.getRecoveryScenario()))) {
                     try {
                         List<String> existingVerifiedMobileNumbersList = Utils.getMultiValuedClaim(userStoreManager,
                                 user, IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM);
@@ -1218,9 +1215,6 @@ public class UserSelfRegistrationManager {
         Map<String, String> userClaimsToBeModified = new HashMap<>();
         Map<String, String> userClaimsToBeDeleted = new HashMap<>();
 
-        boolean supportMultipleEmailsAndMobileNumbers =
-                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
-
         String pendingMobileNumberClaimValue = recoveryData.getRemainingSetIds();
         String primaryMobile = null;
 
@@ -1239,7 +1233,7 @@ public class UserSelfRegistrationManager {
             */
             if ((RecoveryScenarios.MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE.equals(recoveryData.getRecoveryScenario()
                     ) || RecoveryScenarios.PROGRESSIVE_PROFILE_MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE.equals(
-                    recoveryData.getRecoveryScenario())) && supportMultipleEmailsAndMobileNumbers) {
+                    recoveryData.getRecoveryScenario()))) {
                 try {
                     String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
                     List<String> existingVerifiedMobileNumbersList = Utils.getMultiValuedClaim(userStoreManager,

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -39,9 +39,6 @@ import org.wso2.carbon.identity.auth.attribute.handler.model.ValidationFailureRe
 import org.wso2.carbon.identity.auth.attribute.handler.model.ValidationResult;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
-import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
-import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
-import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
@@ -1524,75 +1521,6 @@ public class Utils {
 
         return Boolean.parseBoolean(IdentityUtil.getProperty
                 (IdentityRecoveryConstants.ConnectorConfig.USE_VERIFY_CLAIM_ON_UPDATE));
-    }
-
-    /**
-     * Check whether the supporting multiple email addresses and mobile numbers per user feature is enabled.
-     *
-     * @param tenantDomain   Tenant domain.
-     * @param userStoreDomain User store domain.
-     * @return True if the config is set to true, false otherwise.
-     */
-    public static boolean isMultiEmailsAndMobileNumbersPerUserEnabled(String tenantDomain, String userStoreDomain) {
-
-        if (!Boolean.parseBoolean(IdentityUtil.getProperty(
-                IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER))) {
-            return false;
-        }
-
-        if (StringUtils.isBlank(tenantDomain) || StringUtils.isBlank(userStoreDomain)) {
-            return false;
-        }
-
-        try {
-            List<LocalClaim> localClaims =
-                    IdentityRecoveryServiceDataHolder.getInstance().getClaimMetadataManagementService()
-                            .getLocalClaims(tenantDomain);
-
-            List<String> requiredClaims = Arrays.asList(
-                    IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM,
-                    IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM,
-                    IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM,
-                    IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM);
-
-            // Check if all required claims are valid for the user store.
-            return requiredClaims.stream().allMatch(claimUri ->
-                            isClaimSupportedForUserStore(localClaims, claimUri, userStoreDomain));
-        } catch (ClaimMetadataException e) {
-            log.error("Error while retrieving multiple emails and mobiles config.", e);
-            return false;
-        }
-    }
-
-    /**
-     * Check if a claim is supported and not excluded for a specific user store.
-     *
-     * @param localClaims     List of local claims.
-     * @param claimUri        URI of the claim to check.
-     * @param userStoreDomain User store domain to validate against.
-     * @return True if claim is supported and not excluded.
-     */
-    private static boolean isClaimSupportedForUserStore(List<LocalClaim> localClaims, String claimUri,
-                                                        String userStoreDomain) {
-
-        return localClaims.stream()
-            .filter(claim -> claimUri.equals(claim.getClaimURI()))
-            .anyMatch(claim -> {
-                Map<String, String> properties = claim.getClaimProperties();
-
-                // Check if claim is supported by default.
-                boolean isSupported = Boolean.parseBoolean(
-                        properties.getOrDefault(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY,
-                                Boolean.FALSE.toString()));
-
-                // Check if user store is not in excluded list.
-                String excludedUserStoreDomains = properties.get(ClaimConstants.EXCLUDED_USER_STORES_PROPERTY);
-                boolean isNotExcluded = StringUtils.isBlank(excludedUserStoreDomains) ||
-                        !Arrays.asList(excludedUserStoreDomains.toUpperCase().split(","))
-                                .contains(userStoreDomain.toUpperCase());
-
-                return isSupported && isNotExcluded;
-            });
     }
 
     /**

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandlerTest.java
@@ -171,34 +171,6 @@ public class MobileNumberVerificationHandlerTest {
         Assert.assertEquals(mobileNumberVerificationHandler.getFriendlyName(), "User Mobile Number Verification");
     }
 
-    @Test(description = "Verification disabled, Multi-attribute disabled, Change primary mobile")
-    public void testHandleEventVerificationDisabledMultiAttributeDisabled()
-            throws UserStoreException, IdentityEventException, IdentityRecoveryException {
-
-        Event event =
-                createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIM, null,
-                        null, null, NEW_MOBILE_NUMBER);
-        mockVerificationPendingMobileNumber();
-        mockUtilMethods(false, false, false);
-
-        mobileNumberVerificationHandler.handleEvent(event);
-
-        // Expectation: Any pending mobile verification should be invalidated.
-        verify(userRecoveryDataStore).invalidate(any(), eq(RecoveryScenarios.MOBILE_VERIFICATION_ON_UPDATE),
-                eq(RecoverySteps.VERIFY_MOBILE_NUMBER));
-        Map<String, String> userClaims = getUserClaimsFromEvent(event);
-        Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM),
-                StringUtils.EMPTY);
-
-        reset(userRecoveryDataStore);
-        // Case 2: User claims null.
-        Event event2 =
-                createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIM, null,
-                        null, null, null);
-        mobileNumberVerificationHandler.handleEvent(event2);
-        verify(userRecoveryDataStore, never()).invalidate(any(), eq(RecoveryScenarios.MOBILE_VERIFICATION_ON_UPDATE), any());
-    }
-
     @Test(description = "Verification disabled, Multi-attribute enabled, Change primary mobile")
     public void testHandleEventVerificationDisabledMultiAttributeEnabled()
             throws UserStoreException, IdentityEventException, IdentityRecoveryException {
@@ -206,7 +178,7 @@ public class MobileNumberVerificationHandlerTest {
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIM, null,
                 null, null, NEW_MOBILE_NUMBER);
         mockVerificationPendingMobileNumber();
-        mockUtilMethods(false, true, false);
+        mockUtilMethods(false, false);
 
         // New primary mobile number is not included in existing all mobile numbers list.
         List<String> allMobileNumbers = new ArrayList<>(Arrays.asList(EXISTING_NUMBER_1, EXISTING_NUMBER_2));
@@ -232,143 +204,10 @@ public class MobileNumberVerificationHandlerTest {
         Assert.assertFalse(userClaims3.containsKey(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM));
     }
 
-    @Test(description = "PRE_SET_USER_CLAIMS: Verification enabled, Multi-attribute disabled, Claims null")
-    public void testHandleEventVerificationEnabledMultiAttributeDisabledThreadLocal() throws Exception {
-
-        /*
-         Case 1: Claims null, skipSendingSmsOtpVerificationOnUpdate set to skip.
-         */
-        mockVerificationPendingMobileNumber();
-        mockUtilMethods(true, false, false);
-        Event event1 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, null,
-                null, null, null);
-
-        mobileNumberVerificationHandler.handleEvent(event1);
-        mockedUtils.verify(() -> Utils.setThreadLocalToSkipSendingSmsOtpVerificationOnUpdate(
-                eq(IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates
-                        .SKIP_ON_INAPPLICABLE_CLAIMS.toString())));
-
-        /*
-         Case 2: skipSendingSmsOtpVerificationOnUpdate set to skip.
-         */
-        // Case 2.1: skipSendingSmsOtpVerificationOnUpdate set to SKIP_ON_CONFIRM.
-        mockVerificationPendingMobileNumber();
-        Event event2 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, null,
-                null, null, NEW_MOBILE_NUMBER);
-        mockedUtils.when(Utils::getThreadLocalToSkipSendingSmsOtpVerificationOnUpdate)
-                .thenReturn(IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates
-                        .SKIP_ON_CONFIRM.toString());
-
-        mobileNumberVerificationHandler.handleEvent(event2);
-        Map<String, String> userClaims2 = getUserClaimsFromEvent(event2);
-        Assert.assertEquals(userClaims2.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM),
-                StringUtils.EMPTY);
-
-        // Case 2.2: skipSendingSmsOtpVerificationOnUpdate set to SKIP_ON_SMS_OTP_FLOW.
-        mockVerificationPendingMobileNumber();
-        Event event2_1 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, null,
-                null, null, NEW_MOBILE_NUMBER);
-        mockedUtils.when(Utils::getThreadLocalToSkipSendingSmsOtpVerificationOnUpdate)
-                .thenReturn(IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates
-                        .SKIP_ON_SMS_OTP_FLOW.toString());
-
-        mobileNumberVerificationHandler.handleEvent(event2_1);
-        Map<String, String> userClaims2_1 = getUserClaimsFromEvent(event2_1);
-        Assert.assertEquals(userClaims2_1.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM),
-                StringUtils.EMPTY);
-
-        /*
-         Case 3: skipSendingSmsOtpVerificationOnUpdate set to some value.
-         */
-        Event event3 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, null,
-                null, null, NEW_MOBILE_NUMBER);
-        mockedUtils.when(Utils::getThreadLocalToSkipSendingSmsOtpVerificationOnUpdate)
-                .thenReturn("test");
-
-        mobileNumberVerificationHandler.handleEvent(event3);
-        mockedUtils.verify(Utils::unsetThreadLocalToSkipSendingSmsOtpVerificationOnUpdate);
-    }
-
-    @Test(description = "PRE_SET_USER_CLAIMS: Verification enabled, Multi-attribute disabled, Change primary mobile")
-    public void testHandleEventVerificationEnabledMultiAttributeDisabled() throws Exception {
-
-        mockVerificationPendingMobileNumber();
-        mockUtilMethods(true, false, false);
-        Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, null,
-                null, null, NEW_MOBILE_NUMBER);
-
-        mobileNumberVerificationHandler.handleEvent(event);
-
-        Map<String, String> userClaims = getUserClaimsFromEvent(event);
-        Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM),
-                NEW_MOBILE_NUMBER);
-
-        /*
-         Case 2: New mobile number is same as existing verified primary mobile number.
-         */
-        mockExistingPrimaryMobileNumber(NEW_MOBILE_NUMBER);
-        Event event2 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, null,
-                null, null, NEW_MOBILE_NUMBER);
-        mockPrimaryMobileVerificationStatus(true);
-
-        mobileNumberVerificationHandler.handleEvent(event2);
-        Map<String, String> userClaims2 = getUserClaimsFromEvent(event2);
-        Assert.assertEquals(userClaims2.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM),
-                StringUtils.EMPTY);
-
-        /*
-         Case 3: New mobile number is same as existing unverified primary mobile number.
-         */
-        Event event3 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, null,
-                null, null, NEW_MOBILE_NUMBER);
-        mockPrimaryMobileVerificationStatus(false);
-
-        mobileNumberVerificationHandler.handleEvent(event3);
-        Map<String, String> userClaims3 = getUserClaimsFromEvent(event3);
-        Assert.assertEquals(userClaims3.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM),
-                NEW_MOBILE_NUMBER);
-
-        /*
-         Case 4: Enable userVerify and send verifyMobileClaim as false.
-         */
-        mockExistingPrimaryMobileNumber(EXISTING_NUMBER_1);
-        mockedUtils.when(Utils::isUseVerifyClaimEnabled).thenReturn(true);
-        Event event4 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, NEW_MOBILE_NUMBER);
-
-        mobileNumberVerificationHandler.handleEvent(event4);
-        mockedUtils.verify(() -> Utils.setThreadLocalToSkipSendingSmsOtpVerificationOnUpdate(
-                IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates
-                        .SKIP_ON_INAPPLICABLE_CLAIMS.toString()), atLeastOnce());
-
-        /*
-         Case 5: Mobile number claim is null.
-         */
-        Event event5 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, null);
-
-        mobileNumberVerificationHandler.handleEvent(event5);
-        mockedUtils.verify(() -> Utils.setThreadLocalToSkipSendingSmsOtpVerificationOnUpdate(
-                IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates
-                        .SKIP_ON_INAPPLICABLE_CLAIMS.toString()), atLeastOnce());
-
-        /*
-         Case 6: Throw error when retrieving existing mobile number.
-         */
-        when(userStoreManager.getUserClaimValue(anyString(),
-                eq(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM), isNull()))
-                .thenThrow(new org.wso2.carbon.user.core.UserStoreException());
-        try {
-            mobileNumberVerificationHandler.handleEvent(event);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof IdentityEventException);
-        }
-    }
-
     @Test(description = "Verification enabled, Multi-attribute enabled, Update primary mobile not in verified list")
     public void testUpdatePrimaryMobileNotInVerifiedList() throws Exception {
 
-        mockUtilMethods(true, true, false);
+        mockUtilMethods(true, false);
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, null,
                 null, null, NEW_MOBILE_NUMBER);
         mockExistingVerifiedNumbersList(new ArrayList<>(Arrays.asList(EXISTING_NUMBER_1)));
@@ -400,7 +239,7 @@ public class MobileNumberVerificationHandlerTest {
     public void testUpdatePrimaryMobileInVerifiedList() throws Exception {
 
         mockVerificationPendingMobileNumber();
-        mockUtilMethods(true, true, false);
+        mockUtilMethods(true, false);
         String newVerifiedMobileNumbers = EXISTING_NUMBER_1 + "," + NEW_MOBILE_NUMBER;
         String newMobileNumbers = EXISTING_NUMBER_1 + "," + NEW_MOBILE_NUMBER;
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS,
@@ -420,7 +259,7 @@ public class MobileNumberVerificationHandlerTest {
     public void testAddNewMobileToVerifiedList() throws Exception {
 
         mockVerificationPendingMobileNumber();
-        mockUtilMethods(true, true, false);
+        mockUtilMethods(true, false);
         String newVerifiedMobileNumbers = EXISTING_NUMBER_1 + "," + NEW_MOBILE_NUMBER;
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS,
                 IdentityRecoveryConstants.FALSE,
@@ -494,7 +333,7 @@ public class MobileNumberVerificationHandlerTest {
 
         Event event = createEvent(IdentityEventConstants.Event.POST_SET_USER_CLAIMS, null,
                 null, null, null);
-        mockUtilMethods(true, true, false);
+        mockUtilMethods(true, false);
 
         MockedStatic<RecoveryScenarios> mockedStaticRecoveryScenarios = mockStatic(RecoveryScenarios.class);
         mockedStaticRecoveryScenarios.when(() ->
@@ -542,7 +381,7 @@ public class MobileNumberVerificationHandlerTest {
 
         Event event = createEvent(IdentityEventConstants.Event.POST_SET_USER_CLAIMS, null,
                 null, null, null);
-        mockUtilMethods(true, true, false);
+        mockUtilMethods(true, false);
 
         MockedStatic<RecoveryScenarios> mockedStaticRecoveryScenarios = mockStatic(RecoveryScenarios.class);
         mockedStaticRecoveryScenarios.when(() ->
@@ -612,21 +451,12 @@ public class MobileNumberVerificationHandlerTest {
         }
     }
 
-    @DataProvider(name = "multiAttributeEnabledData")
-    public Object[][] multiAttributeEnabledData() {
-
-        return new Object[][]{
-                {false},
-                {true}
-        };
-    }
-
-    @Test(description = "Test handling of primary mobile deletion — primary mobile set to EMPTY should clear" +
-            "phoneVerified claim.", dataProvider = "multiAttributeEnabledData")
-    public void testHandleEventPreSetUserClaimsPrimaryMobileDeletionClearsVerification(boolean multiAttributeEnabled)
+    @Test(description = "Test handling of primary mobile deletion — primary mobile set to EMPTY should clear " +
+            "phoneVerified claim.")
+    public void testHandleEventPreSetUserClaimsPrimaryMobileDeletionClearsVerification()
             throws IdentityEventException {
 
-        mockUtilMethods(true, multiAttributeEnabled, false);
+        mockUtilMethods(true, false);
 
         Map<String, Object> eventProperties = new HashMap<>();
         eventProperties.put(IdentityEventConstants.EventProperty.USER_NAME, TEST_USERNAME);
@@ -681,11 +511,8 @@ public class MobileNumberVerificationHandlerTest {
         return (Map<String, String>) eventProperties.get(IdentityEventConstants.EventProperty.USER_CLAIMS);
     }
 
-    private void mockUtilMethods(boolean mobileVerificationEnabled, boolean multiAttributeEnabled,
-                                 boolean useVerifyClaimEnabled) {
+    private void mockUtilMethods(boolean mobileVerificationEnabled, boolean useVerifyClaimEnabled) {
 
-        mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
-                .thenReturn(multiAttributeEnabled);
         mockedUtils.when(Utils::isUseVerifyClaimEnabled).thenReturn(useVerifyClaimEnabled);
         mockedUtils.when(() -> Utils.getConnectorConfig(
                         eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_NUM_VERIFICATION_ON_UPDATE),

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandlerTest.java
@@ -160,55 +160,6 @@ public class UserEmailVerificationHandlerTest {
         Assert.assertEquals(userEmailVerificationHandler.getFriendlyName(), "User Email Verification");
     }
 
-    @Test(description = "Verification - Disabled, Multi attribute - Disabled")
-    public void testHandleEventPreSetUserClaimsVerificationDisabledMultiDisabled()
-            throws IdentityEventException, UserStoreException {
-
-        /*
-         Notification on email update is enabled.
-         Expected: Notification event should be triggered, pending email claim should be set to empty string.
-         */
-        Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, NEW_EMAIL);
-
-        mockUtilMethods(false, false, false,
-                true);
-        mockPrimaryEmail(EXISTING_EMAIL_1);
-        mockPendingVerificationEmail(EXISTING_EMAIL_2);
-
-        userEmailVerificationHandler.handleEvent(event);
-        verify(identityEventService).handleEvent(any());
-        Map<String, String> userClaims = getUserClaimsFromEvent(event);
-        Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM),
-                StringUtils.EMPTY);
-
-        // Case 2: Throw error when triggering event.
-        doThrow(new IdentityEventException("error")).when(identityEventService).handleEvent(any());
-        try {
-            userEmailVerificationHandler.handleEvent(event);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof IdentityEventException);
-        }
-
-        // Reset.
-        doNothing().when(identityEventService).handleEvent(any());
-
-        // Case 2: Throw UserStoreException when getting the primary email.
-        Event event2 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, NEW_EMAIL);
-        mockUtilMethods(false, false, false,
-                true);
-        mockPendingVerificationEmail(EXISTING_EMAIL_2);
-        when(userStoreManager.getUserClaimValue(anyString(), eq(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM),
-                any())).thenThrow(new UserStoreException("error"));
-
-        try {
-            userEmailVerificationHandler.handleEvent(event2);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof IdentityEventException);
-        }
-    }
-
     @Test(description = "Verification - Disabled, Multi attribute - Enabled")
     public void testHandleEventPreSetUserClaimsVerificationDisabledMultiEnabled()
             throws IdentityEventException, IdentityRecoveryException, UserStoreException {
@@ -220,8 +171,7 @@ public class UserEmailVerificationHandlerTest {
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, null, NEW_EMAIL);
 
-        mockUtilMethods(false, true, false,
-                false);
+        mockUtilMethods(false, false, false);
         List<String> existingEmails = new ArrayList<>(Arrays.asList(EXISTING_EMAIL_1, EXISTING_EMAIL_2));
         mockExistingEmailAddressesList(existingEmails);
 
@@ -236,91 +186,12 @@ public class UserEmailVerificationHandlerTest {
         Event event2 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, emailsClaim, NEW_EMAIL);
 
-        mockUtilMethods(false, true, false,
-                false);
+        mockUtilMethods(false, false, false);
 
         userEmailVerificationHandler.handleEvent(event2);
         Map<String, String> userClaims2 = getUserClaimsFromEvent(event2);
         Assert.assertEquals(userClaims2.get(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM), NEW_EMAIL);
         Assert.assertEquals(userClaims2.get(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM), emailsClaim);
-    }
-
-    @Test(description = "Verification - Enabled, Multi attribute - Disabled")
-    public void testHandleEventPreSetUserClaimsVerificationEnabledMultiDisabled()
-            throws IdentityEventException, IdentityRecoveryException, UserStoreException {
-
-        Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, NEW_EMAIL);
-        mockUtilMethods(true, false, false,
-                false);
-        mockPendingVerificationEmail(EXISTING_EMAIL_1);
-
-        userEmailVerificationHandler.handleEvent(event);
-        Map<String, String> userClaimsC1 = getUserClaimsFromEvent(event);
-        Assert.assertEquals(userClaimsC1.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM), NEW_EMAIL);
-
-        // Case 2: Send SELF_SIGNUP_ROLE with the event.
-        mockPendingVerificationEmail(EXISTING_EMAIL_1);
-        String[] roleList = new String[]{IdentityRecoveryConstants.SELF_SIGNUP_ROLE};
-        Map<String, Object> additionalEventProperties = new HashMap<>();
-        additionalEventProperties.put(IdentityEventConstants.EventProperty.ROLE_LIST, roleList);
-        Event event2 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, NEW_EMAIL, additionalEventProperties, null);
-
-        userEmailVerificationHandler.handleEvent(event2);
-        Map<String, String> userClaimsC2 = getUserClaimsFromEvent(event2);
-        Assert.assertFalse(userClaimsC2.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM));
-
-        // Case 3: Try to change the primary email value with existing verified primary email value.
-        Event event3 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, NEW_EMAIL);
-        mockPendingVerificationEmail(EXISTING_EMAIL_1);
-        mockPrimaryEmail(NEW_EMAIL);
-        mockPrimaryEmailVerificationStatus(true);
-
-        userEmailVerificationHandler.handleEvent(event3);
-        Map<String, String> userClaimsC3 = getUserClaimsFromEvent(event3);
-        Assert.assertEquals(userClaimsC3.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM),
-                StringUtils.EMPTY);
-
-        // Case 4: Try to change the primary email value with existing unverified primary email value.
-        Event event4 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, NEW_EMAIL);
-        mockPendingVerificationEmail(EXISTING_EMAIL_1);
-        mockPrimaryEmail(NEW_EMAIL);
-        mockPrimaryEmailVerificationStatus(false);
-
-        userEmailVerificationHandler.handleEvent(event4);
-        Map<String, String> userClaimsC4 = getUserClaimsFromEvent(event4);
-        Assert.assertEquals(userClaimsC4.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM),
-                NEW_EMAIL);
-    }
-
-    @Test(description = "Verification - Enabled, Multi attribute - Disabled, User verify - Enabled")
-    public void testHandleEventPreSetUserClaimsVerificationEnabledMultiDisabledUserVerifyEnabled()
-            throws IdentityEventException, IdentityRecoveryException, UserStoreException {
-
-        Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.TRUE,
-                null, null, NEW_EMAIL);
-        mockUtilMethods(true, false, true,
-                false);
-        mockPendingVerificationEmail(EXISTING_EMAIL_1);
-
-        userEmailVerificationHandler.handleEvent(event);
-        Map<String, String> userClaimsC1 = getUserClaimsFromEvent(event);
-        Assert.assertEquals(userClaimsC1.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM), NEW_EMAIL);
-
-        // Case 2: verifyEmail claim is false.
-        Event event2 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, NEW_EMAIL);
-        mockUtilMethods(true, false, true,
-                false);
-        mockPendingVerificationEmail(EXISTING_EMAIL_1);
-
-        userEmailVerificationHandler.handleEvent(event2);
-        Map<String, String> userClaimsC2 = getUserClaimsFromEvent(event2);
-        Assert.assertEquals(userClaimsC2.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM),
-                StringUtils.EMPTY);
     }
 
     @Test(description = "Verification - Enabled, Multi attribute - Enabled, Change primary email which is not in the " +
@@ -334,8 +205,7 @@ public class UserEmailVerificationHandlerTest {
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, null, NEW_EMAIL);
 
-        mockUtilMethods(true, true, false,
-                false);
+        mockUtilMethods(true, false, false);
         List<String> existingEmails = new ArrayList<>(Arrays.asList(EXISTING_EMAIL_1, EXISTING_EMAIL_2));
         mockExistingEmailAddressesList(existingEmails);
 
@@ -360,8 +230,7 @@ public class UserEmailVerificationHandlerTest {
             Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                     null, null, NEW_EMAIL);
 
-            mockUtilMethods(true, true, false,
-                    false);
+            mockUtilMethods(true, false, false);
             List<String> existingEmails = new ArrayList<>(Arrays.asList(EXISTING_EMAIL_1, NEW_EMAIL));
             mockExistingEmailAddressesList(existingEmails);
 
@@ -390,7 +259,7 @@ public class UserEmailVerificationHandlerTest {
         Event event1 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 newVerifiedEmails1, null, null);
 
-        mockUtilMethods(true, true, false, false);
+        mockUtilMethods(true, false, false);
         List<String> existingEmails1 = new ArrayList<>(Arrays.asList(EXISTING_EMAIL_1));
         mockExistingEmailAddressesList(existingEmails1);
 
@@ -420,7 +289,7 @@ public class UserEmailVerificationHandlerTest {
         Event event2 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 newVerifiedEmails2, null, null);
 
-        mockUtilMethods(true, true, false, false);
+        mockUtilMethods(true, false, false);
         List<String> existingEmails2 = new ArrayList<>(Arrays.asList(EXISTING_EMAIL_1));
         mockExistingEmailAddressesList(existingEmails2);
 
@@ -447,7 +316,7 @@ public class UserEmailVerificationHandlerTest {
         */
         String newVerifiedEmails3 = String.format("%s,%s", EXISTING_EMAIL_1, NEW_EMAIL);
 
-        mockUtilMethods(true, true, false, false);
+        mockUtilMethods(true, false, false);
         List<String> existingEmails3 = new ArrayList<>(Arrays.asList(EXISTING_EMAIL_1));
         mockExistingEmailAddressesList(existingEmails3);
 
@@ -484,7 +353,7 @@ public class UserEmailVerificationHandlerTest {
         Event event5 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 newVerifiedEmails5, null, null);
 
-        mockUtilMethods(true, true, false, false);
+        mockUtilMethods(true, false, false);
         mockExistingEmailAddressesList(new ArrayList<>());
         mockExistingVerifiedEmailAddressesList(new ArrayList<>());
 
@@ -507,8 +376,7 @@ public class UserEmailVerificationHandlerTest {
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, EXISTING_EMAIL_1, null);
 
-        mockUtilMethods(true, true, false,
-                false);
+        mockUtilMethods(true, false, false);
         List<String> existingEmails = new ArrayList<>(Arrays.asList(EXISTING_EMAIL_1, EXISTING_EMAIL_2));
         mockExistingEmailAddressesList(existingEmails);
 
@@ -524,8 +392,7 @@ public class UserEmailVerificationHandlerTest {
     @Test
     public void testHandleEventThreadLocalValues() throws IdentityEventException, UserStoreException {
 
-        mockUtilMethods(true, false, false,
-                false);
+        mockUtilMethods(true, false, false);
         mockPendingVerificationEmail(EXISTING_EMAIL_1);
 
         // Case 1: Thread local value = SKIP_ON_CONFIRM.
@@ -570,8 +437,7 @@ public class UserEmailVerificationHandlerTest {
 
         Event event = createEvent(IdentityEventConstants.Event.POST_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, null, null);
-        mockUtilMethods(true, true, false,
-                true);
+        mockUtilMethods(true, false, true);
         mockPendingVerificationEmail(EXISTING_EMAIL_1);
 
         userEmailVerificationHandler.handleEvent(event);
@@ -580,8 +446,7 @@ public class UserEmailVerificationHandlerTest {
         // Case 2: Error is thrown when retrieving verification pending email.
         Event event1 = createEvent(IdentityEventConstants.Event.POST_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, null, null);
-        mockUtilMethods(true, true, false,
-                true);
+        mockUtilMethods(true, false, true);
         when(userStoreManager.getUserClaimValues(TEST_USERNAME, new String[]{
                 IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM}, null))
                 .thenThrow(new UserStoreException());
@@ -598,8 +463,7 @@ public class UserEmailVerificationHandlerTest {
 
         Event event = createEvent(IdentityEventConstants.Event.POST_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, null, null);
-        mockUtilMethods(true, true, false,
-                true);
+        mockUtilMethods(true, false, true);
         mockPendingVerificationEmail(EXISTING_EMAIL_1);
 
         // Case 1: Change primary email address.
@@ -737,21 +601,12 @@ public class UserEmailVerificationHandlerTest {
         }
     }
 
-    @DataProvider(name = "multiAttributeEnabledData")
-    public Object[][] multiAttributeEnabledData() {
-
-        return new Object[][]{
-                {false},
-                {true}
-        };
-    }
-
-    @Test(description = "Test handling of primary email deletion — primary email set to EMPTY should clear" +
-            "emailVerified claim", dataProvider = "multiAttributeEnabledData")
-    public void testHandleEventPreSetUserClaimsPrimaryEmailDeletionClearsVerification(boolean multiAttributeEnabled)
+    @Test(description = "Test handling of primary email deletion — primary email set to EMPTY should clear " +
+            "emailVerified claim")
+    public void testHandleEventPreSetUserClaimsPrimaryEmailDeletionClearsVerification()
             throws IdentityEventException {
 
-        mockUtilMethods(true, multiAttributeEnabled, false, false);
+        mockUtilMethods(true, false, false);
 
         Map<String, Object> eventProperties = new HashMap<>();
         eventProperties.put(IdentityEventConstants.EventProperty.USER_NAME, TEST_USERNAME);
@@ -807,11 +662,9 @@ public class UserEmailVerificationHandlerTest {
                 .thenReturn(String.valueOf(isVerified));
     }
 
-    private void mockUtilMethods(boolean emailVerificationEnabled, boolean multiAttributeEnabled,
-                                 boolean userVerifyClaimEnabled, boolean notificationOnEmailUpdate) {
+    private void mockUtilMethods(boolean emailVerificationEnabled, boolean userVerifyClaimEnabled,
+                                 boolean notificationOnEmailUpdate) {
 
-        mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
-                .thenReturn(multiAttributeEnabled);
         mockedUtils.when(Utils::isUseVerifyClaimEnabled).thenReturn(userVerifyClaimEnabled);
         mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION_ON_UPDATE,
                 emailVerificationEnabled);

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManagerTest.java
@@ -697,23 +697,7 @@ public class UserSelfRegistrationManagerTest {
         assertEquals(updatedVerificationPendingMobile, StringUtils.EMPTY);
         assertEquals(updatedPrimaryMobile, verificationPendingMobileNumber);
 
-        // Case 2: Multiple email and mobile per user is disabled.
-        mockMultiAttributeEnabled(false);
-        ArgumentCaptor<Map<String, String>> claimsCaptor2 = ArgumentCaptor.forClass(Map.class);
-
-        userSelfRegistrationManager.confirmVerificationCodeMe(TEST_CODE, new HashMap<>());
-
-        verify(userStoreManager, atLeastOnce()).setUserClaimValues(anyString(), claimsCaptor2.capture(), isNull());
-        Map<String, String> capturedClaims2 = claimsCaptor2.getValue();
-        String mobileNumberClaims =
-                capturedClaims2.get(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM);
-        String updatedVerificationPendingMobile2 =
-                capturedClaims.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM);
-
-        assertEquals(updatedVerificationPendingMobile2, StringUtils.EMPTY);
-        assertEquals(mobileNumberClaims, verificationPendingMobileNumber);
-
-        // Case 3: Wrong recovery step.
+        // Case 2: Wrong recovery step.
         UserRecoveryData userRecoveryData3 = new UserRecoveryData(user, TEST_RECOVERY_DATA_STORE_SECRET,
                 RecoveryScenarios.MOBILE_VERIFICATION_ON_UPDATE, RecoverySteps.VALIDATE_ALL_CHALLENGE_QUESTION);
         userRecoveryData.setRemainingSetIds(verificationPendingMobileNumber);
@@ -780,23 +764,7 @@ public class UserSelfRegistrationManagerTest {
 
         reset(userStoreManager);
 
-        // Case 3: Multiple email and mobile per user is disabled.
-        mockMultiAttributeEnabled(false);
-        ArgumentCaptor<Map<String, String>> claimsCaptor3 = ArgumentCaptor.forClass(Map.class);
-
-        userSelfRegistrationManager.confirmVerificationCodeMe(TEST_CODE, new HashMap<>());
-
-        verify(userStoreManager, atLeastOnce()).setUserClaimValues(anyString(), claimsCaptor3.capture(), isNull());
-        Map<String, String> capturedClaims3 = claimsCaptor3.getValue();
-        assertEquals(capturedClaims.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM),
-                StringUtils.EMPTY);
-        assertEquals(capturedClaims3.get(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM),
-                verificationPendingMobileNumber);
-        assertFalse(capturedClaims3.containsKey(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM));
-
-        reset(userStoreManager);
-        reset(userRecoveryDataStore);
-        // Case 4: When pending mobile number claim value is null.
+        // Case 3: When pending mobile number claim value is null.
         UserRecoveryData userRecoveryData2 = new UserRecoveryData(user, TEST_RECOVERY_DATA_STORE_SECRET,
                 RecoveryScenarios.MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE, RecoverySteps.VERIFY_MOBILE_NUMBER);
         userRecoveryData2.setRemainingSetIds(null);
@@ -883,24 +851,8 @@ public class UserSelfRegistrationManagerTest {
         assertFalse(capturedClaims.containsKey(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM));
 
         reset(userStoreManager);
-        // Case 2: Multiple email and mobile per user is disabled.
-        mockMultiAttributeEnabled(false);
-        mockGetUserClaimValue(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM, verificationPendingEmail);
 
-        userSelfRegistrationManager.getConfirmedSelfRegisteredUser(TEST_CODE, verifiedChannelType, verifiedChannelClaim,
-                metaProperties);
-
-        ArgumentCaptor<Map<String, String>> claimsCaptor2 = ArgumentCaptor.forClass(Map.class);
-        verify(userStoreManager).setUserClaimValues(anyString(), claimsCaptor2.capture(), isNull());
-
-        Map<String, String> capturedClaims2 = claimsCaptor2.getValue();
-        String emailAddressClaim =
-                capturedClaims2.get(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM);
-        assertEquals(emailAddressClaim, verificationPendingEmail);
-        assertFalse(capturedClaims2.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM));
-        assertFalse(capturedClaims2.containsKey(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM));
-
-        // Case 3 : Throws user store exception while getting user store manager.
+        // Case 2 : Throws user store exception while getting user store manager.
         when(userRealm.getUserStoreManager()).thenThrow(new org.wso2.carbon.user.core.UserStoreException());
         try {
             userSelfRegistrationManager.getConfirmedSelfRegisteredUser(TEST_CODE, verifiedChannelType,
@@ -988,22 +940,6 @@ public class UserSelfRegistrationManagerTest {
                 verificationPendingEmail);
 
         reset(userStoreManager);
-        // Case 2: Multiple email and mobile per user is disabled.
-        mockMultiAttributeEnabled(false);
-        mockGetUserClaimValue(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM, verificationPendingEmail);
-
-        userSelfRegistrationManager.getConfirmedSelfRegisteredUser(TEST_CODE, verifiedChannelType, verifiedChannelClaim,
-                metaProperties);
-
-        ArgumentCaptor<Map<String, String>> claimsCaptor3 = ArgumentCaptor.forClass(Map.class);
-        verify(userStoreManager).setUserClaimValues(anyString(), claimsCaptor3.capture(), isNull());
-
-        Map<String, String> capturedClaims3 = claimsCaptor3.getValue();
-        String emailAddressClaim =
-                capturedClaims3.get(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM);
-        assertEquals(emailAddressClaim, verificationPendingEmail);
-        assertFalse(capturedClaims3.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM));
-        assertFalse(capturedClaims3.containsKey(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM));
     }
 
     @Test
@@ -1103,8 +1039,6 @@ public class UserSelfRegistrationManagerTest {
         when(identityGovernanceService.getConfiguration(any(), anyString())).thenReturn(testProperties);
 
         try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class)) {
-            mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
-                    .thenReturn(true);
             mockedUtils.when(() -> Utils.getConnectorConfig(
                             eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER),
                             anyString()))
@@ -1133,8 +1067,6 @@ public class UserSelfRegistrationManagerTest {
         // Case 2: External Verified Channel type.
         verifiedChannelType = NotificationChannels.EXTERNAL_CHANNEL.getChannelType();
         try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class)) {
-            mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
-                    .thenReturn(true);
             mockedUtils.when(() -> Utils.getConnectorConfig(
                             eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER),
                             anyString()))
@@ -1156,8 +1088,6 @@ public class UserSelfRegistrationManagerTest {
 
         // Case 3: Throws user store exception while getting user claim values.
         try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class)) {
-            mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
-                    .thenReturn(true);
             mockedUtils.when(() -> Utils.getConnectorConfig(
                             eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER),
                             anyString()))
@@ -1181,8 +1111,6 @@ public class UserSelfRegistrationManagerTest {
         verifiedChannelType = NotificationChannels.SMS_CHANNEL.getChannelType();
         verifiedChannelClaim = "http://wso2.org/claims/invalid";
         try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class)) {
-            mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
-                    .thenReturn(true);
             mockedUtils.when(() -> Utils.getConnectorConfig(
                             eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER),
                             anyString()))
@@ -1228,8 +1156,6 @@ public class UserSelfRegistrationManagerTest {
         when(identityGovernanceService.getConfiguration(any(), anyString())).thenReturn(testProperties);
 
         try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class)) {
-            mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
-                    .thenReturn(true);
             mockedUtils.when(() -> Utils.getConnectorConfig(
                             eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER),
                             anyString()))

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/util/UtilsTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/util/UtilsTest.java
@@ -36,9 +36,7 @@ import org.wso2.carbon.identity.auth.attribute.handler.exception.AuthAttributeHa
 import org.wso2.carbon.identity.auth.attribute.handler.model.ValidationFailureReason;
 import org.wso2.carbon.identity.auth.attribute.handler.model.ValidationResult;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
-import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
-import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
@@ -1436,62 +1434,6 @@ public class UtilsTest {
         } catch (Exception e) {
             assertTrue(e instanceof IdentityEventException);
         }
-    }
-
-    @Test
-    public void testIsMultiEmailsAndMobileNumbersPerUserEnabled() throws Exception {
-
-        // Mock ClaimMetadataManagementService
-        ClaimMetadataManagementService claimMetadataManagementService = mock(ClaimMetadataManagementService.class);
-        when(identityRecoveryServiceDataHolder.getClaimMetadataManagementService())
-                .thenReturn(claimMetadataManagementService);
-
-        // Case 1: When support_multi_emails_and_mobile_numbers_per_user config is false.
-        mockedStaticIdentityUtil.when(() -> IdentityUtil.getProperty(
-                        IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER))
-                .thenReturn("false");
-
-        boolean isEnabled = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
-        assertFalse(isEnabled);
-
-        // Case 2: When support_multi_emails_and_mobile_numbers_per_user config is true.
-        mockedStaticIdentityUtil.when(() -> IdentityUtil.getProperty(
-                        IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER))
-                .thenReturn("true");
-
-        Map<String, String> claimProperties2 = new HashMap<>();
-        claimProperties2.put(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY, Boolean.TRUE.toString());
-        when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN)).thenReturn(
-                returnMultiEmailAndMobileRelatedLocalClaims(claimProperties2));
-
-        isEnabled = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
-        assertTrue(isEnabled);
-
-        // Case 3: When support by default is disabled for feature related claims.
-        Map<String, String> claimProperties3 = new HashMap<>();
-        claimProperties3.put(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY, Boolean.FALSE.toString());
-        when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN)).thenReturn(
-                returnMultiEmailAndMobileRelatedLocalClaims(claimProperties3));
-
-        isEnabled = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
-        assertFalse(isEnabled);
-
-        // Case 4: When user store domain is excluded for feature related claims.
-        Map<String, String> claimProperties4 = new HashMap<>();
-        claimProperties4.put(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY, Boolean.TRUE.toString());
-        claimProperties4.put(ClaimConstants.EXCLUDED_USER_STORES_PROPERTY, USER_STORE_DOMAIN);
-        when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN)).thenReturn(
-                returnMultiEmailAndMobileRelatedLocalClaims(claimProperties4));
-
-        isEnabled = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
-        assertFalse(isEnabled);
-
-        // Case 5: When ClaimMetadataException is thrown.
-        when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN))
-                .thenThrow(new ClaimMetadataException("Test exception"));
-
-        isEnabled = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
-        assertFalse(isEnabled);
     }
 
     @Test(description = "Test getUserClaim() returns the stored claim value if it exists in the user store.")


### PR DESCRIPTION
### Related Issues
- https://github.com/wso2/product-is/issues/27156

### Proposed changes in this pull request

This pull request removes all logic and checks related to the "support multiple emails and mobile numbers per user" feature flag from the identity recovery codebase. As a result, the code now always handles multiple emails and mobile numbers per user, simplifying the logic and ensuring consistent behavior regardless of the previous configuration setting.

The most important changes are:

**Removal of Feature Flag Checks:**
* All references to the `Utils.isMultiEmailsAndMobileNumbersPerUserEnabled` method and related boolean variables (e.g., `supportMultipleEmails`, `supportMultipleMobileNumbers`) have been removed from `MobileNumberVerificationHandler.java`, `UserEmailVerificationHandler.java`, and `UserSelfRegistrationManager.java`. The code paths previously conditional on this flag now always execute the logic for multiple emails/mobile numbers. [[1]](diffhunk://#diff-a3020f0e614e3e8156422df806e7f9181b040bff14a515ce181e0dbfb2650a9cL122-L133) [[2]](diffhunk://#diff-d9563798eea549a0b0451cfb68c0a7a588b10038ae656cd6fc29ef12df4a5745L124-L126) [[3]](diffhunk://#diff-2d6464e51a37ccddbc57324c279309b49e5f4a211bbad5932080fc9670118aa7L844-L845)

**Simplification of Claim Handling Logic:**
* Conditional blocks that removed multi-valued claims or skipped updating them when the feature was disabled have been removed. The code now always updates or checks multi-valued claims for emails and mobile numbers. [[1]](diffhunk://#diff-a3020f0e614e3e8156422df806e7f9181b040bff14a515ce181e0dbfb2650a9cL153-R143) [[2]](diffhunk://#diff-d9563798eea549a0b0451cfb68c0a7a588b10038ae656cd6fc29ef12df4a5745L138-L145) [[3]](diffhunk://#diff-a3020f0e614e3e8156422df806e7f9181b040bff14a515ce181e0dbfb2650a9cL375) [[4]](diffhunk://#diff-d9563798eea549a0b0451cfb68c0a7a588b10038ae656cd6fc29ef12df4a5745L581)

**Consistent ThreadLocal and Claim Update Logic:**
* ThreadLocal flags and claim update methods that previously depended on the feature flag now always execute when relevant claims are present or absent, leading to more predictable state management. [[1]](diffhunk://#diff-a3020f0e614e3e8156422df806e7f9181b040bff14a515ce181e0dbfb2650a9cL441-R422) [[2]](diffhunk://#diff-d9563798eea549a0b0451cfb68c0a7a588b10038ae656cd6fc29ef12df4a5745L641-R634) [[3]](diffhunk://#diff-2d6464e51a37ccddbc57324c279309b49e5f4a211bbad5932080fc9670118aa7L886-R884)

**Code Cleanup:**
* Unused imports related to claim metadata management have been removed from `Utils.java`, further simplifying the codebase.

**Behavioral Impact:**
* The system now universally supports multiple emails and mobile numbers per user, eliminating the possibility of inconsistent behavior based on tenant or user store configuration. [[1]](diffhunk://#diff-2d6464e51a37ccddbc57324c279309b49e5f4a211bbad5932080fc9670118aa7L954-R952) [[2]](diffhunk://#diff-2d6464e51a37ccddbc57324c279309b49e5f4a211bbad5932080fc9670118aa7L1242-R1236)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Multi-email and multi-mobile number support is now always enabled, removing per-tenant configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->