### PR TITLE
Make suspension-date format configurable

### DIFF
--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
@@ -61,6 +61,16 @@
             <artifactId>jacoco-maven-plugin</artifactId>
             <version>${jacoco.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -98,6 +108,16 @@
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <configuration>
                     <threshold>High</threshold>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
                 </configuration>
             </plugin>
             <plugin>

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/handler/AccountSuspensionNotificationHandler.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/handler/AccountSuspensionNotificationHandler.java
@@ -130,6 +130,7 @@ public class AccountSuspensionNotificationHandler extends AbstractEventHandler i
         nameMapping.put(NotificationConstants.SUSPENSION_NOTIFICATION_ACCOUNT_DISABLE_DELAY, "Allowed idle time span " +
                 "in days");
         nameMapping.put(NotificationConstants.SUSPENSION_NOTIFICATION_DELAYS, "Alert sending time periods in days");
+        nameMapping.put(NotificationConstants.SUSPENSION_NOTIFICATION_DATE_FORMAT, "Alert date format");
         return nameMapping;
 
     }
@@ -143,6 +144,8 @@ public class AccountSuspensionNotificationHandler extends AbstractEventHandler i
                 "days before locking the user account.");
         descriptionMapping.put(NotificationConstants.SUSPENSION_NOTIFICATION_DELAYS, "Send warning alerts to users " +
                 "before locking the account, after each period. Comma separated multiple values accepted.");
+        descriptionMapping.put(NotificationConstants.SUSPENSION_NOTIFICATION_DATE_FORMAT, "Date format of the " +
+                "suspension date in the idle account reminder email. Examples: dd-MM-yyyy, MM-dd-yyyy, yyyy/MM/dd.");
         return descriptionMapping;
     }
 
@@ -170,6 +173,7 @@ public class AccountSuspensionNotificationHandler extends AbstractEventHandler i
         properties.add(NotificationConstants.SUSPENSION_NOTIFICATION_ENABLED);
         properties.add(NotificationConstants.SUSPENSION_NOTIFICATION_ACCOUNT_DISABLE_DELAY);
         properties.add(NotificationConstants.SUSPENSION_NOTIFICATION_DELAYS);
+        properties.add(NotificationConstants.SUSPENSION_NOTIFICATION_DATE_FORMAT);
         return properties.toArray(new String[0]);
     }
 
@@ -186,6 +190,13 @@ public class AccountSuspensionNotificationHandler extends AbstractEventHandler i
 
         defaultProperties.put(NotificationConstants.SUSPENSION_NOTIFICATION_DELAYS,
                 configs.getModuleProperties().getProperty(NotificationConstants.SUSPENSION_NOTIFICATION_DELAYS));
+
+        String dateFormat = configs.getModuleProperties()
+                .getProperty(NotificationConstants.SUSPENSION_NOTIFICATION_DATE_FORMAT);
+        defaultProperties.put(NotificationConstants.SUSPENSION_NOTIFICATION_DATE_FORMAT,
+                StringUtils.isNotBlank(dateFormat)
+                        ? dateFormat
+                        : NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT);
 
         Properties properties = new Properties();
         properties.putAll(defaultProperties);

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/jdbc/JDBCNotificationReceiversRetrieval.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/jdbc/JDBCNotificationReceiversRetrieval.java
@@ -94,6 +94,8 @@ public class JDBCNotificationReceiversRetrieval implements NotificationReceivers
 
             String lastLoginClaim = NotificationConstants.LAST_LOGIN_TIME;
             String lastLoginTimeAttribute = claimManager.getAttributeName(userStoreDomain, lastLoginClaim);
+            SimpleDateFormat suspensionDateFormatter = new SimpleDateFormat(
+                    NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat());
 
             try (Connection dbConnection = getDBConnection(realmConfiguration)) {
                 String sqlStmt = NotificationConstants.GET_USERS_FILTERED_BY_LAST_LOGIN_TIME;
@@ -134,9 +136,7 @@ public class JDBCNotificationReceiversRetrieval implements NotificationReceivers
 
                                 long lastLoginTime = Long.parseLong(map.get(lastLoginClaim));
                                 long expireDate = lastLoginTime + TimeUnit.DAYS.toMillis(delayForSuspension);
-                                receiver.setExpireDate(new SimpleDateFormat(
-                                        NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat())
-                                        .format(new Date(expireDate)));
+                                receiver.setExpireDate(suspensionDateFormatter.format(new Date(expireDate)));
                                 users.add(receiver);
                             }
                         }

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/jdbc/JDBCNotificationReceiversRetrieval.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/jdbc/JDBCNotificationReceiversRetrieval.java
@@ -134,7 +134,9 @@ public class JDBCNotificationReceiversRetrieval implements NotificationReceivers
 
                                 long lastLoginTime = Long.parseLong(map.get(lastLoginClaim));
                                 long expireDate = lastLoginTime + TimeUnit.DAYS.toMillis(delayForSuspension);
