### PR TITLE
Fix test failures

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandlerTest.java
@@ -488,7 +488,7 @@ public class MobileNumberVerificationHandlerTest {
 
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, null, NEW_MOBILE_NUMBER);
-        mockUtilMethods(true, false, false);
+        mockUtilMethods(true, false);
         mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
                 .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER, true);
         mockExistingPrimaryMobileNumber(EXISTING_NUMBER_1);
@@ -508,7 +508,7 @@ public class MobileNumberVerificationHandlerTest {
 
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 NEW_MOBILE_NUMBER, null, null);
-        mockUtilMethods(true, true, false);
+        mockUtilMethods(true, false);
         mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
                 .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER, true);
         mockExistingPrimaryMobileNumber(EXISTING_NUMBER_1);
@@ -531,7 +531,7 @@ public class MobileNumberVerificationHandlerTest {
 
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, null, NEW_MOBILE_NUMBER);
-        mockUtilMethods(true, false, false);
+        mockUtilMethods(true, false);
         mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
                 .ENABLE_SKIP_INITIATING_MOBILE_VERIFICATION_BY_PRIVILEGED_USER, true);
         mockVerificationPendingMobileNumber();

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandlerTest.java
@@ -759,7 +759,7 @@ public class UserEmailVerificationHandlerTest {
 
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, null, NEW_EMAIL);
-        mockUtilMethods(true, false, false, false);
+        mockUtilMethods(true, false, false);
         mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
                 .ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER, true);
         enterAdminInitiatedFlow();
@@ -778,7 +778,7 @@ public class UserEmailVerificationHandlerTest {
 
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 NEW_EMAIL, null, null);
-        mockUtilMethods(true, true, false, false);
+        mockUtilMethods(true, false, false);
         mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
                 .ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER, true);
         enterAdminInitiatedFlow();
@@ -799,7 +799,7 @@ public class UserEmailVerificationHandlerTest {
 
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, null, NEW_EMAIL);
-        mockUtilMethods(true, false, false, false);
+        mockUtilMethods(true, false, false);
         mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
                 .ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER, true);
         enterUserInitiatedFlow();
@@ -816,7 +816,7 @@ public class UserEmailVerificationHandlerTest {
 
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, null, NEW_EMAIL);
-        mockUtilMethods(true, false, false, false);
+        mockUtilMethods(true, false, false);
         mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
                 .ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER, true);
 
@@ -834,7 +834,7 @@ public class UserEmailVerificationHandlerTest {
 
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, null, NEW_EMAIL);
-        mockUtilMethods(true, false, false, false);
+        mockUtilMethods(true, false, false);
         mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig
                 .ENABLE_SKIP_INITIATING_EMAIL_VERIFICATION_BY_PRIVILEGED_USER, false);
         enterAdminInitiatedFlow();


### PR DESCRIPTION
### Proposed changes in this pull request
$subject

This pull request simplifies the unit tests for `MobileNumberVerificationHandler` and `UserEmailVerificationHandler` by updating the `mockUtilMethods` calls. The changes remove unnecessary arguments from these method calls, making the tests easier to maintain and understand.

**Test simplification:**

* Updated `mockUtilMethods` calls in `MobileNumberVerificationHandlerTest.java` to remove redundant boolean arguments, improving clarity in tests related to skipping mobile number verification. [[1]](diffhunk://#diff-551b3996c55b63dcd2ff75f6508eabe022ebd4e8049448e58fd965601fb41b74L491-R491) [[2]](diffhunk://#diff-551b3996c55b63dcd2ff75f6508eabe022ebd4e8049448e58fd965601fb41b74L511-R511) [[3]](diffhunk://#diff-551b3996c55b63dcd2ff75f6508eabe022ebd4e8049448e58fd965601fb41b74L534-R534)
* Updated `mockUtilMethods` calls in `UserEmailVerificationHandlerTest.java` to remove unnecessary arguments, simplifying tests for skipping email verification under various scenarios. [[1]](diffhunk://#diff-f86e6ece09d960748e867162e17d0ccdbbef75bd423be1b398b87cc1c0b629efL762-R762) [[2]](diffhunk://#diff-f86e6ece09d960748e867162e17d0ccdbbef75bd423be1b398b87cc1c0b629efL781-R781) [[3]](diffhunk://#diff-f86e6ece09d960748e867162e17d0ccdbbef75bd423be1b398b87cc1c0b629efL802-R802) [[4]](diffhunk://#diff-f86e6ece09d960748e867162e17d0ccdbbef75bd423be1b398b87cc1c0b629efL819-R819) [[5]](diffhunk://#diff-f86e6ece09d960748e867162e17d0ccdbbef75bd423be1b398b87cc1c0b629efL837-R837)