### PR TITLE
Fix 500 error on duplicate self-registration with blocking outbound provisioning

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -242,6 +242,13 @@ public class UserSelfRegistrationManager {
                 String preferredChannel;
                 try {
 
+                    // Fail early if the user already exists to avoid triggering downstream listeners unnecessarily.
+                    if (userStoreManager.isExistingUser(
+                            IdentityUtil.addDomainToName(user.getUserName(), user.getUserStoreDomain()))) {
+                        throw Utils.handleClientException(
+                                IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS, user.getUserName());
+                    }
+
                     //TODO It is required to add this role before tenant creation. And also, this role should not not be able remove.
                     if (!userStoreManager.isExistingRole(IdentityRecoveryConstants.SELF_SIGNUP_ROLE)) {
                         Permission permission =


### PR DESCRIPTION
### Problem resolved

When outbound provisioning is enabled in blocking mode with `fail_on_blocking_outbound_provision_failure=true`, duplicate self-registration attempts via `/api/identity/user/v1.0/me` exhibit inconsistent behavior:

  - **1st attempt** → `201 Created` (user created locally + provisioned to target)
  - **2nd attempt** → `500 Internal Server Error` (provisioned user also gets deleted)
  - **3rd attempt onwards** → `409 Conflict` (expected)

### Fix

Added an early user existence check in `UserSelfRegistrationManager.registerUser()` before invoking `addUserWithID()`. If the user already exists, an `IdentityRecoveryClientException` with `ERROR_CODE_USER_ALREADY_EXISTS` is thrown  immediately, returning a consistent `409 Conflict` for all duplicate attempts.

This prevents:
  - Downstream user store listeners (outbound provisioning) from being triggered unnecessarily
  - The unintended compensating delete of the already provisioned user from the target system
  
  
### Related Issue
- https://github.com/wso2/product-is/issues/27181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent duplicate user registrations by checking if a username already exists at the start of the registration process, returning an appropriate error if a duplicate registration is attempted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->