### PR TITLE
Fix password reset flow failure for secondary user store users

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
@@ -176,7 +176,15 @@ public class UserProvisioningExecutor implements Executor {
             password =
                     credentials.getOrDefault(PASSWORD_KEY, new DefaultPasswordGenerator().generatePassword());
 
-            String userStoreDomainName = resolveUserStoreDomain(user.getUsername());
+            // Prefer the userStoreDomain explicitly set on FlowUser (populated during flow initiation for
+            // secondary store users). Fall back to parsing the domain from the username string.
+            String userStoreDomainName;
+            if (StringUtils.isNotBlank(user.getUserStoreDomain())) {
+                userStoreDomainName = user.getUserStoreDomain().toUpperCase(ENGLISH);
+            } else {
+                userStoreDomainName = resolveUserStoreDomain(user.getUsername());
+            }
+
             UserStoreManager userStoreManager = getUserStoreManager(context.getTenantDomain(), userStoreDomainName,
                     context.getContextIdentifier(), context.getFlowType());
 
@@ -269,7 +277,19 @@ public class UserProvisioningExecutor implements Executor {
                 }
             }
         });
-        user.setUsername(resolveUsername(user, context.getTenantDomain()));
+         String resolvedUsername = resolveUsername(user, context.getTenantDomain());
+        // For registration flows the FlowUser has no userStoreDomain pre-populated (unlike password-reset flows
+        // where the user is identified during flow initiation). If the submitted username carries a domain
+        // prefix (e.g. "SecondaryJDBC/john"), extract it now so that the downstream domain resolution logic
+        // can rely on FlowUser.getUserStoreDomain() as the single source of truth.
+        if (StringUtils.isBlank(user.getUserStoreDomain())) {
+            int separatorIndex = resolvedUsername.indexOf(UserCoreConstants.DOMAIN_SEPARATOR);
+            if (separatorIndex >= 0) {
+                user.setUserStoreDomain(resolvedUsername.substring(0, separatorIndex).toUpperCase(ENGLISH));
+                resolvedUsername = resolvedUsername.substring(separatorIndex + 1);
+            }
+        }
+        user.setUsername(resolvedUsername);
         setUsernamePatternValidation(context);
         return user;
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
@@ -199,7 +199,6 @@ public class UserProvisioningExecutor implements Executor {
             userStoreManager.addUser(IdentityUtil.addDomainToName(user.getUsername(), userStoreDomainName),
                     String.valueOf(password), userRoles, userClaims, null);
             String userid = ((AbstractUserStoreManager) userStoreManager).getUserIDFromUserName(user.getUsername());
-            user.setUserStoreDomain(userStoreDomainName);
             user.setUserId(userid);
             createFederatedAssociations(user, context.getTenantDomain(), context.getContextIdentifier());
             if (LOG.isDebugEnabled()) {
@@ -277,14 +276,10 @@ public class UserProvisioningExecutor implements Executor {
         });
         String resolvedUsername = resolveUsername(user, context.getTenantDomain());
         // For registration flows the FlowUser has no userStoreDomain pre-populated (unlike password-reset flows
-        // where the user is identified during flow initiation). If the submitted username carries a domain
-        // prefix (e.g. "SecondaryJDBC/john"), extract it now so that the downstream domain resolution logic
+        // where the user is identified during flow initiation). Resolve and set it now so that downstream logic
         // can rely on FlowUser.getUserStoreDomain() as the single source of truth.
         if (StringUtils.isBlank(user.getUserStoreDomain())) {
-            int separatorIndex = resolvedUsername.indexOf(UserCoreConstants.DOMAIN_SEPARATOR);
-            if (separatorIndex >= 0) {
-                user.setUserStoreDomain(resolveUserStoreDomain(resolvedUsername));
-            }
+            user.setUserStoreDomain(resolveUserStoreDomain(resolvedUsername));
         }
         user.setUsername(resolvedUsername);
         setUsernamePatternValidation(context);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
@@ -286,7 +286,6 @@ public class UserProvisioningExecutor implements Executor {
             int separatorIndex = resolvedUsername.indexOf(UserCoreConstants.DOMAIN_SEPARATOR);
             if (separatorIndex >= 0) {
                 user.setUserStoreDomain(resolveUserStoreDomain(resolvedUsername));
-                resolvedUsername = resolvedUsername.substring(separatorIndex + 1);
             }
         }
         user.setUsername(resolvedUsername);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
@@ -129,7 +129,15 @@ public class UserProvisioningExecutor implements Executor {
             FlowUser user = updateUserProfile(context);
             Map<String, String> userClaims = user.getClaims();
 
-            String userStoreDomainName = resolveUserStoreDomain(user.getUsername());
+            // Prefer the userStoreDomain explicitly set on FlowUser (populated during flow initiation for
+            // secondary store users). Fall back to parsing the domain from the username string.
+            String userStoreDomainName;
+            if (StringUtils.isNotBlank(user.getUserStoreDomain())) {
+                userStoreDomainName = user.getUserStoreDomain().toUpperCase(ENGLISH);
+            } else {
+                userStoreDomainName = resolveUserStoreDomain(user.getUsername());
+            }
+
             UserStoreManager userStoreManager = getUserStoreManager(context.getTenantDomain(), userStoreDomainName,
                     context.getContextIdentifier(), context.getFlowType());
             String domainQualifiedName = IdentityUtil.addDomainToName(user.getUsername(), userStoreDomainName);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
@@ -133,7 +133,7 @@ public class UserProvisioningExecutor implements Executor {
             // secondary store users). Fall back to parsing the domain from the username string.
             String userStoreDomainName;
             if (StringUtils.isNotBlank(user.getUserStoreDomain())) {
-                userStoreDomainName = user.getUserStoreDomain().toUpperCase(ENGLISH);
+                userStoreDomainName = user.getUserStoreDomain();
             } else {
                 userStoreDomainName = resolveUserStoreDomain(user.getUsername());
             }
@@ -180,7 +180,7 @@ public class UserProvisioningExecutor implements Executor {
             // secondary store users). Fall back to parsing the domain from the username string.
             String userStoreDomainName;
             if (StringUtils.isNotBlank(user.getUserStoreDomain())) {
-                userStoreDomainName = user.getUserStoreDomain().toUpperCase(ENGLISH);
+                userStoreDomainName = user.getUserStoreDomain();
             } else {
                 userStoreDomainName = resolveUserStoreDomain(user.getUsername());
             }
@@ -285,7 +285,7 @@ public class UserProvisioningExecutor implements Executor {
         if (StringUtils.isBlank(user.getUserStoreDomain())) {
             int separatorIndex = resolvedUsername.indexOf(UserCoreConstants.DOMAIN_SEPARATOR);
             if (separatorIndex >= 0) {
-                user.setUserStoreDomain(resolvedUsername.substring(0, separatorIndex).toUpperCase(ENGLISH));
+                user.setUserStoreDomain(resolveUserStoreDomain(resolvedUsername));
                 resolvedUsername = resolvedUsername.substring(separatorIndex + 1);
             }
         }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
@@ -176,8 +176,6 @@ public class UserProvisioningExecutor implements Executor {
             password =
                     credentials.getOrDefault(PASSWORD_KEY, new DefaultPasswordGenerator().generatePassword());
 
-            // Prefer the userStoreDomain explicitly set on FlowUser (populated during flow initiation for
-            // secondary store users). Fall back to parsing the domain from the username string.
             String userStoreDomainName;
             if (StringUtils.isNotBlank(user.getUserStoreDomain())) {
                 userStoreDomainName = user.getUserStoreDomain();
@@ -277,7 +275,7 @@ public class UserProvisioningExecutor implements Executor {
                 }
             }
         });
-         String resolvedUsername = resolveUsername(user, context.getTenantDomain());
+        String resolvedUsername = resolveUsername(user, context.getTenantDomain());
         // For registration flows the FlowUser has no userStoreDomain pre-populated (unlike password-reset flows
         // where the user is identified during flow initiation). If the submitted username carries a domain
         // prefix (e.g. "SecondaryJDBC/john"), extract it now so that the downstream domain resolution logic


### PR DESCRIPTION
## Problem

Related issue: https://github.com/wso2/product-is/issues/27494

The password reset flow fails with a `UserNotFound` error for users in a secondary user store. When `UserProvisioningExecutor` handles non-registration flows (e.g. password reset), it resolves the user store domain by parsing a domain prefix from the username string (e.g. `"SECONDARY/jane"`). However, in the password reset flow the
username stored in `FlowUser` has no domain prefix — it is just `"jane"`. This causes `resolveUserStoreDomain()` to always fall back to `PRIMARY`, and the subsequent `setUserClaimValues` call fails because the user does not exist in the primary store.



## Root Cause

`resolveUserStoreDomain(user.getUsername())` returns `PRIMARY` when:
- The username has no domain prefix (common in password reset flow), and
- `FlowExecution.Registration.DefaultUserStore` is not configured
  (which is the default in most deployments).

## Fix

Prefer `FlowUser.getUserStoreDomain()` as the source of truth for the user store domain. This field is populated correctly when the user is identified during flow initiation (e.g. email OTP verification). `resolveUserStoreDomain()` is retained as a fallback for cases where the username itself carries a domain prefix but `userStoreDomain` is not explicitly set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * User provisioning now prioritizes an explicitly specified user store domain (including during registration), preventing incorrect account placement across multiple user stores.
  * Registration and profile updates now normalize resolved usernames and correctly strip/apply domain prefixes so stored profiles reflect the intended username and domain, improving account consistency and login reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->