### PR TITLE
Address review comments on 1087.

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AskPasswordBasedPasswordSetupHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AskPasswordBasedPasswordSetupHandler.java
@@ -243,18 +243,14 @@ public class AskPasswordBasedPasswordSetupHandler extends AdminForcedPasswordRes
                 .ENABLE_EMAIL_VERIFICATION, tenantDomain));
     }
 
-    private static boolean isInviteUserRegistrationFlowEnabled(String tenantDomain) throws IdentityEventException {
+    private boolean isInviteUserRegistrationFlowEnabled(String tenantDomain) throws IdentityEventException {
 
         try {
             FlowConfigDTO flowConfigDTO = FlowMgtConfigUtils.getFlowConfig(
                     Constants.FlowTypes.INVITED_USER_REGISTRATION.getType(), tenantDomain);
             // A null flow configuration indicates that the Invited User Registration flow is not configured for the
             // tenant; therefore, invited user registration is not enabled.
-            if (flowConfigDTO != null) {
-                return flowConfigDTO.getIsEnabled();
-            } else {
-                return false;
-            }
+            return flowConfigDTO != null && flowConfigDTO.getIsEnabled();
         } catch (FlowMgtServerException e) {
             throw new IdentityEventException(
                     "Error while checking the invite user registration flow enablement for tenant: " +

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/AskPasswordBasedPasswordSetupHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/AskPasswordBasedPasswordSetupHandlerTest.java
@@ -374,6 +374,38 @@ public class AskPasswordBasedPasswordSetupHandlerTest {
         mockedUtils.verify(() -> Utils.publishRecoveryEvent(any(), any(), any()), org.mockito.Mockito.never());
     }
 
+    @Test
+    public void testHandleEventProceedsWhenOnlyInviteUserRegistrationFlowEnabled() throws IdentityEventException {
+
+        mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION, false);
+        FlowConfigDTO enabledFlowConfig = mock(FlowConfigDTO.class);
+        when(enabledFlowConfig.getIsEnabled()).thenReturn(true);
+        mockedFlowMgtUtils.when(() -> FlowMgtConfigUtils.getFlowConfig(
+                        eq(Constants.FlowTypes.INVITED_USER_REGISTRATION.getType()), anyString()))
+                .thenReturn(enabledFlowConfig);
+
+        char[] password = "test1".toCharArray();
+        mockedUtils.when(() -> Utils.generateRandomPassword(anyInt()))
+                .thenReturn(password);
+
+        StringBuffer credentials = new StringBuffer("test1");
+        Map<String, Object> additionalProperties = new HashMap<>();
+        additionalProperties.put(IdentityEventConstants.EventProperty.CREDENTIAL, credentials);
+
+        Map<String, String> additionalClaims = new HashMap<>();
+        additionalClaims.put(IdentityRecoveryConstants.ASK_PASSWORD_CLAIM, Boolean.TRUE.toString());
+
+        Event event = createEvent(IdentityEventConstants.Event.PRE_ADD_USER, IdentityRecoveryConstants.FALSE,
+                null, null, NEW_EMAIL, additionalProperties, additionalClaims);
+
+        askPasswordBasedPasswordSetupHandler.handleEvent(event);
+
+        // Verify the handler proceeded past the enablement gate.
+        mockedUtils.verify(() -> Utils.publishRecoveryEvent(any(),
+                eq(IdentityEventConstants.Event.PRE_ADD_USER_WITH_ASK_PASSWORD),
+                any()));
+    }
+
     @Test(expectedExceptions = IdentityEventException.class,
           expectedExceptionsMessageRegExp = "Error while checking the invite user registration flow enablement " +
                   "for tenant: .*")


### PR DESCRIPTION
This PR address comments on

- [ ] https://github.com/wso2-extensions/identity-governance/pull/1087

This pull request improves the logic for checking if the "Invite User Registration" flow is enabled and adds a new unit test to ensure correct handler behavior when only this flow is enabled. The main changes are a code simplification and an additional test case.

**Logic improvement:**

* Refactored the `isInviteUserRegistrationFlowEnabled` method in `AskPasswordBasedPasswordSetupHandler` to use a more concise return statement and changed its access from static to instance, simplifying the logic for checking if the invited user registration flow is enabled.

**Testing enhancements:**

* Added a new test, `testHandleEventProceedsWhenOnlyInviteUserRegistrationFlowEnabled`, to verify that the handler proceeds correctly when only the invite user registration flow is enabled, ensuring the event is published as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal method logic for improved code maintainability.

* **Tests**
  * Added a new unit test to verify handler behavior when invite user registration is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->