### PR TITLE
Add preference consent mgt in flow engine

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutor.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.flow.execution.engine.Constants;
+import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineException;
 import org.wso2.carbon.identity.flow.execution.engine.graph.AuthenticationExecutor;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
@@ -39,6 +40,7 @@ import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
 import org.wso2.carbon.identity.recovery.util.Utils;
+import org.wso2.carbon.identity.recovery.util.ExecutorConsentUtils;
 import org.wso2.carbon.identity.user.action.api.constant.UserActionError;
 import org.wso2.carbon.identity.user.action.api.exception.UserActionExecutionClientException;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -159,8 +161,13 @@ public class PasswordProvisioningExecutor extends AuthenticationExecutor {
             String userId = ((AbstractUserStoreManager) userStoreManager)
                     .getUserIDFromUserName(context.getFlowUser().getUsername());
             context.getFlowUser().setUserId(userId);
+            context.getFlowUser().setUserStoreDomain(user.getUserStoreDomain());
+
+            ExecutorConsentUtils.processUserConsent(getName(), context, context.getFlowUser(),
+                    user.getUserStoreDomain());
+
             return new ExecutorResponse(STATUS_COMPLETE);
-        } catch (UserStoreException | IdentityEventException | IdentityRecoveryException e) {
+        } catch (UserStoreException | IdentityEventException | IdentityRecoveryException | FlowEngineException e) {
             ExecutorResponse errorResponse = handleClientExceptionForActionFailure(e);
             if (errorResponse.getResult() != null) {
                 return errorResponse;

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
@@ -22,25 +22,15 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.consent.mgt.core.exception.ConsentManagementException;
-import org.wso2.carbon.consent.mgt.core.model.PIICategory;
-import org.wso2.carbon.consent.mgt.core.model.PurposePIICategoryBinding;
-import org.wso2.carbon.consent.mgt.core.model.ReceiptInput;
-import org.wso2.carbon.consent.mgt.core.util.ConsentReceiptUtils;
-import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
-import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ApplicationBasicInfo;
 import org.wso2.carbon.identity.application.common.model.User;
-import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil;
-import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.core.util.LambdaExceptionUtils;
-import org.wso2.carbon.utils.DiagnosticLog;
 import org.wso2.carbon.identity.flow.execution.engine.Constants;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineClientException;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineException;
@@ -55,6 +45,7 @@ import org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErro
 import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
 import org.wso2.carbon.identity.recovery.model.Property;
 import org.wso2.carbon.identity.recovery.util.Utils;
+import org.wso2.carbon.identity.recovery.util.ExecutorConsentUtils;
 import org.wso2.carbon.identity.user.action.api.constant.UserActionError;
 import org.wso2.carbon.identity.user.action.api.exception.UserActionExecutionClientException;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
@@ -71,15 +62,12 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.user.mgt.common.DefaultPasswordGenerator;
 
 import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
 import static java.util.Locale.ENGLISH;
-import static org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.constant.SSOConsentConstants.RESIDENT_IDP;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.EMAIL_ADDRESS_CLAIM;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.MY_ACCOUNT_APPLICATION_NAME;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.PASSWORD_KEY;
@@ -89,8 +77,6 @@ import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.REGISTRATION
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.DISPLAY_CLAIM_AVAILABILITY_CONFIG;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.DUPLICATE_CLAIMS_ERROR_CODE;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.DUPLICATE_CLAIM_ERROR_CODE;
-import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_INVALID_USER_INPUT;
-import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_POLICY_CONSENT_FAILURE;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_INVALID_USERNAME;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_VALIDATION_FAILURE;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_RESOLVE_NOTIFICATION_PROPERTY_FAILURE;
@@ -152,6 +138,9 @@ public class UserProvisioningExecutor implements Executor {
                     context.getContextIdentifier(), context.getFlowType());
             String domainQualifiedName = IdentityUtil.addDomainToName(user.getUsername(), userStoreDomainName);
             userStoreManager.setUserClaimValues(domainQualifiedName, userClaims, null);
+
+            ExecutorConsentUtils.processUserConsent(COMPONENT_ID, context, user, userStoreDomainName);
+
             response.setResult(STATUS_COMPLETE);
             return response;
         } catch (UserStoreException e) {
@@ -206,7 +195,7 @@ public class UserProvisioningExecutor implements Executor {
             user.setUserStoreDomain(userStoreDomainName);
             user.setUserId(userid);
 
-            processUserConsent(context, user, userStoreDomainName);
+            ExecutorConsentUtils.processUserConsent(COMPONENT_ID, context, user, userStoreDomainName);
 
             createFederatedAssociations(user, context.getTenantDomain(), context.getContextIdentifier());
             if (LOG.isDebugEnabled()) {
@@ -373,154 +362,6 @@ public class UserProvisioningExecutor implements Executor {
             throw handleServerException(ERROR_CODE_USER_EXISTENCE_CHECK_FAILURE, e,
                     maskedUsername, context.getContextIdentifier());
         }
-    }
-
-    private void processUserConsent(FlowExecutionContext context, FlowUser user, String userStoreDomainName)
-            throws FlowEngineException {
-
-        if (!FrameworkUtils.isConsentV2APIEnabled()) {
-            return;
-        }
-
-        String usernameWithUserStoreDomain = UserCoreUtil.addDomainToName(user.getUsername(), userStoreDomainName);
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Processing consent for user: " + user.getUsername() + " in tenant: " +
-                    context.getTenantDomain());
-        }
-        PrivilegedCarbonContext.startTenantFlow();
-        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(context.getTenantDomain(), true);
-        PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(usernameWithUserStoreDomain);
-        try {
-            for (FlowUser.UserConsent userConsent : user.getUserConsents()) {
-                for (FlowUser.ConsentPurpose purpose : userConsent.getPurposes()) {
-                    createPurposeConsent(usernameWithUserStoreDomain, context.getTenantDomain(),
-                            userConsent.getPurposeType(), purpose);
-                }
-            }
-        } finally {
-            PrivilegedCarbonContext.endTenantFlow();
-        }
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Consent processing completed for user: " + user.getUsername() + " in tenant: " +
-                    context.getTenantDomain());
-        }
-        if (LoggerUtils.isDiagnosticLogsEnabled()) {
-            LoggerUtils.triggerDiagnosticLogEvent(
-                    consentDiagnosticLogBuilder(user.getUsername(), context.getTenantDomain())
-                    .resultMessage("Consent processing completed for user.")
-                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS));
-        }
-    }
-
-    private void createPurposeConsent(String username, String tenantDomain, String purposeType,
-                                      FlowUser.ConsentPurpose purpose) throws FlowEngineException {
-
-        if (StringUtils.isBlank(purpose.getId())) {
-            throw FlowExecutionEngineUtils.handleClientException(ERROR_CODE_INVALID_USER_INPUT,
-                    purposeType + " consent");
-        }
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Processing consent type: " + purposeType + ", User: " +
-                    Utils.maskIfRequired(username) + ", Purpose: " + purpose.getId() +
-                    ", Tenant: " + tenantDomain);
-        }
-
-        try {
-            List<String> attributes = purpose.getAttributes();
-            List<PIICategory> piiCategories = new ArrayList<>();
-
-            PIICategory defaultPiiCategory = ConsentReceiptUtils.getDefaultPiiCategory(purposeType,
-                    IdentityRecoveryServiceDataHolder.getInstance().getConsentManager());
-            if (defaultPiiCategory != null) {
-                piiCategories.add(defaultPiiCategory);
-            }
-
-            if (attributes != null && !attributes.isEmpty()) {
-                List<PIICategory> attributeCategories = getPiiCategories(attributes);
-                piiCategories.addAll(attributeCategories);
-            }
-
-            addConsentReceipt(username, tenantDomain, purposeType,
-                    Collections.singletonList(new PurposePIICategoryBinding(purpose.getId(), piiCategories)),
-                    !purpose.isAccepted());
-        } catch (ConsentManagementException e) {
-            throw FlowExecutionEngineUtils.handleServerException(ERROR_CODE_POLICY_CONSENT_FAILURE, e, purposeType,
-                    Utils.maskIfRequired(username));
-        }
-
-        if (LoggerUtils.isDiagnosticLogsEnabled()) {
-            LoggerUtils.triggerDiagnosticLogEvent(
-                    consentDiagnosticLogBuilder(username, tenantDomain)
-                    .inputParam("consent_type", purposeType)
-                    .inputParam("purpose_id", purpose.getId())
-                    .resultMessage("Policy consent successfully processed.")
-                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS));
-        }
-    }
-
-    private List<PIICategory> getPiiCategories(List<String> attributes)
-            throws FlowEngineException {
-
-        org.wso2.carbon.consent.mgt.core.ConsentManager consentManager =
-                IdentityRecoveryServiceDataHolder.getInstance().getConsentManager();
-        List<PIICategory> piiCategories = new ArrayList<>();
-        try {
-            for (String attributeUuid : attributes) {
-                PIICategory piiCategory = consentManager.getPIICategoryByUuid(attributeUuid);
-                if (piiCategory != null) {
-                    piiCategories.add(piiCategory);
-                }
-            }
-        } catch (ConsentManagementException e) {
-            throw FlowExecutionEngineUtils.handleServerException(ERROR_CODE_POLICY_CONSENT_FAILURE, e,
-                    String.join(",", attributes), null);
-        }
-        return piiCategories;
-    }
-
-    private void addConsentReceipt(String subjectId, String tenantDomain, String purposeType,
-                                   List<PurposePIICategoryBinding> purposeBindings, boolean isRejected)
-            throws FlowEngineServerException {
-
-        try {
-            // Use Resident IDP as the ApplicationId since the policy consent is system-wide.
-            ReceiptInput receiptInput = ConsentReceiptUtils.buildReceiptInput("en", subjectId, tenantDomain,
-                    null, isRejected, null, null, RESIDENT_IDP, purposeBindings,
-                    IdentityRecoveryServiceDataHolder.getInstance().getConsentManager());
-            IdentityRecoveryServiceDataHolder.getInstance().getConsentManager().addConsent(receiptInput);
-
-            if (LoggerUtils.isDiagnosticLogsEnabled()) {
-                LoggerUtils.triggerDiagnosticLogEvent(
-                        consentDiagnosticLogBuilder(subjectId, tenantDomain)
-                        .inputParam("consent_type", purposeType)
-                        .inputParam("purpose_count", purposeBindings.size())
-                        .resultMessage("Consent receipt successfully added.")
-                        .resultStatus(DiagnosticLog.ResultStatus.SUCCESS));
-            }
-        } catch (ConsentManagementException e) {
-            if (LoggerUtils.isDiagnosticLogsEnabled()) {
-                LoggerUtils.triggerDiagnosticLogEvent(
-                        consentDiagnosticLogBuilder(subjectId, tenantDomain)
-                        .inputParam("consent_type", purposeType)
-                        .inputParam(LogConstants.InputKeys.ERROR_MESSAGE, e.getMessage())
-                        .resultMessage("Failed to add consent receipt.")
-                        .resultStatus(DiagnosticLog.ResultStatus.FAILED));
-            }
-            throw FlowExecutionEngineUtils.handleServerException(ERROR_CODE_POLICY_CONSENT_FAILURE, e, purposeType,
-                    Utils.maskIfRequired(subjectId));
-        }
-    }
-
-    private DiagnosticLog.DiagnosticLogBuilder consentDiagnosticLogBuilder(String subjectId, String tenantDomain) {
-
-        return new DiagnosticLog.DiagnosticLogBuilder(
-                COMPONENT_ID, FrameworkConstants.LogConstants.ActionIDs.PROCESS_POLICY_CONSENT)
-                .inputParam(LogConstants.InputKeys.USER, LoggerUtils.isLogMaskingEnable ?
-                        LoggerUtils.getMaskedContent(subjectId) : subjectId)
-                .inputParam(LogConstants.InputKeys.TENANT_DOMAIN, tenantDomain)
-                .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION);
     }
 
     private void createFederatedAssociations(FlowUser user, String tenantDomain, String flowId) {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
@@ -71,8 +71,8 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.user.mgt.common.DefaultPasswordGenerator;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -392,10 +392,10 @@ public class UserProvisioningExecutor implements Executor {
         PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(usernameWithUserStoreDomain);
         try {
             for (FlowUser.UserConsent userConsent : user.getUserConsents()) {
-                createAcceptedConsents(usernameWithUserStoreDomain, context.getTenantDomain(),
-                        userConsent.getPurposeType(), userConsent.getAccepted());
-                createRejectedConsents(usernameWithUserStoreDomain, context.getTenantDomain(),
-                        userConsent.getPurposeType(), userConsent.getRejected());
+                for (FlowUser.ConsentPurpose purpose : userConsent.getPurposes()) {
+                    createPurposeConsent(usernameWithUserStoreDomain, context.getTenantDomain(),
+                            userConsent.getPurposeType(), purpose);
+                }
             }
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
@@ -413,114 +413,71 @@ public class UserProvisioningExecutor implements Executor {
         }
     }
 
-    private void createAcceptedConsents(String username, String tenantDomain, String purposeType, List<String> consents)
-            throws FlowEngineException {
+    private void createPurposeConsent(String username, String tenantDomain, String purposeType,
+                                      FlowUser.ConsentPurpose purpose) throws FlowEngineException {
 
-        if (consents == null || consents.isEmpty()) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("No accepted consents found for user: " + Utils.maskIfRequired(username));
-            }
-            return;
+        if (StringUtils.isBlank(purpose.getId())) {
+            throw FlowExecutionEngineUtils.handleClientException(ERROR_CODE_INVALID_USER_INPUT,
+                    purposeType + " consent");
         }
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Creating accepted consents for user: " + Utils.maskIfRequired(username) +
-                    " with consent count: " + consents.size());
+            LOG.debug("Processing consent type: " + purposeType + ", User: " +
+                    Utils.maskIfRequired(username) + ", Purpose: " + purpose.getId() +
+                    ", Tenant: " + tenantDomain);
         }
 
-        int purposeCount = 0;
-        // One receipt per consent — batching would prevent individual revocation.
-        for (String purposeUuid : consents) {
-            if (StringUtils.isBlank(purposeUuid)) {
-                throw FlowExecutionEngineUtils.handleClientException(ERROR_CODE_INVALID_USER_INPUT,
-                        purposeType + " consent");
+        try {
+            List<String> attributes = purpose.getAttributes();
+            List<PIICategory> piiCategories = new ArrayList<>();
+
+            PIICategory defaultPiiCategory = ConsentReceiptUtils.getDefaultPiiCategory(purposeType,
+                    IdentityRecoveryServiceDataHolder.getInstance().getConsentManager());
+            if (defaultPiiCategory != null) {
+                piiCategories.add(defaultPiiCategory);
             }
-            processPolicyConsent(username, tenantDomain, purposeUuid, purposeType);
-            purposeCount++;
+
+            if (attributes != null && !attributes.isEmpty()) {
+                List<PIICategory> attributeCategories = getPiiCategories(attributes);
+                piiCategories.addAll(attributeCategories);
+            }
+
+            addConsentReceipt(username, tenantDomain, purposeType,
+                    Collections.singletonList(new PurposePIICategoryBinding(purpose.getId(), piiCategories)),
+                    !purpose.isAccepted());
+        } catch (ConsentManagementException e) {
+            throw FlowExecutionEngineUtils.handleServerException(ERROR_CODE_POLICY_CONSENT_FAILURE, e, purposeType,
+                    Utils.maskIfRequired(username));
         }
 
         if (LoggerUtils.isDiagnosticLogsEnabled()) {
             LoggerUtils.triggerDiagnosticLogEvent(
                     consentDiagnosticLogBuilder(username, tenantDomain)
                     .inputParam("consent_type", purposeType)
-                    .inputParam("purpose_count", purposeCount)
-                    .resultMessage("Accepted consents successfully created.")
+                    .inputParam("purpose_id", purpose.getId())
+                    .resultMessage("Policy consent successfully processed.")
                     .resultStatus(DiagnosticLog.ResultStatus.SUCCESS));
         }
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Successfully created " + purposeCount + " accepted consent(s) of type: " +
-                    purposeType + " for user: " + Utils.maskIfRequired(username));
-        }
     }
 
