### PR TITLE
Skip captcha connector when tenant resolution fails for malformed username

### DIFF
--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -199,6 +199,8 @@
                             org.wso2.carbon.utils.httpclient5; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.application.common.model;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.base;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.util;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.model;

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/SSOLoginReCaptchaConfig.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/SSOLoginReCaptchaConfig.java
@@ -371,9 +371,6 @@ public class SSOLoginReCaptchaConfig extends AbstractReCaptchaConnector implemen
             }
             return false;
         } catch (IdentityRuntimeException e) {
-            // Username may carry an unresolvable tenant domain (e.g. malformed
-            // multi-`@` input). Skip this connector and let the downstream
-            // auth flow emit a proper client-side error.
             if (log.isDebugEnabled()) {
                 log.debug("Unable to resolve tenant from username while loading captcha "
                         + "connector configuration; skipping connector.", e);

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/SSOLoginReCaptchaConfig.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/SSOLoginReCaptchaConfig.java
@@ -372,8 +372,7 @@ public class SSOLoginReCaptchaConfig extends AbstractReCaptchaConnector implemen
             return false;
         } catch (IdentityRuntimeException e) {
             if (log.isDebugEnabled()) {
-                log.debug("Unable to resolve tenant from username while loading captcha "
-                        + "connector configuration; skipping connector.", e);
+                log.debug("Unable to load connector configuration.", e);
             }
             return false;
         }

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/SSOLoginReCaptchaConfig.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/SSOLoginReCaptchaConfig.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.identity.application.authentication.framework.context.Aut
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedIdPData;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.captcha.connector.CaptchaPostValidationResponse;
 import org.wso2.carbon.identity.captcha.connector.CaptchaPreValidationResponse;
 import org.wso2.carbon.identity.captcha.exception.CaptchaException;
@@ -367,6 +368,15 @@ public class SSOLoginReCaptchaConfig extends AbstractReCaptchaConnector implemen
             // Can happen due to invalid user/ invalid tenant/ invalid configuration.
             if (log.isDebugEnabled()) {
                 log.debug("Unable to load connector configuration.", e);
+            }
+            return false;
+        } catch (IdentityRuntimeException e) {
+            // Username may carry an unresolvable tenant domain (e.g. malformed
+            // multi-`@` input). Skip this connector and let the downstream
+            // auth flow emit a proper client-side error.
+            if (log.isDebugEnabled()) {
+                log.debug("Unable to resolve tenant from username while loading captcha "
+                        + "connector configuration; skipping connector.", e);
             }
             return false;
         }


### PR DESCRIPTION
## Issue

Fixes [wso2/product-is#27314](https://github.com/wso2/product-is/issues/27314)

## Root Cause

When reCAPTCHA is enabled, posting a malformed username (e.g. `user@@example.com`) to `/commonauth`, `/oauth2`, or `/samlsso` causes `CaptchaFilter` to call `SSOLoginReCaptchaConfig.canHandle`, which delegates to `isReCaptchaEnabledForSSOLogin`. That method extracts a tenant domain from the username via `MultitenantUtils.getTenantDomain`. For `user@@example.com` that yields `example.com`. The subsequent call to `IdentityGovernanceServiceImpl.getConfiguration` routes through `IdentityProviderManager.getResidentIdP` and `IdentityTenantUtil.getTenantId`, which throws an unchecked `IdentityRuntimeException: Invalid tenant domain example.com`. The existing `catch (IdentityGovernanceException e)` does not catch the runtime exception, so it propagates out of the filter and the user receives an HTTP 500 page with a stack trace instead of a normal authentication error.

## Change

`SSOLoginReCaptchaConfig.isReCaptchaEnabledForSSOLogin` now also catches `IdentityRuntimeException`, logs at debug, and returns `false`. When the connector cannot resolve a tenant from the supplied username it cleanly opts out and the request continues through the regular authentication chain, which rejects the malformed username with a normal client-side error.

The catch is kept narrow (`IdentityRuntimeException` only, not `Exception`) so unrelated bugs still surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when loading SSO login reCAPTCHA configuration so failures no longer cause an incorrect enabled state; the connector is now treated as disabled when configuration cannot be resolved.
  * Added debug-level logging to aid troubleshooting when configuration loading fails, without affecting runtime behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-extensions/identity-governance/pull/1126)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->