### PR TITLE
Add mobile number verification of update expiry time for recovery event properties

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -96,7 +96,8 @@ public class IdentityRecoveryConstants {
     public static final String CONFIRMATION_CODE_INPUT = "confirmationCode";
     public static final String NOTIFICATION_CHANNEL = "notification-channel";
     public static final String RECOVERY_SCENARIO = "recovery-scenario";
-    public static final String USER = "user";;
+    public static final String USER = "user";
+    public static final String VERIFICATION_OTP_EXPIRY_TIME = "verificationOtpExpiryTime";
 
     public static final String OTP_CODE = "OTPCode";
     public static final String OTP_TOKEN = "otpToken";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
@@ -255,6 +255,13 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
         properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, user.getUserStoreDomain());
         properties.put(IdentityEventConstants.EventProperty.NOTIFICATION_CHANNEL,
                 NotificationChannels.SMS_CHANNEL.getChannelType());
+        /*
+         Adding SMS confirmation code expiry time to event properties so from the downstream services can use
+         the expiry time based on the requirements.
+        */
+        String expiryTime = Utils.getRecoveryConfigs(IdentityRecoveryConstants
+                .ConnectorConfig.MOBILE_NUM_VERIFICATION_ON_UPDATE_EXPIRY_TIME, user.getTenantDomain());
+        properties.put(IdentityRecoveryConstants.VERIFICATION_OTP_EXPIRY_TIME, expiryTime);
         properties.put(IdentityRecoveryConstants.TEMPLATE_TYPE, notificationType);
         if (StringUtils.isNotBlank(verificationPendingMobileNumber)) {
             properties.put(IdentityRecoveryConstants.SEND_TO, verificationPendingMobileNumber);


### PR DESCRIPTION
### Proposed changes in this pull request

- $subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a syntax issue in identity recovery constants.

* **New Features**
  * Added a configurable SMS OTP expiry identifier.
  * Mobile number verification events now include OTP expiry timestamps sourced from tenant configuration to support proper expiry validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-extensions/identity-governance/pull/1129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->