-    private void createRejectedConsents(String subjectId, String tenantDomain, String purposeType,
-                                        List<String> consents) throws FlowEngineException {
+    private List<PIICategory> getPiiCategories(List<String> attributes)
+            throws FlowEngineException {
 
-        if (consents == null || consents.isEmpty()) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("No rejected consents found for user: " + Utils.maskIfRequired(subjectId));
-            }
-            return;
-        }
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Creating rejected consents for user: " + Utils.maskIfRequired(subjectId) +
-                    " with consent count: " + consents.size() + ", tenant domain: " + tenantDomain);
-        }
-
+        org.wso2.carbon.consent.mgt.core.ConsentManager consentManager =
+                IdentityRecoveryServiceDataHolder.getInstance().getConsentManager();
+        List<PIICategory> piiCategories = new ArrayList<>();
         try {
-            PIICategory piiCategory = ConsentReceiptUtils.getDefaultPiiCategory(purposeType,
-                    IdentityRecoveryServiceDataHolder.getInstance().getConsentManager());
-            if (piiCategory == null) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Default PII category not found for consent type: " + purposeType +
-                            ". Skipping rejected consent processing for user: " + Utils.maskIfRequired(subjectId));
+            for (String attributeUuid : attributes) {
+                PIICategory piiCategory = consentManager.getPIICategoryByUuid(attributeUuid);
+                if (piiCategory != null) {
+                    piiCategories.add(piiCategory);
                 }
-                return;
             }
