### PR TITLE
Skip username validation if the user already exists in email username–enabled scenario

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/ExecutorConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/ExecutorConstants.java
@@ -60,7 +60,10 @@ public class ExecutorConstants {
         ERROR_CODE_RESOLVE_NOTIFICATION_PROPERTY_FAILURE("65003",
                 "Error while resolving notification properties.",
                 "Error occurred while resolving notification properties for user: %s " +
-                        "in the request of flow id: %s");
+                        "in the request of flow id: %s"),
+        ERROR_CODE_USER_EXISTENCE_CHECK_FAILURE("65004",
+                "Error while checking user existence.",
+                "Error occurred while checking the existence of user: %s in the request of flow id: %s.");
 
         private static final String ERROR_PREFIX = "FEE";
         private final String code;

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ApplicationBasicInfo;
 import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -81,6 +82,7 @@ import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.Execu
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_USERNAME_ALREADY_EXISTS;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_USERSTORE_MANAGER_FAILURE;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_USER_ONBOARD_FAILURE;
+import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_USER_EXISTENCE_CHECK_FAILURE;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_USER_PROVISIONING_FAILURE;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.REGISTRATION_DEFAULT_USER_STORE_CONFIG;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.USER_ALREADY_EXISTING_USERNAME;
@@ -261,7 +263,7 @@ public class UserProvisioningExecutor implements Executor {
                 }
             }
         });
-        user.setUsername(resolveUsername(user, context.getTenantDomain()));
+        user.setUsername(resolveUsername(user, context));
         setUsernamePatternValidation(context);
         return user;
     }
@@ -315,8 +317,9 @@ public class UserProvisioningExecutor implements Executor {
                 IdentityUtil.getPrimaryDomainName().toUpperCase(ENGLISH);
     }
 
