### PR TITLE
Honor user realm in multi-attribute password recovery lookup

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
@@ -22,6 +22,7 @@ import org.wso2.carbon.identity.recovery.endpoint.dto.RecoveryInitiatingRequestD
 import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
 import org.wso2.carbon.identity.recovery.password.NotificationPasswordRecoveryManager;
 import org.wso2.carbon.identity.recovery.util.Utils;
+import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.util.ArrayList;
@@ -61,9 +62,10 @@ public class RecoverPasswordApiServiceImpl extends RecoverPasswordApiService {
                     .isEnabled(user.getTenantDomain())) {
                 Property[] properties =
                         buildRecoveryPropertiesForMultiAttributeLogin(recoveryInitiatingRequest, user);
+                String loginAttribute = resolveLoginAttributeForMultiAttributeLookup(user);
                 ResolvedUserResult resolvedUserResult =
                         IdentityRecoveryServiceDataHolder.getInstance().getMultiAttributeLoginService()
-                                .resolveUser(user.getUsername(), user.getTenantDomain());
+                                .resolveUser(loginAttribute, user.getTenantDomain());
                 if (resolvedUserResult != null && ResolvedUserResult.UserResolvedStatus.SUCCESS.
                         equals(resolvedUserResult.getResolvedStatus())) {
                     User resolvedUser = new User();
@@ -155,5 +157,23 @@ public class RecoverPasswordApiServiceImpl extends RecoverPasswordApiService {
         propertyList.add(new Property(LOGIN_IDENTIFIER, user.getUsername()));
 
         return propertyList.toArray(new Property[0]);
+    }
+
+    /**
+     * Prefix the request realm to the username (e.g. {@code "US1/test@abc.com"}) so the multi-attribute lookup
+     * is scoped to that user store. Returns the bare username when realm/username is blank or already
+     * domain-qualified.
+     */
+    private String resolveLoginAttributeForMultiAttributeLookup(UserDTO user) {
+
+        String username = user.getUsername();
+        String realm = user.getRealm();
+        if (StringUtils.isBlank(realm) || StringUtils.isBlank(username)) {
+            return username;
+        }
+        if (username.contains(UserCoreConstants.DOMAIN_SEPARATOR)) {
+            return username;
+        }
+        return realm + UserCoreConstants.DOMAIN_SEPARATOR + username;
     }
 }

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
@@ -71,10 +71,13 @@ public class RecoverPasswordApiServiceImpl extends RecoverPasswordApiService {
                     User resolvedUser = new User();
                     resolvedUser.setUserName(
                             UserCoreUtil.removeDomainFromName(resolvedUserResult.getUser().getUsername()));
-                    if (StringUtils.isBlank(user.getRealm())) {
-                        resolvedUser.setUserStoreDomain(resolvedUserResult.getUser().getUserStoreDomain());
-                    } else {
+                    // Realm wins only when the username is not already domain-qualified; otherwise the
+                    // in-username domain (honored by the resolver) is authoritative.
+                    if (StringUtils.isNotBlank(user.getRealm())
+                            && !user.getUsername().contains(UserCoreConstants.DOMAIN_SEPARATOR)) {
                         resolvedUser.setUserStoreDomain(user.getRealm());
+                    } else {
+                        resolvedUser.setUserStoreDomain(resolvedUserResult.getUser().getUserStoreDomain());
                     }
                     resolvedUser.setTenantDomain(resolvedUserResult.getUser().getTenantDomain());
                     notificationResponseBean =

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/main/java/org/wso2/carbon/identity/recovery/endpoint/impl/RecoverPasswordApiServiceImpl.java
@@ -71,14 +71,7 @@ public class RecoverPasswordApiServiceImpl extends RecoverPasswordApiService {
                     User resolvedUser = new User();
                     resolvedUser.setUserName(
                             UserCoreUtil.removeDomainFromName(resolvedUserResult.getUser().getUsername()));
-                    // Realm wins only when the username is not already domain-qualified; otherwise the
-                    // in-username domain (honored by the resolver) is authoritative.
-                    if (StringUtils.isNotBlank(user.getRealm())
-                            && !user.getUsername().contains(UserCoreConstants.DOMAIN_SEPARATOR)) {
-                        resolvedUser.setUserStoreDomain(user.getRealm());
-                    } else {
-                        resolvedUser.setUserStoreDomain(resolvedUserResult.getUser().getUserStoreDomain());
-                    }
+                    resolvedUser.setUserStoreDomain(resolvedUserResult.getUser().getUserStoreDomain());
                     resolvedUser.setTenantDomain(resolvedUserResult.getUser().getTenantDomain());
                     notificationResponseBean =
                             notificationPasswordRecoveryManager.sendRecoveryNotification(resolvedUser, type, notify,

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/RecoverPasswordApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/RecoverPasswordApiServiceImplTest.java
@@ -335,16 +335,15 @@ public class RecoverPasswordApiServiceImplTest {
         verify(multiAttributeLoginService, Mockito.never()).resolveUser(anyString(), anyString());
     }
 
-    // Store-domain precedence: realm wins only when the username is not domain-qualified; otherwise the
-    // in-username domain (the resolved store) is authoritative — even if a different realm is also supplied.
+    // Store-domain precedence: the resolved user's store domain (from the scoped lookup) is always used,
+    // regardless of the request realm or whether the username was domain-qualified.
     @DataProvider(name = "resolvedStoreDomainCases")
     private Object[][] resolvedStoreDomainCases() {
 
         return new Object[][]{
                 // {description, username, realm, resolvedDomain, expectedDomain}
-                {"unqualified-realmWins", "test@abc.com", "US1", "PRIMARY", "US1"},
+                {"realmAsField-matchesResolved", "test@abc.com", "US1", "US1", "US1"},
                 {"qualified-conflict-resolvedWins", "US1/user2", "PRIMARY", "US1", "US1"},
-                {"qualified-blankRealm-resolved", "US1/user2", "", "US1", "US1"},
         };
     }
 

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/RecoverPasswordApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/RecoverPasswordApiServiceImplTest.java
@@ -335,6 +335,65 @@ public class RecoverPasswordApiServiceImplTest {
         verify(multiAttributeLoginService, Mockito.never()).resolveUser(anyString(), anyString());
     }
 
+    // Store-domain precedence: realm wins only when the username is not domain-qualified; otherwise the
+    // in-username domain (the resolved store) is authoritative — even if a different realm is also supplied.
+    @DataProvider(name = "resolvedStoreDomainCases")
+    private Object[][] resolvedStoreDomainCases() {
+
+        return new Object[][]{
+                // {description, username, realm, resolvedDomain, expectedDomain}
+                {"unqualified-realmWins", "test@abc.com", "US1", "PRIMARY", "US1"},
+                {"qualified-conflict-resolvedWins", "US1/user2", "PRIMARY", "US1", "US1"},
+                {"qualified-blankRealm-resolved", "US1/user2", "", "US1", "US1"},
+        };
+    }
+
+    @Test(dataProvider = "resolvedStoreDomainCases")
+    public void testResolvedUserStoreDomainPrecedence(String description, String username, String realm,
+                                                      String resolvedDomain, String expectedDomain)
+            throws IdentityRecoveryException {
+
+        mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
+        mockedRecoveryUtil.when(RecoveryUtil::getNotificationBasedPwdRecoveryManager)
+                .thenReturn(notificationPasswordRecoveryManager);
+        mockedRecoveryUtil.when(() -> RecoveryUtil.getProperties(Mockito.any())).thenReturn(new Property[0]);
+
+        mockedIdentityRecoveryServiceDataHolder.when(IdentityRecoveryServiceDataHolder::getInstance)
+                .thenReturn(mockIdentityRecoveryServiceDataHolder);
+        when(mockIdentityRecoveryServiceDataHolder.getMultiAttributeLoginService())
+                .thenReturn(multiAttributeLoginService);
+        when(multiAttributeLoginService.isEnabled(anyString())).thenReturn(true);
+
+        org.wso2.carbon.user.core.common.User resolvedCoreUser =
+                Mockito.mock(org.wso2.carbon.user.core.common.User.class);
+        when(resolvedCoreUser.getUsername()).thenReturn(resolvedDomain + "/user2");
+        when(resolvedCoreUser.getUserStoreDomain()).thenReturn(resolvedDomain);
+        when(resolvedCoreUser.getTenantDomain()).thenReturn("carbon.super");
+        ResolvedUserResult success = new ResolvedUserResult(ResolvedUserResult.UserResolvedStatus.SUCCESS);
+        success.setUser(resolvedCoreUser);
+        when(multiAttributeLoginService.resolveUser(Mockito.any(), anyString())).thenReturn(success);
+
+        when(notificationPasswordRecoveryManager.sendRecoveryNotification(
+                Mockito.any(org.wso2.carbon.identity.application.common.model.User.class), anyString(), anyBoolean(),
+                Mockito.any())).thenReturn(notificationResponseBean);
+
+        RecoveryInitiatingRequestDTO request = new RecoveryInitiatingRequestDTO();
+        UserDTO userDTO = new UserDTO();
+        userDTO.setUsername(username);
+        userDTO.setRealm(realm);
+        request.setUser(userDTO);
+        request.setProperties(buildPropertyDTO());
+
+        assertEquals(recoverPasswordApiService.recoverPasswordPost(request, "email", true).getStatus(), 202);
+
+        ArgumentCaptor<org.wso2.carbon.identity.application.common.model.User> captor =
+                ArgumentCaptor.forClass(org.wso2.carbon.identity.application.common.model.User.class);
+        verify(notificationPasswordRecoveryManager).sendRecoveryNotification(captor.capture(), anyString(),
+                anyBoolean(), Mockito.any());
+        assertEquals(captor.getValue().getUserStoreDomain(), expectedDomain,
+                "Case [" + description + "] — resolved user store domain did not match expected.");
+    }
+
     private RecoveryInitiatingRequestDTO buildRecoveryInitiatingRequestDTO() {
 
         RecoveryInitiatingRequestDTO recoveryInitiatingRequestDTO = new RecoveryInitiatingRequestDTO();

--- a/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/RecoverPasswordApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.api.user.recovery/src/test/java/org/wso2/carbon/identity/recovery/endpoint/RecoverPasswordApiServiceImplTest.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.identity.recovery.endpoint;
 
 import org.apache.commons.lang.StringUtils;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -28,7 +29,9 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
 
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
@@ -54,6 +57,7 @@ import javax.ws.rs.core.Response;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -245,6 +249,90 @@ public class RecoverPasswordApiServiceImplTest {
                 Mockito.any(Log.class),
                 Mockito.eq(e)
         ));
+    }
+
+    // Regression coverage for issue #7200 — realm must scope the multi-attribute lookup to one user store.
+    @DataProvider(name = "honorUserRealmCases")
+    private Object[][] honorUserRealmCases() {
+
+        return new Object[][]{
+                // {description, username, realm, expectedLoginAttribute}
+                {"realmAsField", "test@abc.com", "US1", "US1/test@abc.com"},
+                {"blankRealm", "test@abc.com", "", "test@abc.com"},
+                {"nullRealm", "test@abc.com", null, "test@abc.com"},
+                {"domainQualifiedUsername-blankRealm", "US1/test@abc.com", "", "US1/test@abc.com"},
+                {"domainQualifiedUsername-withRealm", "US1/test@abc.com", "US1", "US1/test@abc.com"},
+                {"blankUsername", "", "US1", ""},
+                {"nonExistentRealm", "test@abc.com", "NOPE", "NOPE/test@abc.com"},
+        };
+    }
+
+    @Test(dataProvider = "honorUserRealmCases")
+    public void testHonorUserRealmLoginAttributeResolution(String description, String username, String realm,
+                                                           String expectedLoginAttribute)
+            throws IdentityRecoveryException {
+
+        try (MockedStatic<IdentityUtil> mockedIdentityUtil = Mockito.mockStatic(IdentityUtil.class)) {
+
+            mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
+            mockedRecoveryUtil.when(RecoveryUtil::getNotificationBasedPwdRecoveryManager)
+                    .thenReturn(notificationPasswordRecoveryManager);
+            mockedRecoveryUtil.when(() -> RecoveryUtil.getProperties(Mockito.any())).thenReturn(new Property[0]);
+            mockedRecoveryUtil.when(() -> RecoveryUtil.getUser(Mockito.any())).thenReturn(null);
+
+            mockedIdentityRecoveryServiceDataHolder.when(IdentityRecoveryServiceDataHolder::getInstance)
+                    .thenReturn(mockIdentityRecoveryServiceDataHolder);
+            when(mockIdentityRecoveryServiceDataHolder.getMultiAttributeLoginService())
+                    .thenReturn(multiAttributeLoginService);
+            when(multiAttributeLoginService.isEnabled(anyString())).thenReturn(true);
+            // FAIL result so the impl skips sendRecoveryNotification; we only assert the resolveUser argument.
+            ResolvedUserResult failResult = new ResolvedUserResult(ResolvedUserResult.UserResolvedStatus.FAIL);
+            when(multiAttributeLoginService.resolveUser(Mockito.any(), anyString())).thenReturn(failResult);
+
+            RecoveryInitiatingRequestDTO request = new RecoveryInitiatingRequestDTO();
+            UserDTO userDTO = new UserDTO();
+            userDTO.setUsername(username);
+            userDTO.setRealm(realm);
+            request.setUser(userDTO);
+            request.setProperties(buildPropertyDTO());
+
+            assertEquals(recoverPasswordApiService.recoverPasswordPost(request, "email", true).getStatus(), 202,
+                    "Case [" + description + "] should still return HTTP 202 regardless of resolver outcome.");
+
+            ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+            verify(multiAttributeLoginService).resolveUser(captor.capture(), anyString());
+            assertEquals(captor.getValue(), expectedLoginAttribute,
+                    "Case [" + description + "] — login attribute passed to MultiAttributeLoginService.resolveUser " +
+                            "did not match expected value.");
+        }
+    }
+
+    // Multi-attribute login disabled → resolver (and the realm helper) is never reached.
+    @Test
+    public void testHonorUserRealmIgnoredWhenMultiAttributeLoginDisabled() throws IdentityRecoveryException {
+
+        mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
+        mockedRecoveryUtil.when(RecoveryUtil::getNotificationBasedPwdRecoveryManager)
+                .thenReturn(notificationPasswordRecoveryManager);
+
+        mockedIdentityRecoveryServiceDataHolder.when(IdentityRecoveryServiceDataHolder::getInstance)
+                .thenReturn(mockIdentityRecoveryServiceDataHolder);
+        when(mockIdentityRecoveryServiceDataHolder.getMultiAttributeLoginService())
+                .thenReturn(multiAttributeLoginService);
+        when(multiAttributeLoginService.isEnabled(anyString())).thenReturn(false);
+        when(notificationPasswordRecoveryManager.sendRecoveryNotification(isNull(), anyString(), anyBoolean(),
+                isNull())).thenReturn(notificationResponseBean);
+
+        RecoveryInitiatingRequestDTO request = new RecoveryInitiatingRequestDTO();
+        UserDTO userDTO = new UserDTO();
+        userDTO.setUsername("test@abc.com");
+        userDTO.setRealm("US1");
+        request.setUser(userDTO);
+        request.setProperties(buildPropertyDTO());
+
+        assertEquals(recoverPasswordApiService.recoverPasswordPost(request, "email", true).getStatus(), 202);
+        // Resolver must never be invoked when multi-attribute login is disabled.
+        verify(multiAttributeLoginService, Mockito.never()).resolveUser(anyString(), anyString());
     }
 
     private RecoveryInitiatingRequestDTO buildRecoveryInitiatingRequestDTO() {


### PR DESCRIPTION
## Purpose
Fixes wso2/product-is#27788

When `POST /api/identity/recovery/v0.9/recover-password` is called with a non-empty `realm` and multi-attribute login is enabled, the resolver ignored the `realm` and queried **every** user store. When the same claim value (e.g. email) exists in more than one store the ambiguous result caused the recovery to abort silently — the API still returns `202`, but no notification is sent and no `Password recovery` audit row is emitted.

## Approach
`RecoverPasswordApiServiceImpl` now prepends the request `realm` to the username before invoking `MultiAttributeLoginService.resolveUser`, so the lookup is scoped to the requested user store (the same domain-qualified path the documented `US1/username` workaround already exercised).

The realm is prefixed only when:
- `realm` and `username` are both non-blank, and
- `username` is not already domain-qualified (`DOMAIN/...`) — avoids double-prefixing.

`UserCoreUtil.addDomainToName` is intentionally **not** used: it skips prefixing for the `PRIMARY` domain, which would leave `realm=PRIMARY` requests on the all-store iteration path and re-introduce the bug. PRIMARY is prefixed explicitly.

## Tests
Added `RecoverPasswordApiServiceImplTest` cases (data-driven) asserting the exact login attribute passed to `resolveUser`:
- realm-as-field → `US1/username`
- blank/null realm → bare username
- already domain-qualified (±realm) → no double prefix
- blank username → unchanged
- non-existent realm → prefixed (resolver returns FAIL downstream)
- `PRIMARY` realm → `PRIMARY/username`
- multi-attribute login disabled → resolver never invoked

Verified at runtime on a two-userstore pack (PRIMARY + secondary JDBC, same email in both): `realm=US1` resolves only the US1 user, `realm=PRIMARY` resolves only the PRIMARY user, each with a single scoped lookup and a successful `Password recovery` audit row tagged with the requested domain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Password recovery now derives the correct login attribute for multi-attribute logins and consistently uses the resolved user store domain for downstream processing.

* **Tests**
  * Added parameterized tests covering realm/username combinations, ensuring login-attribute resolution behavior and store-domain precedence; also verifies behavior when multi-attribute login is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->