-            List<PurposePIICategoryBinding> purposeBindings = new ArrayList<>();
-            for (String purposeUuid : consents) {
-                if (StringUtils.isBlank(purposeUuid)) {
-                    throw FlowExecutionEngineUtils.handleClientException(ERROR_CODE_INVALID_USER_INPUT,
-                            purposeType + " consent");
-                }
-                purposeBindings.add(
-                        new PurposePIICategoryBinding(purposeUuid, Collections.singletonList(piiCategory)));
-            }
-            if (purposeBindings.isEmpty()) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("No purpose bindings found for rejected consent type: " + purposeType +
-                            " for user: " + Utils.maskIfRequired(subjectId));
-                }
-                return;
-            }
-            addConsentReceipt(subjectId, tenantDomain, purposeType, purposeBindings, true);
         } catch (ConsentManagementException e) {
-            throw FlowExecutionEngineUtils.handleServerException(ERROR_CODE_POLICY_CONSENT_FAILURE, e, purposeType,
-                    Utils.maskIfRequired(subjectId));
+            throw FlowExecutionEngineUtils.handleServerException(ERROR_CODE_POLICY_CONSENT_FAILURE, e,
+                    String.join(",", attributes), null);
         }
-    }
-
-    private void processPolicyConsent(String subjectId, String tenantDomain, String purposeUuid, String consentType)
-            throws FlowEngineServerException {
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Processing policy consent. Type: " + consentType + ", User: " +
-                    Utils.maskIfRequired(subjectId) + ", Purpose: " + purposeUuid +
-                    ", Tenant: " + tenantDomain);
-        }
-
-        try {
-            PIICategory piiCategory = ConsentReceiptUtils.getDefaultPiiCategory(consentType,
-                    IdentityRecoveryServiceDataHolder.getInstance().getConsentManager());
-            List<PurposePIICategoryBinding> purposeBindings = Collections.singletonList(
-                    new PurposePIICategoryBinding(purposeUuid, Collections.singletonList(piiCategory)));
-            addConsentReceipt(subjectId, tenantDomain, consentType, purposeBindings, false);
-        } catch (ConsentManagementException e) {
-            throw FlowExecutionEngineUtils.handleServerException(ERROR_CODE_POLICY_CONSENT_FAILURE, e, consentType,
-                    Utils.maskIfRequired(subjectId));
-        }
+        return piiCategories;
     }
 
     private void addConsentReceipt(String subjectId, String tenantDomain, String purposeType,

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/ExecutorConsentUtils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/ExecutorConsentUtils.java
@@ -121,6 +121,8 @@ public class ExecutorConsentUtils {
         }
 
         try {
+            // Attributes list contains only accepted attribute IDs when purpose is accepted,
+            // and only rejected attribute IDs when purpose is not accepted.
             List<String> attributes = purpose.getAttributes();
             List<PIICategory> piiCategories = new ArrayList<>();
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/ExecutorConsentUtils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/ExecutorConsentUtils.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.recovery.util;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.consent.mgt.core.exception.ConsentManagementException;
+import org.wso2.carbon.consent.mgt.core.model.PIICategory;
+import org.wso2.carbon.consent.mgt.core.model.PurposePIICategoryBinding;
+import org.wso2.carbon.consent.mgt.core.model.ReceiptInput;
+import org.wso2.carbon.consent.mgt.core.util.ConsentReceiptUtils;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineException;
+import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineServerException;
+import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
+import org.wso2.carbon.identity.flow.execution.engine.model.FlowUser;
+import org.wso2.carbon.identity.flow.execution.engine.util.FlowExecutionEngineUtils;
+import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.utils.DiagnosticLog;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.constant.SSOConsentConstants.RESIDENT_IDP;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_INVALID_USER_INPUT;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_POLICY_CONSENT_FAILURE;
+
+/**
+ * Utility class for consent processing in executor flows.
+ */
+public class ExecutorConsentUtils {
+
+    private static final Log LOG = LogFactory.getLog(ExecutorConsentUtils.class);
+
+    private ExecutorConsentUtils() {
+    }
+
+    /**
+     * Processes user consent for all purposes declared on the flow user.
+     * No-op if Consent V2 API is not enabled.
+     *
+     * @param componentId         Executor component identifier used in diagnostic logs.
+     * @param context             Current flow execution context.
+     * @param user                Flow user whose consents are to be processed.
+     * @param userStoreDomainName User store domain of the user.
+     * @throws FlowEngineException if consent processing fails.
+     */
+    public static void processUserConsent(String componentId, FlowExecutionContext context, FlowUser user,
+                                          String userStoreDomainName) throws FlowEngineException {
+
+        if (!FrameworkUtils.isConsentV2APIEnabled() || user.getUserConsents().isEmpty()) {
+            return;
+        }
+
+        String usernameWithUserStoreDomain = UserCoreUtil.addDomainToName(user.getUsername(), userStoreDomainName);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Processing consent for user: " + user.getUsername() + " in tenant: " +
+                    context.getTenantDomain());
+        }
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(context.getTenantDomain(), true);
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(usernameWithUserStoreDomain);
+        try {
+            for (FlowUser.UserConsent userConsent : user.getUserConsents()) {
+                for (FlowUser.ConsentPurpose purpose : userConsent.getPurposes()) {
+                    createPurposeConsent(usernameWithUserStoreDomain, context.getTenantDomain(),
+                            userConsent.getPurposeType(), purpose);
+                }
+            }
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Consent processing completed for user: " + user.getUsername() + " in tenant: " +
+                    context.getTenantDomain());
+        }
+        if (LoggerUtils.isDiagnosticLogsEnabled()) {
+            LoggerUtils.triggerDiagnosticLogEvent(
+                    consentDiagnosticLogBuilder(componentId, user.getUsername(), context.getTenantDomain())
+                    .resultMessage("Consent processing completed for user.")
+                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS));
+        }
+    }
+
+    private static void createPurposeConsent(String username, String tenantDomain, String purposeType,
+                                             FlowUser.ConsentPurpose purpose) throws FlowEngineException {
+
+        if (StringUtils.isBlank(purpose.getId())) {
+            throw FlowExecutionEngineUtils.handleClientException(ERROR_CODE_INVALID_USER_INPUT,
+                    purposeType + " consent");
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Processing consent type: " + purposeType + ", User: " +
+                    Utils.maskIfRequired(username) + ", Purpose: " + purpose.getId() +
+                    ", Tenant: " + tenantDomain);
+        }
+
+        try {
+            List<String> attributes = purpose.getAttributes();
+            List<PIICategory> piiCategories = new ArrayList<>();
+
+            PIICategory defaultPiiCategory = ConsentReceiptUtils.getDefaultPiiCategory(purposeType,
+                    IdentityRecoveryServiceDataHolder.getInstance().getConsentManager());
+            if (defaultPiiCategory != null) {
+                piiCategories.add(defaultPiiCategory);
+            }
+
+            if (attributes != null && !attributes.isEmpty()) {
+                piiCategories.addAll(getPiiCategories(attributes));
+            }
+
+            addConsentReceipt(username, tenantDomain, purposeType,
+                    Collections.singletonList(new PurposePIICategoryBinding(purpose.getId(), piiCategories)),
+                    !purpose.isAccepted());
+        } catch (ConsentManagementException e) {
+            throw FlowExecutionEngineUtils.handleServerException(ERROR_CODE_POLICY_CONSENT_FAILURE, e, purposeType,
+                    Utils.maskIfRequired(username));
+        }
+
+        if (LoggerUtils.isDiagnosticLogsEnabled()) {
+            LoggerUtils.triggerDiagnosticLogEvent(
+                    consentDiagnosticLogBuilder(null, username, tenantDomain)
+                    .inputParam("consent_type", purposeType)
+                    .inputParam("purpose_id", purpose.getId())
+                    .resultMessage("Policy consent successfully processed.")
+                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS));
+        }
+    }
+
+    private static List<PIICategory> getPiiCategories(List<String> attributes) throws FlowEngineException {
+
+        org.wso2.carbon.consent.mgt.core.ConsentManager consentManager =
+                IdentityRecoveryServiceDataHolder.getInstance().getConsentManager();
+        List<PIICategory> piiCategories = new ArrayList<>();
+        try {
+            for (String attributeUuid : attributes) {
+                PIICategory piiCategory = consentManager.getPIICategoryByUuid(attributeUuid);
+                if (piiCategory != null) {
+                    piiCategories.add(piiCategory);
+                }
+            }
+        } catch (ConsentManagementException e) {
+            throw FlowExecutionEngineUtils.handleServerException(ERROR_CODE_POLICY_CONSENT_FAILURE, e,
+                    String.join(",", attributes), null);
+        }
+        return piiCategories;
+    }
+
+    private static void addConsentReceipt(String subjectId, String tenantDomain, String purposeType,
+                                          List<PurposePIICategoryBinding> purposeBindings, boolean isRejected)
+            throws FlowEngineServerException {
+
+        try {
+            org.wso2.carbon.consent.mgt.core.ConsentManager consentManager =
+                    IdentityRecoveryServiceDataHolder.getInstance().getConsentManager();
+            ReceiptInput receiptInput = ConsentReceiptUtils.buildReceiptInput("en", subjectId, tenantDomain,
+                    null, isRejected, null, null, RESIDENT_IDP, purposeBindings, consentManager);
+            consentManager.addConsent(receiptInput);
+
+            if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                LoggerUtils.triggerDiagnosticLogEvent(
+                        consentDiagnosticLogBuilder(null, subjectId, tenantDomain)
+                        .inputParam("consent_type", purposeType)
+                        .inputParam("purpose_count", purposeBindings.size())
+                        .resultMessage("Consent receipt successfully added.")
+                        .resultStatus(DiagnosticLog.ResultStatus.SUCCESS));
+            }
+        } catch (ConsentManagementException e) {
+            if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                LoggerUtils.triggerDiagnosticLogEvent(
+                        consentDiagnosticLogBuilder(null, subjectId, tenantDomain)
+                        .inputParam("consent_type", purposeType)
+                        .inputParam(LogConstants.InputKeys.ERROR_MESSAGE, e.getMessage())
+                        .resultMessage("Failed to add consent receipt.")
+                        .resultStatus(DiagnosticLog.ResultStatus.FAILED));
+            }
+            throw FlowExecutionEngineUtils.handleServerException(ERROR_CODE_POLICY_CONSENT_FAILURE, e, purposeType,
+                    Utils.maskIfRequired(subjectId));
+        }
+    }
+
+    /**
+     * Builds a DiagnosticLog builder for consent-related events.
+     *
+     * @param componentId  Executor component identifier, or null to omit it from the builder.
+     * @param subjectId    Username or subject identifier.
+     * @param tenantDomain Tenant domain.
+     * @return Configured DiagnosticLog builder.
+     */
+    public static DiagnosticLog.DiagnosticLogBuilder consentDiagnosticLogBuilder(String componentId,
+                                                                                  String subjectId,
+                                                                                  String tenantDomain) {
+
+        String component = StringUtils.isNotBlank(componentId) ? componentId : "ExecutorConsentUtils";
+        return new DiagnosticLog.DiagnosticLogBuilder(
+                component, FrameworkConstants.LogConstants.ActionIDs.PROCESS_POLICY_CONSENT)
+                .inputParam(LogConstants.InputKeys.USER, LoggerUtils.isLogMaskingEnable ?
+                        LoggerUtils.getMaskedContent(subjectId) : subjectId)
+                .inputParam(LogConstants.InputKeys.TENANT_DOMAIN, tenantDomain)
+                .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION);
+    }
+}

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutorTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutorTest.java
@@ -1009,6 +1009,123 @@ public class UserProvisioningExecutorTest {
         verify(consentManager, org.mockito.Mockito.never()).addConsent(any(ReceiptInput.class));
     }
 