-    private String resolveUsername(FlowUser user, String tenantDomain) throws FlowEngineException {
+    private String resolveUsername(FlowUser user, FlowExecutionContext context) throws FlowEngineException {
 
+        String tenantDomain = context.getTenantDomain();
         String username = Optional.ofNullable(user.getClaims().get(USERNAME_CLAIM_URI)).orElse("");
         if (StringUtils.isBlank(username)) {
             if ((FlowExecutionEngineUtils.isEmailUsernameValidator(tenantDomain) ||
@@ -329,10 +332,28 @@ public class UserProvisioningExecutor implements Executor {
             username = UUID.randomUUID().toString();
             UserCoreUtil.setSkipUsernamePatternValidationThreadLocal(true);
             return username;
-        } else if (IdentityUtil.isEmailUsernameEnabled() && !username.contains("@")) {
+        } else if (IdentityUtil.isEmailUsernameEnabled() && !username.contains("@")
+                && !isExistingUser(user, context)) {
             throw handleClientException(ERROR_CODE_INVALID_USERNAME, username);
         }
         return username;
+    }
+
+    private boolean isExistingUser(FlowUser user, FlowExecutionContext context) throws FlowEngineException {
+
+        try {
+            String userStoreDomain = StringUtils.isNotBlank(user.getUserStoreDomain())
+                    ? user.getUserStoreDomain()
+                    : resolveUserStoreDomain(user.getUsername());
+            UserStoreManager userStoreManager = getUserStoreManager(context.getTenantDomain(), userStoreDomain,
+                    context.getContextIdentifier(), context.getFlowType());
+            return userStoreManager.isExistingUser(user.getUsername());
+        } catch (UserStoreException e) {
+            String maskedUsername = LoggerUtils.isLogMaskingEnable
+                    ? LoggerUtils.getMaskedContent(user.getUsername()) : user.getUsername();
+            throw handleServerException(ERROR_CODE_USER_EXISTENCE_CHECK_FAILURE, e,
+                    maskedUsername, context.getContextIdentifier());
+        }
     }
 
     private void createFederatedAssociations(FlowUser user, String tenantDomain, String flowId) {

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutorTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutorTest.java
@@ -65,6 +65,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.EMAIL_ADDRESS_CLAIM;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_COMPLETE;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_ERROR;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_USER_ERROR;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.PASSWORD_KEY;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.USERNAME_CLAIM_URI;
@@ -635,6 +636,70 @@ public class UserProvisioningExecutorTest {
 
         assertEquals(response.getResult(), STATUS_USER_ERROR);
         assertEquals(response.getErrorCode(), ERROR_CODE_INVALID_USERNAME.getCode());
+    }
+
+    @Test
+    public void testIsExistingUserWithUserStoreDomainSet() throws Exception {
+
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        FlowUser flowUser = createTestFlowUser(USERNAME);
+        when(flowUser.getUserStoreDomain()).thenReturn(SECONDARY_DOMAIN);
+
+        when(context.getFlowType()).thenReturn(PASSWORD_RECOVERY.getType());
+        when(context.getFlowUser()).thenReturn(flowUser);
+        when(context.getUserInputData()).thenReturn(new HashMap<>());
+        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+        when(context.getContextIdentifier()).thenReturn(CONTEXT_ID);
+        when(context.getProperty("isUsernamePatternValidationSkipped")).thenReturn(null);
+
+        mockedIdentityUtil.when(IdentityUtil::isEmailUsernameEnabled).thenReturn(true);
+
+        IdentityRecoveryServiceDataHolder dataHolder = mock(IdentityRecoveryServiceDataHolder.class);
+        RealmService realmService = mock(RealmService.class);
+        UserRealm userRealm = mock(UserRealm.class);
+        AbstractUserStoreManager primaryStoreManager = mock(AbstractUserStoreManager.class);
+        AbstractUserStoreManager secondaryStoreManager = mock(AbstractUserStoreManager.class);
+
+        mockedDataHolder.when(IdentityRecoveryServiceDataHolder::getInstance).thenReturn(dataHolder);
+        when(dataHolder.getRealmService()).thenReturn(realmService);
+        when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
+        when(userRealm.getUserStoreManager()).thenReturn(primaryStoreManager);
+        when(primaryStoreManager.getSecondaryUserStoreManager(SECONDARY_DOMAIN)).thenReturn(secondaryStoreManager);
+        // User exists in secondary domain, so isExistingUser returns true and validation is skipped.
+        when(secondaryStoreManager.isExistingUser(USERNAME)).thenReturn(true);
+
+        mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN)).thenReturn(TENANT_ID);
+        mockedIdentityUtil.when(IdentityUtil::getPrimaryDomainName).thenReturn(PRIMARY_DOMAIN);
+        mockedIdentityUtil.when(() -> IdentityUtil.addDomainToName(anyString(), anyString()))
+                .thenReturn(PRIMARY_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + USERNAME);
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_COMPLETE);
+        verify(secondaryStoreManager).isExistingUser(USERNAME);
+    }
+
+    @Test
+    public void testIsExistingUserThrowsExceptionOnUserStoreFailure() throws Exception {
+
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        FlowUser flowUser = createTestFlowUser(USERNAME);
+
+        when(context.getFlowType()).thenReturn(PASSWORD_RECOVERY.getType());
+        when(context.getFlowUser()).thenReturn(flowUser);
+        when(context.getUserInputData()).thenReturn(new HashMap<>());
+        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+        when(context.getContextIdentifier()).thenReturn(CONTEXT_ID);
+        when(context.getProperty("isUsernamePatternValidationSkipped")).thenReturn(null);
+
+        mockedIdentityUtil.when(IdentityUtil::isEmailUsernameEnabled).thenReturn(true);
+        AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+        doThrow(new UserStoreException("User store connection error"))
+                .when(userStoreManager).isExistingUser(USERNAME);
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_ERROR);
     }
 
     private FlowUser createTestFlowUser(String username) {

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutorTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutorTest.java
@@ -68,8 +68,10 @@ import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorS
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_USER_ERROR;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.PASSWORD_KEY;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.USERNAME_CLAIM_URI;
+import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.PASSWORD_RECOVERY;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.REGISTRATION;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.DISPLAY_CLAIM_AVAILABILITY_CONFIG;
+import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_INVALID_USERNAME;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_USERNAME_ALREADY_EXISTS;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_USER_PROVISIONING_FAILURE;
 
@@ -584,6 +586,55 @@ public class UserProvisioningExecutorTest {
         assertEquals(response.getResult(), STATUS_COMPLETE);
         verify(internalUserStoreManager).addUser(eq("Internal/testuser"), anyString(),
                 any(), any(Map.class), any());
+    }
+
+    @Test
+    public void testExecutePasswordRecoveryWithNonEmailUsernameSkipsValidationForExistingUser() throws Exception {
+
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        FlowUser flowUser = createTestFlowUser(USERNAME);
+
+        when(context.getFlowType()).thenReturn(PASSWORD_RECOVERY.getType());
+        when(context.getFlowUser()).thenReturn(flowUser);
+        when(context.getUserInputData()).thenReturn(new HashMap<>());
+        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+        when(context.getContextIdentifier()).thenReturn(CONTEXT_ID);
+        when(context.getProperty("isUsernamePatternValidationSkipped")).thenReturn(null);
+
+        // Email username validation is enabled, but the username has no "@".
+        // Since the user already exists the validation should be skipped.
+        mockedIdentityUtil.when(IdentityUtil::isEmailUsernameEnabled).thenReturn(true);
+        AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+        when(userStoreManager.isExistingUser(USERNAME)).thenReturn(true);
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_COMPLETE);
+    }
+
+    @Test
+    public void testExecuteWithNonEmailUsernameFailsValidationForNonExistingUser() throws Exception {
+
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        FlowUser flowUser = createTestFlowUser(USERNAME);
+
+        when(context.getFlowType()).thenReturn(PASSWORD_RECOVERY.getType());
+        when(context.getFlowUser()).thenReturn(flowUser);
+        when(context.getUserInputData()).thenReturn(new HashMap<>());
+        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+        when(context.getContextIdentifier()).thenReturn(CONTEXT_ID);
+        when(context.getProperty("isUsernamePatternValidationSkipped")).thenReturn(null);
+
+        // Email username validation is enabled, the username has no "@", and the user does not exist.
+        // Validation should fire and return a user error.
+        mockedIdentityUtil.when(IdentityUtil::isEmailUsernameEnabled).thenReturn(true);
+        AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+        when(userStoreManager.isExistingUser(USERNAME)).thenReturn(false);
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_USER_ERROR);
+        assertEquals(response.getErrorCode(), ERROR_CODE_INVALID_USERNAME.getCode());
     }
 
     private FlowUser createTestFlowUser(String username) {

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutorTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutorTest.java
@@ -74,6 +74,7 @@ import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.REGISTRATION
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.DISPLAY_CLAIM_AVAILABILITY_CONFIG;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_INVALID_USERNAME;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_USERNAME_ALREADY_EXISTS;
+import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_USER_EXISTENCE_CHECK_FAILURE;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_USER_PROVISIONING_FAILURE;
 
 /**
@@ -700,6 +701,7 @@ public class UserProvisioningExecutorTest {
         ExecutorResponse response = executor.execute(context);
 
         assertEquals(response.getResult(), STATUS_ERROR);
+        assertEquals(response.getErrorCode(), ERROR_CODE_USER_EXISTENCE_CHECK_FAILURE.getCode());
     }
 
     private FlowUser createTestFlowUser(String username) {


### PR DESCRIPTION
### Purpose
> $subject

### Related Issue
- https://github.com/wso2/product-is/issues/27633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when verifying user existence during account provisioning and password recovery operations.
  * Enhanced username validation logic to properly handle non-email usernames when users already exist.

* **Tests**
  * Added new test scenarios for user existence checks and username validation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->