### PR TITLE
Filter recovery flow claim writeback to user-changed claims only

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutor.java
@@ -35,7 +35,6 @@ import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineExcept
 import org.wso2.carbon.identity.flow.execution.engine.graph.AuthenticationExecutor;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
-import org.wso2.carbon.identity.flow.execution.engine.model.FlowUser;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
@@ -75,7 +74,6 @@ import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.CONFIR
 public class PasswordProvisioningExecutor extends AuthenticationExecutor {
 
     private static final Log LOG = LogFactory.getLog(PasswordProvisioningExecutor.class);
-    private static final String WSO2_CLAIM_DIALECT = "http://wso2.org/claims/";
 
     @Override
     public String getName() {
@@ -154,10 +152,7 @@ public class PasswordProvisioningExecutor extends AuthenticationExecutor {
 
             UserStoreManager userStoreManager = IdentityRecoveryServiceDataHolder.getInstance()
                     .getRealmService().getTenantUserRealm(tenantId).getUserStoreManager();
-            // If there are any claims to be updated, update them before updating the password.
-            updateUserClaims(userStoreManager, context);
             userStoreManager.updateCredentialByAdmin(context.getFlowUser().getUsername(), password);
-
             String userId = ((AbstractUserStoreManager) userStoreManager)
                     .getUserIDFromUserName(context.getFlowUser().getUsername());
             context.getFlowUser().setUserId(userId);
@@ -267,38 +262,6 @@ public class PasswordProvisioningExecutor extends AuthenticationExecutor {
         ExecutorResponse response = new ExecutorResponse(STATUS_USER_INPUT_REQUIRED);
         response.setRequiredData(Collections.singletonList(PASSWORD_KEY));
         return response;
-    }
-
-
-    /**
-     * Updates user claims in the user store.
-     *
-     * @param userStoreManager UserStoreManager instance to update user claims.
-     * @param context          FlowExecutionContext containing user information and claims.
-     * @throws UserStoreException if an error occurs while accessing the user store.
-     */
-    private void updateUserClaims(UserStoreManager userStoreManager, FlowExecutionContext context)
-            throws UserStoreException {
-
-        FlowUser user = enrichUserProfile(context);
-        userStoreManager.setUserClaimValues(user.getUsername(), user.getClaims(), null);
-    }
-
-    /**
-     * Enriches the user profile with claims from the context.
-     *
-     * @param context FlowExecutionContext containing user information and claims.
-     * @return Enriched FlowUser with claims and username.
-     */
-    private FlowUser enrichUserProfile(FlowExecutionContext context) {
-
-        FlowUser user = context.getFlowUser();
-        context.getUserInputData().forEach((key, value) -> {
-            if (key.startsWith(WSO2_CLAIM_DIALECT) && !user.getClaims().containsKey(key)) {
-                user.addClaim(key, value);
-            }
-        });
-        return user;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
@@ -62,9 +62,11 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.user.mgt.common.DefaultPasswordGenerator;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import static java.util.Locale.ENGLISH;
@@ -131,13 +133,17 @@ public class UserProvisioningExecutor implements Executor {
         try {
             // If the flow type is not registration, update the user profile.
             FlowUser user = updateUserProfile(context);
-            Map<String, String> userClaims = user.getClaims();
+            // Only persist claims the user actually changed during this flow. The preloaded CONSOLE-profile
+            // snapshot (which includes non-attribute claims like role/roles) must not be written back.
+            Map<String, String> userClaims = filterUpdatedClaims(user);
 
             String userStoreDomainName = resolveUserStoreDomain(user.getUsername());
             UserStoreManager userStoreManager = getUserStoreManager(context.getTenantDomain(), userStoreDomainName,
                     context.getContextIdentifier(), context.getFlowType());
             String domainQualifiedName = IdentityUtil.addDomainToName(user.getUsername(), userStoreDomainName);
-            userStoreManager.setUserClaimValues(domainQualifiedName, userClaims, null);
+            if (!userClaims.isEmpty()) {
+                userStoreManager.setUserClaimValues(domainQualifiedName, userClaims, null);
+            }
 
             ExecutorConsentUtils.processUserConsent(COMPONENT_ID, context, user, userStoreDomainName);
 
@@ -570,5 +576,32 @@ public class UserProvisioningExecutor implements Executor {
         properties[1] = new Property("sp", applicationName);
         properties[2] = new Property("callback", callBackUrl);
         return properties;
+    }
+
+    /**
+     * Returns claims the user actually changed during this flow, based on
+     * {@link FlowUser#getUpdatedClaimUris()}.
+     *
+     * @param user flow user whose claims are being filtered.
+     * @return map of user-updated claims; empty when nothing was changed in this flow.
+     */
+    private Map<String, String> filterUpdatedClaims(FlowUser user) {
+
+        Set<String> updated = user.getUpdatedClaimUris();
+        if (updated == null || updated.isEmpty()) {
+            return new HashMap<>();
+        }
+        Map<String, String> result = new HashMap<>();
+        for (String uri : updated) {
+            // Skip updating username in non-registration flows.
+            if (USERNAME_CLAIM_URI.equals(uri)) {
+                continue;
+            }
+            String value = user.getClaims().get(uri);
+            if (value != null) {
+                result.put(uri, value);
+            }
+        }
+        return result;
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutorTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutorTest.java
@@ -172,8 +172,6 @@ public class PasswordProvisioningExecutorTest {
         assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_COMPLETE);
         if (Flow.Name.INVITED_USER_REGISTRATION.name().equals(flowType)) {
             assertEquals(flowUser.getUserId(), USER_ID);
-            assertTrue(flowUser.getClaims().containsKey("http://wso2.org/claims/givenname"));
-            assertEquals(flowUser.getClaims().get("http://wso2.org/claims/givenname"), "John");
         }
         verify(storeManager).updateCredentialByAdmin(eq(USERNAME), any(char[].class));
     }

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutorTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutorTest.java
@@ -207,8 +207,11 @@ public class UserProvisioningExecutorTest {
         FlowExecutionContext context = mock(FlowExecutionContext.class);
         FlowUser flowUser = createTestFlowUser(USERNAME);
 
+        String givenNameClaim = WSO2_CLAIM_DIALECT + "givenname";
         Map<String, String> userInputData = new HashMap<>();
-        userInputData.put(WSO2_CLAIM_DIALECT + "givenname", "John");
+        userInputData.put(givenNameClaim, "John");
+        flowUser.getClaims().put(givenNameClaim, "John");
+        when(flowUser.getUpdatedClaimUris()).thenReturn(Collections.singleton(givenNameClaim));
 
         when(context.getFlowType()).thenReturn("INVITED_USER_REGISTRATION");
         when(context.getFlowUser()).thenReturn(flowUser);
@@ -224,7 +227,7 @@ public class UserProvisioningExecutorTest {
 
         assertEquals(response.getResult(), STATUS_COMPLETE);
         verify(userStoreManager).setUserClaimValues(eq(PRIMARY_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + USERNAME),
-                any(Map.class), isNull());
+                eq(Collections.singletonMap(givenNameClaim, "John")), isNull());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -744,7 +744,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.11.102</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.107</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose

Fixes the password-recovery (and invited-user / ask-password) flow failure on AD/LDAP user stores caused by bulk-writing the entire preloaded CONSOLE-profile claim snapshot back to the user store on every flow completion.

`ConfirmationCodeValidationExecutor.setupFlowUser` preloads every local claim URI for the CONSOLE profile — including `http://wso2.org/claims/role` and `http://wso2.org/claims/roles` — onto `FlowUser`. The recovery executors then wrote that full snapshot back via `setUserClaimValues(...)`:

- **AD/LDAP**: `role` / `roles` aren't real LDAP attributes → `NoSuchAttributeException` → recovery never completes.
- **JDBC**: succeeds, but every recovery silently rewrites every preloaded claim with its unchanged value — needless listener traffic, outbound-provisioning re-syncs and attribute-row touches.

## Changes

- `UserProvisioningExecutor.execute` (non-registration branch): claim writeback is filtered through a new `filterUpdatedClaims(FlowUser)` helper that intersects `user.getClaims()` with `FlowUser.getUpdatedClaimUris()` (populated by the engine's centralised claim-merge sites — see the paired framework PR). The `setUserClaimValues` call is skipped when the filtered map is empty. The registration branch (`handleRegistrationFlow`, `addUser`) and the subsequent `processUserConsent` call are left intact.
- `PasswordProvisioningExecutor.handleAskPasswordFlow`: the in-line claim writeback is removed. This executor now performs the password update only; profile-claim persistence for the invited-user / ask-password flow is the responsibility of the upstream profile-update executor in the flow definition (which sees the same `getUpdatedClaimUris()` set). The now-unused `updateUserClaims` / `enrichUserProfile` helpers, the `FlowUser` import and the `WSO2_CLAIM_DIALECT` constant are dropped.

## Behaviour

- **Password recovery on AD/LDAP**: was failing with `NoSuchAttributeException`; now completes — the writeback is skipped because a password-only recovery declares no claim-typed inputs.
- **Password recovery on JDBC**: still completes; no longer issues a same-value bulk rewrite.
- **Invited-user / ask-password**: claims the user actually submits are persisted by the upstream profile-update executor; preloaded values the user didn't touch are no longer rewritten.
- **Custom recovery flow with a claim-typed input step**: only the submitted claim is persisted.
- **Self-registration**: unaffected (registration takes the `addUser` branch, untouched).

## Dependency

> [!IMPORTANT]
> This change requires the paired framework PR **wso2/carbon-identity-framework#8130** (`FlowUser.getUpdatedClaimUris()` / `addUpdatedClaim` plumbing). Once that PR is merged and a `carbon-identity-framework` release carrying it is published, `<carbon.identity.framework.version>` (currently `7.11.102`) must be bumped to that release. Held as **draft** until then.

## Related

- Paired framework PR: wso2/carbon-identity-framework#8130
- Public issue: https://github.com/wso2/product-is/issues/27738


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved credential provisioning for invited user registration workflows by eliminating unnecessary claim updates during the password provisioning process.

* **Improvements**
  * Optimized user provisioning to persist only claims that were actually modified, reducing unnecessary database operations and improving system efficiency.

* **Chores**
  * Updated Carbon Identity Framework dependency from version 7.11.102 to 7.11.107.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->