-                                receiver.setExpireDate(new SimpleDateFormat("dd-MM-yyyy").format(new Date(expireDate)));
+                                receiver.setExpireDate(new SimpleDateFormat(
+                                        NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat())
+                                        .format(new Date(expireDate)));
                                 users.add(receiver);
                             }
                         }

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/jdbc/JDBCNotificationReceiversRetrieval.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/jdbc/JDBCNotificationReceiversRetrieval.java
@@ -95,7 +95,7 @@ public class JDBCNotificationReceiversRetrieval implements NotificationReceivers
             String lastLoginClaim = NotificationConstants.LAST_LOGIN_TIME;
             String lastLoginTimeAttribute = claimManager.getAttributeName(userStoreDomain, lastLoginClaim);
             SimpleDateFormat suspensionDateFormatter = new SimpleDateFormat(
-                    NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat());
+                    NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(tenantDomain));
 
             try (Connection dbConnection = getDBConnection(realmConfiguration)) {
                 String sqlStmt = NotificationConstants.GET_USERS_FILTERED_BY_LAST_LOGIN_TIME;

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/ldap/LDAPNotificationReceiversRetrieval.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/ldap/LDAPNotificationReceiversRetrieval.java
@@ -123,7 +123,7 @@ public class LDAPNotificationReceiversRetrieval implements NotificationReceivers
                 }
 
                 SimpleDateFormat suspensionDateFormatter = new SimpleDateFormat(
-                        NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat());
+                        NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(tenantDomain));
 
                 while (results.hasMoreElements()) {
                     SearchResult result = results.nextElement();

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/ldap/LDAPNotificationReceiversRetrieval.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/ldap/LDAPNotificationReceiversRetrieval.java
@@ -122,6 +122,9 @@ public class LDAPNotificationReceiversRetrieval implements NotificationReceivers
                     log.debug("LDAP user list retrieved.");
                 }
 