+    @Test
+    public void testProcessUserConsentCombinesDefaultAndAttributePiiCategories() throws Exception {
+
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        FlowUser flowUser = createTestFlowUserWithAcceptedConsentAndAttributes(USERNAME,
+                Collections.singletonList("attr-uuid-1"), "PROFILE");
+
+        when(context.getFlowType()).thenReturn(REGISTRATION.getType());
+        when(context.getFlowUser()).thenReturn(flowUser);
+        when(context.getUserInputData()).thenReturn(new HashMap<>());
+        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+        when(context.getContextIdentifier()).thenReturn(CONTEXT_ID);
+        when(context.getProperty("isUsernamePatternValidationSkipped")).thenReturn(null);
+
+        mockedFrameworkUtils.when(FrameworkUtils::isConsentV2APIEnabled).thenReturn(true);
+
+        PrivilegedCarbonContext carbonContext = mock(PrivilegedCarbonContext.class);
+        mockedPrivilegedCarbonContext.when(PrivilegedCarbonContext::getThreadLocalCarbonContext)
+                .thenReturn(carbonContext);
+
+        PIICategory defaultPiiCategory = new PIICategory("default-uuid", "Default", false, "Default Category");
+        PIICategory attrPiiCategory = new PIICategory("attr-uuid-1", "Attribute", false, "Attribute Category");
+        ReceiptInput receiptInput = mock(ReceiptInput.class);
+
+        ConsentManager consentManager = mock(ConsentManager.class);
+        IdentityRecoveryServiceDataHolder dataHolder = setupUserStoreManagerMocksWithConsentManager(consentManager);
+
+        mockedConsentReceiptUtils.when(() -> ConsentReceiptUtils.getDefaultPiiCategory(eq("PROFILE"),
+                eq(consentManager))).thenReturn(defaultPiiCategory);
+        when(consentManager.getPIICategoryByUuid("attr-uuid-1")).thenReturn(attrPiiCategory);
+        mockedConsentReceiptUtils.when(() -> ConsentReceiptUtils.buildReceiptInput(
+                anyString(), anyString(), anyString(), any(), eq(false), any(), any(), anyString(),
+                any(), eq(consentManager))).thenReturn(receiptInput);
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_COMPLETE);
+        verify(consentManager).addConsent(receiptInput);
+    }
+
+    @Test
+    public void testProcessUserConsentRejectedUsesOnlyDefaultCategory() throws Exception {
+
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        FlowUser flowUser = createTestFlowUserWithRejectedConsentAndAttributes(USERNAME,
+                Collections.singletonList("attr-uuid-1"), "PROFILE");
+
+        when(context.getFlowType()).thenReturn(REGISTRATION.getType());
+        when(context.getFlowUser()).thenReturn(flowUser);
+        when(context.getUserInputData()).thenReturn(new HashMap<>());
+        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+        when(context.getContextIdentifier()).thenReturn(CONTEXT_ID);
+        when(context.getProperty("isUsernamePatternValidationSkipped")).thenReturn(null);
+
+        mockedFrameworkUtils.when(FrameworkUtils::isConsentV2APIEnabled).thenReturn(true);
+
+        PrivilegedCarbonContext carbonContext = mock(PrivilegedCarbonContext.class);
+        mockedPrivilegedCarbonContext.when(PrivilegedCarbonContext::getThreadLocalCarbonContext)
+                .thenReturn(carbonContext);
+
+        PIICategory defaultPiiCategory = new PIICategory("default-uuid", "Default", false, "Default Category");
+        ReceiptInput receiptInput = mock(ReceiptInput.class);
+
+        ConsentManager consentManager = mock(ConsentManager.class);
+        setupUserStoreManagerMocksWithConsentManager(consentManager);
+
+        mockedConsentReceiptUtils.when(() -> ConsentReceiptUtils.getDefaultPiiCategory(eq("PROFILE"),
+                eq(consentManager))).thenReturn(defaultPiiCategory);
+        mockedConsentReceiptUtils.when(() -> ConsentReceiptUtils.buildReceiptInput(
+                anyString(), anyString(), anyString(), any(), eq(true), any(), any(), anyString(),
+                any(), eq(consentManager))).thenReturn(receiptInput);
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_COMPLETE);
+        verify(consentManager).addConsent(receiptInput);
+    }
+
+    @Test
+    public void testProcessUserConsentEmptyAttributesUsesOnlyDefaultCategory() throws Exception {
+
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        FlowUser flowUser = createTestFlowUserWithAcceptedConsentAndAttributes(USERNAME,
+                Collections.emptyList(), "PROFILE");
+
+        when(context.getFlowType()).thenReturn(REGISTRATION.getType());
+        when(context.getFlowUser()).thenReturn(flowUser);
+        when(context.getUserInputData()).thenReturn(new HashMap<>());
+        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+        when(context.getContextIdentifier()).thenReturn(CONTEXT_ID);
+        when(context.getProperty("isUsernamePatternValidationSkipped")).thenReturn(null);
+
+        mockedFrameworkUtils.when(FrameworkUtils::isConsentV2APIEnabled).thenReturn(true);
+
+        PrivilegedCarbonContext carbonContext = mock(PrivilegedCarbonContext.class);
+        mockedPrivilegedCarbonContext.when(PrivilegedCarbonContext::getThreadLocalCarbonContext)
+                .thenReturn(carbonContext);
+
+        PIICategory defaultPiiCategory = new PIICategory("default-uuid", "Default", false, "Default Category");
+        ReceiptInput receiptInput = mock(ReceiptInput.class);
+
+        ConsentManager consentManager = mock(ConsentManager.class);
+        setupUserStoreManagerMocksWithConsentManager(consentManager);
+
+        mockedConsentReceiptUtils.when(() -> ConsentReceiptUtils.getDefaultPiiCategory(eq("PROFILE"),
+                eq(consentManager))).thenReturn(defaultPiiCategory);
+        mockedConsentReceiptUtils.when(() -> ConsentReceiptUtils.buildReceiptInput(
+                anyString(), anyString(), anyString(), any(), eq(false), any(), any(), anyString(),
+                any(), eq(consentManager))).thenReturn(receiptInput);
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_COMPLETE);
+        verify(consentManager).addConsent(receiptInput);
+        verify(consentManager, never()).getPIICategoryByUuid(anyString());
+    }
+
     private FlowUser createTestFlowUser(String username) {
 
         FlowUser flowUser = mock(FlowUser.class);
@@ -1037,10 +1154,6 @@ public class UserProvisioningExecutorTest {
         Map<String, char[]> credentials = new HashMap<>();
         credentials.put(PASSWORD_KEY, PASSWORD.toCharArray());
 
-        FlowUser.UserConsent userConsent = new FlowUser.UserConsent();
-        userConsent.getPurposeType(); // ensure fields exist
-
-        // Use a real UserConsent populated via reflection-free setters through fromJson-compatible approach.
         List<FlowUser.UserConsent> consents = FlowUser.UserConsent.fromJson(
                 buildConsentJson(purposeType, accepted, rejected));
 
@@ -1055,18 +1168,104 @@ public class UserProvisioningExecutorTest {
         return flowUser;
     }
 
+    private FlowUser createTestFlowUserWithAcceptedConsentAndAttributes(String username, List<String> attributes,
+                                                                        String purposeType) {
+
+        FlowUser flowUser = mock(FlowUser.class);
+        Map<String, String> claims = new HashMap<>();
+        claims.put(USERNAME_CLAIM_URI, USERNAME);
+        Map<String, char[]> credentials = new HashMap<>();
+        credentials.put(PASSWORD_KEY, PASSWORD.toCharArray());
+
+        List<FlowUser.UserConsent> consents = FlowUser.UserConsent.fromJson(
+                buildConsentJsonWithAttributes(purposeType, Collections.singletonList("purpose-uuid-1"),
+                Collections.emptyList(), attributes));
+
+        when(flowUser.getUsername()).thenReturn(username);
+        when(flowUser.getClaims()).thenReturn(claims);
+        when(flowUser.getClaim(USERNAME_CLAIM_URI)).thenReturn(USERNAME);
+        when(flowUser.getClaim(EMAIL_ADDRESS_CLAIM)).thenReturn(null);
+        when(flowUser.getUserCredentials()).thenReturn(credentials);
+        when(flowUser.getFederatedAssociations()).thenReturn(new HashMap<>());
+        when(flowUser.getUserConsents()).thenReturn(consents);
+
+        return flowUser;
+    }
+
+    private FlowUser createTestFlowUserWithRejectedConsentAndAttributes(String username, List<String> attributes,
+                                                                        String purposeType) {
+
+        FlowUser flowUser = mock(FlowUser.class);
+        Map<String, String> claims = new HashMap<>();
+        claims.put(USERNAME_CLAIM_URI, USERNAME);
+        Map<String, char[]> credentials = new HashMap<>();
+        credentials.put(PASSWORD_KEY, PASSWORD.toCharArray());
+
+        List<FlowUser.UserConsent> consents = FlowUser.UserConsent.fromJson(
+                buildConsentJsonWithAttributes(purposeType, Collections.emptyList(),
+                Collections.singletonList("purpose-uuid-2"), attributes));
+
+        when(flowUser.getUsername()).thenReturn(username);
+        when(flowUser.getClaims()).thenReturn(claims);
+        when(flowUser.getClaim(USERNAME_CLAIM_URI)).thenReturn(USERNAME);
+        when(flowUser.getClaim(EMAIL_ADDRESS_CLAIM)).thenReturn(null);
+        when(flowUser.getUserCredentials()).thenReturn(credentials);
+        when(flowUser.getFederatedAssociations()).thenReturn(new HashMap<>());
+        when(flowUser.getUserConsents()).thenReturn(consents);
+
+        return flowUser;
+    }
+
+    private String buildConsentJsonWithAttributes(String purposeType, List<String> accepted, List<String> rejected,
+                                                   List<String> attributes) {
+
+        StringBuilder json = new StringBuilder("{\"").append(purposeType).append("\":{\"purposes\":[");
+        boolean first = true;
+        for (String id : accepted) {
+            if (!first) json.append(",");
+            json.append("{\"id\":\"").append(id).append("\",\"accepted\":true");
+            if (!attributes.isEmpty()) {
+                json.append(",\"attributes\":[");
+                for (int i = 0; i < attributes.size(); i++) {
+                    if (i > 0) json.append(",");
+                    json.append("\"").append(attributes.get(i)).append("\"");
+                }
+                json.append("]");
+            }
+            json.append("}");
+            first = false;
+        }
+        for (String id : rejected) {
+            if (!first) json.append(",");
+            json.append("{\"id\":\"").append(id).append("\",\"accepted\":false");
+            if (!attributes.isEmpty()) {
+                json.append(",\"attributes\":[");
+                for (int i = 0; i < attributes.size(); i++) {
+                    if (i > 0) json.append(",");
+                    json.append("\"").append(attributes.get(i)).append("\"");
+                }
+                json.append("]");
+            }
+            json.append("}");
+            first = false;
+        }
+        json.append("]}}");
+        return json.toString();
+    }
+
     private String buildConsentJson(String purposeType, List<String> accepted, List<String> rejected) {
 
-        StringBuilder json = new StringBuilder("{\"").append(purposeType).append("\":{");
-        json.append("\"accepted\":[");
-        for (int i = 0; i < accepted.size(); i++) {
-            json.append("\"").append(accepted.get(i)).append("\"");
-            if (i < accepted.size() - 1) json.append(",");
+        StringBuilder json = new StringBuilder("{\"").append(purposeType).append("\":{\"purposes\":[");
+        boolean first = true;
+        for (String id : accepted) {
+            if (!first) json.append(",");
+            json.append("{\"id\":\"").append(id).append("\",\"accepted\":true}");
+            first = false;
         }
-        json.append("],\"rejected\":[");
-        for (int i = 0; i < rejected.size(); i++) {
-            json.append("\"").append(rejected.get(i)).append("\"");
-            if (i < rejected.size() - 1) json.append(",");
+        for (String id : rejected) {
+            if (!first) json.append(",");
+            json.append("{\"id\":\"").append(id).append("\",\"accepted\":false}");
+            first = false;
         }
         json.append("]}}");
         return json.toString();

--- a/pom.xml
+++ b/pom.xml
@@ -744,7 +744,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.11.94-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.102</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -744,7 +744,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.11.92</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.94-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request refactors how user consent is processed during user provisioning and password provisioning flows in the identity recovery module. The main change is the extraction of consent processing logic into a new utility class, `ExecutorConsentUtils`, which is now used by both `UserProvisioningExecutor` and `PasswordProvisioningExecutor`. This leads to cleaner, more maintainable code and avoids duplication of consent handling logic.

### Related issue

https://github.com/wso2/product-is/issues/26859

### When should this PR be merged

After https://github.com/wso2/carbon-identity-framework/pull/8127


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved user-consent processing across provisioning flows, including more accurate PII category resolution and consent receipt handling.

* **Tests**
  * Added unit tests covering combination of default and attribute-specific PII categories and rejected/empty-attribute consent scenarios.

* **Chores**
  * Updated framework dependency versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-extensions/identity-governance/pull/1130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->