+                SimpleDateFormat suspensionDateFormatter = new SimpleDateFormat(
+                        NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat());
+
                 while (results.hasMoreElements()) {
                     SearchResult result = results.nextElement();
 
@@ -134,9 +137,7 @@ public class LDAPNotificationReceiversRetrieval implements NotificationReceivers
                     String lastLoginTimeValue = result.getAttributes().get(lastLoginTimeAttribute).get().toString();
                     long lastLoginTime = convertToWSO2DateFormat(lastLoginTimeValue);
                     long expireDate = lastLoginTime + TimeUnit.DAYS.toMillis(delayForSuspension);
-                    receiver.setExpireDate(new SimpleDateFormat(
-                            NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat())
-                            .format(new Date(expireDate)));
+                    receiver.setExpireDate(suspensionDateFormatter.format(new Date(expireDate)));
 
                     if (log.isDebugEnabled()) {
                         log.debug("Expire date was set to: " + receiver.getExpireDate());

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/ldap/LDAPNotificationReceiversRetrieval.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/ldap/LDAPNotificationReceiversRetrieval.java
@@ -134,7 +134,9 @@ public class LDAPNotificationReceiversRetrieval implements NotificationReceivers
                     String lastLoginTimeValue = result.getAttributes().get(lastLoginTimeAttribute).get().toString();
                     long lastLoginTime = convertToWSO2DateFormat(lastLoginTimeValue);
                     long expireDate = lastLoginTime + TimeUnit.DAYS.toMillis(delayForSuspension);
-                    receiver.setExpireDate(new SimpleDateFormat("dd-MM-yyyy").format(new Date(expireDate)));
+                    receiver.setExpireDate(new SimpleDateFormat(
+                            NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat())
+                            .format(new Date(expireDate)));
 
                     if (log.isDebugEnabled()) {
                         log.debug("Expire date was set to: " + receiver.getExpireDate());

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/EmailUtil.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/EmailUtil.java
@@ -40,7 +40,6 @@ import java.util.concurrent.TimeUnit;
 
 public class EmailUtil {
     private static final Log log = LogFactory.getLog(EmailUtil.class);
-    private static final String DATE_FORMAT = "dd-MM-yyyy";
     private static final String REMAINING_DATES ="remaining-days";
 
     private NotificationSender notificationSender;
@@ -77,7 +76,8 @@ public class EmailUtil {
         }
 
         try {
-            String remainingDates = calculateRemainingDays(receiver.getExpireDate(), DATE_FORMAT);
+            String remainingDates = calculateRemainingDays(receiver.getExpireDate(),
+                    NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat());
             properties.put(REMAINING_DATES, remainingDates);
         } catch (ParseException e) {
             log.error("Error while calculating remaining days", e);

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/EmailUtil.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/EmailUtil.java
@@ -76,8 +76,9 @@ public class EmailUtil {
         }
 
         try {
+            String tenantDomain = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
             String remainingDates = calculateRemainingDays(receiver.getExpireDate(),
-                    NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat());
+                    NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(tenantDomain));
             properties.put(REMAINING_DATES, remainingDates);
         } catch (ParseException e) {
             log.error("Error while calculating remaining days", e);

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationConstants.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationConstants.java
@@ -28,7 +28,7 @@ public class NotificationConstants {
     public static final String SUSPENSION_NOTIFICATION_DELAYS="suspension.notification.delays";
     public static final String USE_IDENTITY_CLAIM_FOR_LAST_LOGIN_TIME = "AccountSuspension.UseIdentityClaims";
     public static final String EXECUTE_TASK_IN_MASTER_NODE = "AccountSuspension.ExecuteTaskOnMasterNode";
-    public static final String SUSPENSION_DATE_FORMAT_CONFIG = "AccountSuspension.SuspensionDateFormat";
+    public static final String SUSPENSION_NOTIFICATION_DATE_FORMAT = "suspension.notification.date.format";
     public static final String DEFAULT_SUSPENSION_DATE_FORMAT = "dd-MM-yyyy";
     public static final String TRIGGER_TIME_FORMAT = "HH:mm:ss";
     public static final long SCHEDULER_DELAY = 24; // In hours

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationConstants.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationConstants.java
@@ -28,6 +28,8 @@ public class NotificationConstants {
     public static final String SUSPENSION_NOTIFICATION_DELAYS="suspension.notification.delays";
     public static final String USE_IDENTITY_CLAIM_FOR_LAST_LOGIN_TIME = "AccountSuspension.UseIdentityClaims";
     public static final String EXECUTE_TASK_IN_MASTER_NODE = "AccountSuspension.ExecuteTaskOnMasterNode";
+    public static final String SUSPENSION_DATE_FORMAT_CONFIG = "AccountSuspension.SuspensionDateFormat";
+    public static final String DEFAULT_SUSPENSION_DATE_FORMAT = "dd-MM-yyyy";
     public static final String TRIGGER_TIME_FORMAT = "HH:mm:ss";
     public static final long SCHEDULER_DELAY = 24; // In hours
     public static final String SUSPENSION_NOTIFICATION_THREAD_POOL_SIZE = "suspension.notification.thread.pool.size";

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationReceiversRetrievalUtil.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationReceiversRetrievalUtil.java
@@ -25,9 +25,12 @@ import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.account.suspension.notification.task.NotificationReceiversRetrieval;
 import org.wso2.carbon.identity.account.suspension.notification.task.exception.AccountSuspensionNotificationException;
 import org.wso2.carbon.identity.account.suspension.notification.task.internal.NotificationTaskDataHolder;
+import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.governance.IdentityGovernanceException;
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserCoreConstants;
@@ -54,9 +57,24 @@ public class NotificationReceiversRetrievalUtil {
     public static final String NOTIFICATION_RECEIVERS_RETRIEVAL_CLASS = "NotificationReceiversRetrievalClass";
     private static final Log log = LogFactory.getLog(NotificationReceiversRetrievalUtil.class);
 
-    public static String resolveSuspensionDateFormat() {
+    public static String resolveSuspensionDateFormat(String tenantDomain) {
 
-        String configured = IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG);
+        String configured = null;
+        IdentityGovernanceService governanceService = NotificationTaskDataHolder.getInstance()
+                .getIdentityGovernanceService();
+        if (governanceService != null) {
+            try {
+                Property[] props = governanceService.getConfiguration(
+                        new String[]{NotificationConstants.SUSPENSION_NOTIFICATION_DATE_FORMAT}, tenantDomain);
+                if (props != null && props.length > 0 && props[0] != null) {
+                    configured = props[0].getValue();
+                }
+            } catch (IdentityGovernanceException e) {
+                log.warn("Failed to read " + NotificationConstants.SUSPENSION_NOTIFICATION_DATE_FORMAT
+                        + " from governance service for tenant: " + tenantDomain
+                        + "; falling back to " + NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT, e);
+            }
+        }
         if (StringUtils.isBlank(configured)) {
             return NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT;
         }
@@ -64,8 +82,8 @@ public class NotificationReceiversRetrievalUtil {
             new SimpleDateFormat(configured);
             return configured;
         } catch (IllegalArgumentException e) {
-            log.warn("Invalid SimpleDateFormat pattern '" + configured + "' configured under "
-                    + NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG
+            log.warn("Invalid SimpleDateFormat pattern configured under "
+                    + NotificationConstants.SUSPENSION_NOTIFICATION_DATE_FORMAT
                     + "; falling back to " + NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT);
             return NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT;
         }
@@ -216,7 +234,7 @@ public class NotificationReceiversRetrievalUtil {
 
         List<NotificationReceiver> users = new ArrayList<>();
         String sqlStmt = NotificationConstants.GET_USERS_FILTERED_BY_LAST_LOGIN_TIME_IDENTITY_CLAIM;
-        SimpleDateFormat suspensionDateFormatter = new SimpleDateFormat(resolveSuspensionDateFormat());
+        SimpleDateFormat suspensionDateFormatter = new SimpleDateFormat(resolveSuspensionDateFormat(tenantDomain));
         try (Connection connection = IdentityDatabaseUtil.getDBConnection(true)) {
             try (PreparedStatement prepStmt = connection.prepareStatement(sqlStmt)) {
                 prepStmt.setString(1, NotificationConstants.LAST_LOGIN_TIME_IDENTITY_CLAIM);

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationReceiversRetrievalUtil.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationReceiversRetrievalUtil.java
@@ -216,6 +216,7 @@ public class NotificationReceiversRetrievalUtil {
 
         List<NotificationReceiver> users = new ArrayList<>();
         String sqlStmt = NotificationConstants.GET_USERS_FILTERED_BY_LAST_LOGIN_TIME_IDENTITY_CLAIM;
+        SimpleDateFormat suspensionDateFormatter = new SimpleDateFormat(resolveSuspensionDateFormat());
         try (Connection connection = IdentityDatabaseUtil.getDBConnection(true)) {
             try (PreparedStatement prepStmt = connection.prepareStatement(sqlStmt)) {
                 prepStmt.setString(1, NotificationConstants.LAST_LOGIN_TIME_IDENTITY_CLAIM);
@@ -244,8 +245,7 @@ public class NotificationReceiversRetrievalUtil {
 
                                 long lastLoginTime = Long.parseLong(resultSet.getString(2));
                                 long expireDate = lastLoginTime + TimeUnit.DAYS.toMillis(delayForSuspension);
-                                receiver.setExpireDate(new SimpleDateFormat(resolveSuspensionDateFormat())
-                                        .format(new Date(expireDate)));
+                                receiver.setExpireDate(suspensionDateFormatter.format(new Date(expireDate)));
                                 users.add(receiver);
                             }
                         }

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationReceiversRetrievalUtil.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationReceiversRetrievalUtil.java
@@ -54,6 +54,23 @@ public class NotificationReceiversRetrievalUtil {
     public static final String NOTIFICATION_RECEIVERS_RETRIEVAL_CLASS = "NotificationReceiversRetrievalClass";
     private static final Log log = LogFactory.getLog(NotificationReceiversRetrievalUtil.class);
 
+    public static String resolveSuspensionDateFormat() {
+
+        String configured = IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG);
+        if (StringUtils.isBlank(configured)) {
+            return NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT;
+        }
+        try {
+            new SimpleDateFormat(configured);
+            return configured;
+        } catch (IllegalArgumentException e) {
+            log.warn("Invalid SimpleDateFormat pattern '" + configured + "' configured under "
+                    + NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG
+                    + "; falling back to " + NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT);
+            return NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT;
+        }
+    }
+
     public static Set<String> getSuspensionNotificationEnabledUserStores(String tenantDomain)
             throws AccountSuspensionNotificationException {
 
@@ -227,7 +244,8 @@ public class NotificationReceiversRetrievalUtil {
 
                                 long lastLoginTime = Long.parseLong(resultSet.getString(2));
                                 long expireDate = lastLoginTime + TimeUnit.DAYS.toMillis(delayForSuspension);
-                                receiver.setExpireDate(new SimpleDateFormat("dd-MM-yyyy").format(new Date(expireDate)));
+                                receiver.setExpireDate(new SimpleDateFormat(resolveSuspensionDateFormat())
+                                        .format(new Date(expireDate)));
                                 users.add(receiver);
                             }
                         }

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/test/java/org/wso2/carbon/identity/account/suspension/notification/task/util/EmailUtilTest.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/test/java/org/wso2/carbon/identity/account/suspension/notification/task/util/EmailUtilTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.account.suspension.notification.task.util;
+
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class EmailUtilTest {
+
+    private MockedStatic<IdentityUtil> identityUtilMock;
+    private static final int DAY_DELTA_TOLERANCE = 1;
+
+    @BeforeMethod
+    public void setUp() {
+
+        identityUtilMock = mockStatic(IdentityUtil.class);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        identityUtilMock.close();
+    }
+
+    @Test
+    public void testCalculateRemainingDaysWithDefaultPattern() throws Exception {
+
+        int offsetDays = 9;
+        String pattern = "dd-MM-yyyy";
+        String suspensionDate = futureDateAsString(offsetDays, pattern);
+
+        long actual = invokeCalculateRemainingDays(suspensionDate, pattern);
+
+        assertWithinTolerance(actual, offsetDays);
+    }
+
+    @Test
+    public void testCalculateRemainingDaysWithMMddyyyy() throws Exception {
+
+        int offsetDays = 9;
+        String pattern = "MM-dd-yyyy";
+        String suspensionDate = futureDateAsString(offsetDays, pattern);
+
+        long actual = invokeCalculateRemainingDays(suspensionDate, pattern);
+
+        assertWithinTolerance(actual, offsetDays);
+    }
+
+    @DataProvider(name = "round-trip-patterns")
+    public Object[][] roundTripPatterns() {
+
+        return new Object[][] {
+                {"dd-MM-yyyy"},
+                {"MM-dd-yyyy"},
+                {"yyyy/MM/dd"},
+                {"yyyy-MM-dd"},
+                {"dd MMM yyyy"},
+        };
+    }
+
+    @Test(dataProvider = "round-trip-patterns")
+    public void testCalculateRemainingDaysRoundTrip(String pattern) throws Exception {
+
+        int offsetDays = 7;
+        String suspensionDate = futureDateAsString(offsetDays, pattern);
+
+        long actual = invokeCalculateRemainingDays(suspensionDate, pattern);
+
+        assertWithinTolerance(actual, offsetDays);
+    }
+
+    @Test
+    public void testCalculateRemainingDaysWithPastSuspensionDate() throws Exception {
+
+        int offsetDays = -3;
+        String pattern = "dd-MM-yyyy";
+        String suspensionDate = futureDateAsString(offsetDays, pattern);
+
+        long actual = invokeCalculateRemainingDays(suspensionDate, pattern);
+
+        assertWithinTolerance(actual, offsetDays);
+    }
+
+    @Test(expectedExceptions = ParseException.class)
+    public void testCalculateRemainingDaysThrowsOnUnparseable() throws Throwable {
+
+        try {
+            invokeCalculateRemainingDays("not-a-date-at-all", "dd-MM-yyyy");
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    @Test
+    public void testResolverProducesSamePatternForFormatterAndParser() {
+
+        String configuredPattern = "MM-dd-yyyy";
+        when(IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG))
+                .thenReturn(configuredPattern);
+
+        String resolved = NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat();
+        assertEquals(resolved, configuredPattern);
+
+        try {
+            String suspensionDate = futureDateAsString(9, resolved);
+            long days = invokeCalculateRemainingDays(suspensionDate, resolved);
+            assertWithinTolerance(days, 9);
+        } catch (Exception e) {
+            fail("Round-trip with resolver-provided pattern threw: " + e, e);
+        }
+    }
+
+    @Test
+    public void testResolverDefaultFallbackKeepsParserOnDdMMyyyy() throws Exception {
+
+        when(IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG))
+                .thenReturn(null);
+
+        String resolved = NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat();
+        assertEquals(resolved, NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT);
+
+        String suspensionDate = futureDateAsString(5, resolved);
+        long days = invokeCalculateRemainingDays(suspensionDate, resolved);
+        assertWithinTolerance(days, 5);
+    }
+
+    private long invokeCalculateRemainingDays(String suspensionDate, String dateFormat) throws Exception {
+
+        Method m = EmailUtil.class.getDeclaredMethod("calculateRemainingDays", String.class, String.class);
+        m.setAccessible(true);
+        return Long.parseLong((String) m.invoke(new EmailUtil(), suspensionDate, dateFormat));
+    }
+
+    private String futureDateAsString(int offsetDays, String pattern) {
+
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.DAY_OF_YEAR, offsetDays);
+        return new SimpleDateFormat(pattern).format(cal.getTime());
+    }
+
+    private void assertWithinTolerance(long actual, int expected) {
+
+        long diff = Math.abs(actual - expected);
+        assertTrue(diff <= DAY_DELTA_TOLERANCE,
+                "actual=" + actual + " expected=~" + expected + " diff=" + diff);
+    }
+}

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/test/java/org/wso2/carbon/identity/account/suspension/notification/task/util/EmailUtilTest.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/test/java/org/wso2/carbon/identity/account/suspension/notification/task/util/EmailUtilTest.java
@@ -17,12 +17,13 @@
  */
 package org.wso2.carbon.identity.account.suspension.notification.task.util;
 
-import org.mockito.MockedStatic;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.account.suspension.notification.task.internal.NotificationTaskDataHolder;
+import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.governance.IdentityGovernanceException;
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -30,7 +31,8 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 
-import static org.mockito.Mockito.mockStatic;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -38,19 +40,14 @@ import static org.testng.Assert.fail;
 
 public class EmailUtilTest {
 
-    private MockedStatic<IdentityUtil> identityUtilMock;
+    private static final String TENANT_DOMAIN = "carbon.super";
+
     private static final int DAY_DELTA_TOLERANCE = 1;
-
-    @BeforeMethod
-    public void setUp() {
-
-        identityUtilMock = mockStatic(IdentityUtil.class);
-    }
 
     @AfterMethod
     public void tearDown() {
 
-        identityUtilMock.close();
+        NotificationTaskDataHolder.getInstance().setIdentityGovernanceService(null);
     }
 
     @Test
@@ -123,13 +120,12 @@ public class EmailUtilTest {
     }
 
     @Test
-    public void testResolverProducesSamePatternForFormatterAndParser() {
+    public void testResolverProducesSamePatternForFormatterAndParser() throws Exception {
 
         String configuredPattern = "MM-dd-yyyy";
-        when(IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG))
-                .thenReturn(configuredPattern);
+        mockGovernanceProperty(configuredPattern);
 
-        String resolved = NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat();
+        String resolved = NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(TENANT_DOMAIN);
         assertEquals(resolved, configuredPattern);
 
         try {
@@ -144,10 +140,9 @@ public class EmailUtilTest {
     @Test
     public void testResolverDefaultFallbackKeepsParserOnDdMMyyyy() throws Exception {
 
-        when(IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG))
-                .thenReturn(null);
+        mockGovernanceProperty(null);
 
-        String resolved = NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat();
+        String resolved = NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(TENANT_DOMAIN);
         assertEquals(resolved, NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT);
 
         String suspensionDate = futureDateAsString(5, resolved);
@@ -174,5 +169,16 @@ public class EmailUtilTest {
         long diff = Math.abs(actual - expected);
         assertTrue(diff <= DAY_DELTA_TOLERANCE,
                 "actual=" + actual + " expected=~" + expected + " diff=" + diff);
+    }
+
+    private void mockGovernanceProperty(String value) throws IdentityGovernanceException {
+
+        IdentityGovernanceService service = mock(IdentityGovernanceService.class);
+        Property property = new Property();
+        property.setName(NotificationConstants.SUSPENSION_NOTIFICATION_DATE_FORMAT);
+        property.setValue(value);
+        when(service.getConfiguration(any(String[].class), any(String.class)))
+                .thenReturn(new Property[]{property});
+        NotificationTaskDataHolder.getInstance().setIdentityGovernanceService(service);
     }
 }

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/test/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationReceiversRetrievalUtilTest.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/test/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationReceiversRetrievalUtilTest.java
@@ -17,61 +17,76 @@
  */
 package org.wso2.carbon.identity.account.suspension.notification.task.util;
 
-import org.mockito.MockedStatic;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.account.suspension.notification.task.internal.NotificationTaskDataHolder;
+import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.governance.IdentityGovernanceException;
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import static org.mockito.Mockito.mockStatic;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 public class NotificationReceiversRetrievalUtilTest {
 
-    private MockedStatic<IdentityUtil> identityUtilMock;
-
-    @BeforeMethod
-    public void setUp() {
-
-        identityUtilMock = mockStatic(IdentityUtil.class);
-    }
+    private static final String TENANT_DOMAIN = "carbon.super";
 
     @AfterMethod
     public void tearDown() {
 
-        identityUtilMock.close();
+        NotificationTaskDataHolder.getInstance().setIdentityGovernanceService(null);
     }
 
     @Test
-    public void testResolveSuspensionDateFormatReturnsDefaultWhenPropertyNotSet() {
+    public void testResolveSuspensionDateFormatReturnsDefaultWhenGovernanceServiceNull() {
 
-        when(IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG)).thenReturn(null);
-
-        assertEquals(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(),
+        assertEquals(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(TENANT_DOMAIN),
                 NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT);
         assertEquals(NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT, "dd-MM-yyyy");
     }
 
     @Test
-    public void testResolveSuspensionDateFormatReturnsDefaultWhenPropertyEmpty() {
+    public void testResolveSuspensionDateFormatReturnsDefaultWhenPropertyNotSet() throws Exception {
 
-        when(IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG)).thenReturn("");
+        mockGovernanceProperty(null);
 
-        assertEquals(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(),
+        assertEquals(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(TENANT_DOMAIN),
                 NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT);
     }
 
     @Test
-    public void testResolveSuspensionDateFormatReturnsDefaultWhenPropertyWhitespace() {
+    public void testResolveSuspensionDateFormatReturnsDefaultWhenPropertyEmpty() throws Exception {
 
-        when(IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG)).thenReturn("   ");
+        mockGovernanceProperty("");
 
-        assertEquals(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(),
+        assertEquals(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(TENANT_DOMAIN),
+                NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT);
+    }
+
+    @Test
+    public void testResolveSuspensionDateFormatReturnsDefaultWhenPropertyWhitespace() throws Exception {
+
+        mockGovernanceProperty("   ");
+
+        assertEquals(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(TENANT_DOMAIN),
+                NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT);
+    }
+
+    @Test
+    public void testResolveSuspensionDateFormatFallsBackWhenGovernanceThrows() throws Exception {
+
+        IdentityGovernanceService service = mock(IdentityGovernanceService.class);
+        when(service.getConfiguration(any(String[].class), any(String.class)))
+                .thenThrow(new IdentityGovernanceException("test failure"));
+        NotificationTaskDataHolder.getInstance().setIdentityGovernanceService(service);
+
+        assertEquals(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(TENANT_DOMAIN),
                 NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT);
     }
 
@@ -88,12 +103,11 @@ public class NotificationReceiversRetrievalUtilTest {
     }
 
     @Test(dataProvider = "validPatterns")
-    public void testResolveSuspensionDateFormatReturnsConfiguredPattern(String configuredPattern) {
+    public void testResolveSuspensionDateFormatReturnsConfiguredPattern(String configuredPattern) throws Exception {
 
-        when(IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG))
-                .thenReturn(configuredPattern);
+        mockGovernanceProperty(configuredPattern);
 
-        assertEquals(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(), configuredPattern);
+        assertEquals(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(TENANT_DOMAIN), configuredPattern);
     }
 
     @DataProvider(name = "invalidPatterns")
@@ -106,47 +120,58 @@ public class NotificationReceiversRetrievalUtilTest {
     }
 
     @Test(dataProvider = "invalidPatterns")
-    public void testResolveSuspensionDateFormatFallsBackOnInvalidPattern(String invalidPattern) {
+    public void testResolveSuspensionDateFormatFallsBackOnInvalidPattern(String invalidPattern) throws Exception {
 
-        when(IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG))
-                .thenReturn(invalidPattern);
+        mockGovernanceProperty(invalidPattern);
 
-        assertEquals(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(),
+        assertEquals(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(TENANT_DOMAIN),
                 NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT);
     }
 
-    // Date(126, 4, 17) = 2026-05-17 anchored at local midnight (timezone-stable for the assertion).
+    // Date(126, 4, 17) = 2026-05-17 anchored at local midnight (timezone-stable).
     @Test
-    public void testConfiguredPatternIsAppliedWhenFormattingExpireDate() {
+    public void testConfiguredPatternIsAppliedWhenFormattingExpireDate() throws Exception {
 
-        when(IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG))
-                .thenReturn("MM-dd-yyyy");
+        mockGovernanceProperty("MM-dd-yyyy");
 
         Date someDate = new Date(126, 4, 17);
-        String rendered = new SimpleDateFormat(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat())
+        String rendered = new SimpleDateFormat(
+                NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(TENANT_DOMAIN))
                 .format(someDate);
 
         assertEquals(rendered, "05-17-2026");
     }
 
     @Test
-    public void testDefaultPatternIsAppliedWhenFormattingExpireDate() {
+    public void testDefaultPatternIsAppliedWhenFormattingExpireDate() throws Exception {
 
-        when(IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG)).thenReturn(null);
+        mockGovernanceProperty(null);
 
         Date someDate = new Date(126, 4, 17);
-        String rendered = new SimpleDateFormat(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat())
+        String rendered = new SimpleDateFormat(
+                NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(TENANT_DOMAIN))
                 .format(someDate);
 
         assertEquals(rendered, "17-05-2026");
     }
 
-    // Pin customer-facing TOML/XML key + default value — patch contract surface.
+    // Pin customer-facing governance property name + default value — patch contract surface.
     @Test
     public void testConstantsForCustomerFacingContract() {
 
-        assertEquals(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG,
-                "AccountSuspension.SuspensionDateFormat");
+        assertEquals(NotificationConstants.SUSPENSION_NOTIFICATION_DATE_FORMAT,
+                "suspension.notification.date.format");
         assertEquals(NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT, "dd-MM-yyyy");
+    }
+
+    private void mockGovernanceProperty(String value) throws IdentityGovernanceException {
+
+        IdentityGovernanceService service = mock(IdentityGovernanceService.class);
+        Property property = new Property();
+        property.setName(NotificationConstants.SUSPENSION_NOTIFICATION_DATE_FORMAT);
+        property.setValue(value);
+        when(service.getConfiguration(any(String[].class), any(String.class)))
+                .thenReturn(new Property[]{property});
+        NotificationTaskDataHolder.getInstance().setIdentityGovernanceService(service);
     }
 }

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/test/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationReceiversRetrievalUtilTest.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/test/java/org/wso2/carbon/identity/account/suspension/notification/task/util/NotificationReceiversRetrievalUtilTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.account.suspension.notification.task.util;
+
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+public class NotificationReceiversRetrievalUtilTest {
+
+    private MockedStatic<IdentityUtil> identityUtilMock;
+
+    @BeforeMethod
+    public void setUp() {
+
+        identityUtilMock = mockStatic(IdentityUtil.class);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        identityUtilMock.close();
+    }
+
+    @Test
+    public void testResolveSuspensionDateFormatReturnsDefaultWhenPropertyNotSet() {
+
+        when(IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG)).thenReturn(null);
+
+        assertEquals(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(),
+                NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT);
+        assertEquals(NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT, "dd-MM-yyyy");
+    }
+
+    @Test
+    public void testResolveSuspensionDateFormatReturnsDefaultWhenPropertyEmpty() {
+
+        when(IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG)).thenReturn("");
+
+        assertEquals(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(),
+                NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT);
+    }
+
+    @Test
+    public void testResolveSuspensionDateFormatReturnsDefaultWhenPropertyWhitespace() {
+
+        when(IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG)).thenReturn("   ");
+
+        assertEquals(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(),
+                NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT);
+    }
+
+    @DataProvider(name = "validPatterns")
+    public Object[][] validPatterns() {
+
+        return new Object[][] {
+                {"MM-dd-yyyy"},
+                {"yyyy/MM/dd"},
+                {"yyyy-MM-dd"},
+                {"dd MMM yyyy"},
+                {"EEEE, MMMM dd, yyyy"}
+        };
+    }
+
+    @Test(dataProvider = "validPatterns")
+    public void testResolveSuspensionDateFormatReturnsConfiguredPattern(String configuredPattern) {
+
+        when(IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG))
+                .thenReturn(configuredPattern);
+
+        assertEquals(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(), configuredPattern);
+    }
+
+    @DataProvider(name = "invalidPatterns")
+    public Object[][] invalidPatterns() {
+
+        return new Object[][] {
+                {"invalid-[[pattern"},
+                {"yyyy-MM-dd 'unterminated"}
+        };
+    }
+
+    @Test(dataProvider = "invalidPatterns")
+    public void testResolveSuspensionDateFormatFallsBackOnInvalidPattern(String invalidPattern) {
+
+        when(IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG))
+                .thenReturn(invalidPattern);
+
+        assertEquals(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat(),
+                NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT);
+    }
+
+    // Date(126, 4, 17) = 2026-05-17 anchored at local midnight (timezone-stable for the assertion).
+    @Test
+    public void testConfiguredPatternIsAppliedWhenFormattingExpireDate() {
+
+        when(IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG))
+                .thenReturn("MM-dd-yyyy");
+
+        Date someDate = new Date(126, 4, 17);
+        String rendered = new SimpleDateFormat(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat())
+                .format(someDate);
+
+        assertEquals(rendered, "05-17-2026");
+    }
+
+    @Test
+    public void testDefaultPatternIsAppliedWhenFormattingExpireDate() {
+
+        when(IdentityUtil.getProperty(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG)).thenReturn(null);
+
+        Date someDate = new Date(126, 4, 17);
+        String rendered = new SimpleDateFormat(NotificationReceiversRetrievalUtil.resolveSuspensionDateFormat())
+                .format(someDate);
+
+        assertEquals(rendered, "17-05-2026");
+    }
+
+    // Pin customer-facing TOML/XML key + default value — patch contract surface.
+    @Test
+    public void testConstantsForCustomerFacingContract() {
+
+        assertEquals(NotificationConstants.SUSPENSION_DATE_FORMAT_CONFIG,
+                "AccountSuspension.SuspensionDateFormat");
+        assertEquals(NotificationConstants.DEFAULT_SUSPENSION_DATE_FORMAT, "dd-MM-yyyy");
+    }
+}

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/test/resources/testng.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+~
+~ WSO2 Inc. licenses this file to you under the Apache License,
+~ Version 2.0 (the "License"); you may not use this file except
+~ in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Account-Suspension-Notification-Test-Suite">
+
+    <test name="account-suspension-notification-tests" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.carbon.identity.account.suspension.notification.task.util.NotificationReceiversRetrievalUtilTest"/>
+            <class name="org.wso2.carbon.identity.account.suspension.notification.task.util.EmailUtilTest"/>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
## Summary
- Add `AccountSuspension.SuspensionDateFormat` config; default `dd-MM-yyyy` keeps existing behaviour byte-identical.
- Shared resolver wired into identity-claim, JDBC, LDAP retrieval paths + `EmailUtil` parser. Invalid pattern → fallback + warn.

## Related
- wso2/product-is#27784
- https://github.com/wso2/carbon-identity-framework/pull/8098

## Test plan
- [x] 24 unit tests pass (`mvn test`).
- [x] Dev-tested on wso2is-5.11.0 with patched pack + Mailpit (port of same fix): default-off / `MM-dd-yyyy` / invalid-pattern fallback for identity-claim and LDAP-direct (`UseIdentityClaims=false`) paths. Email body shows correct date + `{{remaining-days}}`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Suspension date formatting is now configurable for account suspension notification emails, with sensible defaults and tenant-specific overrides.

* **Tests**
  * Added comprehensive unit tests covering date-format resolution and remaining-days calculations across multiple patterns and edge cases.

* **Chores**
  * Test configuration updated to run the new test suite during build.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-extensions/identity-governance/pull/1128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->