### PR TITLE
Fix recaptcha not being engaged in recovery paths

### DIFF
--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/PasswordRecoveryReCaptchaConnector.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/PasswordRecoveryReCaptchaConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2026, WSO2 LLC. (http://www.wso2.com).
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -76,6 +76,9 @@ public class PasswordRecoveryReCaptchaConnector extends AbstractReCaptchaConnect
 
     private static final String RECOVER_PASSWORD_URL = "/api/identity/recovery/v0.9/recover-password";
 
+    private static final String RECOVER_V1_PASSWORD_URL = "/api/users/v1/recovery/password/init";
+    private static final String RECOVER_V2_PASSWORD_URL = "/api/users/v2/recovery/password/init";
+
     private static final String RECOVERY_QUESTION_PASSWORD_RECAPTCHA_ENABLE = "Recovery.Question.Password" +
             ".ReCaptcha.Enable";
     private static final String RECOVERY_QUESTION_PASSWORD_RECAPTCHA_MAX_FAILED_ATTEMPTS = "Recovery.Question" +
@@ -106,7 +109,9 @@ public class PasswordRecoveryReCaptchaConnector extends AbstractReCaptchaConnect
                 (CaptchaUtil.isPathAvailable(path, ACCOUNT_SECURITY_QUESTION_URL) ||
                         CaptchaUtil.isPathAvailable(path, ACCOUNT_SECURITY_QUESTIONS_URL) ||
                         CaptchaUtil.isPathAvailable(path, ACCOUNT_VALIDATE_ANSWER_URL) ||
-                        CaptchaUtil.isPathAvailable(path, RECOVER_PASSWORD_URL));
+                        CaptchaUtil.isPathAvailable(path, RECOVER_PASSWORD_URL) ||
+                        CaptchaUtil.isPathAvailable(path, RECOVER_V1_PASSWORD_URL) ||
+                        CaptchaUtil.isPathAvailable(path, RECOVER_V2_PASSWORD_URL));
     }
 
     @Override
@@ -121,12 +126,15 @@ public class PasswordRecoveryReCaptchaConnector extends AbstractReCaptchaConnect
                 forgotPasswordRecaptchaEnabled) &&
                 (CaptchaUtil.isPathAvailable(pathUrl, ACCOUNT_SECURITY_QUESTION_URL) ||
                 CaptchaUtil.isPathAvailable(pathUrl, ACCOUNT_SECURITY_QUESTIONS_URL) ||
-                CaptchaUtil.isPathAvailable(pathUrl, RECOVER_PASSWORD_URL))) {
+                CaptchaUtil.isPathAvailable(pathUrl, RECOVER_PASSWORD_URL) ||
+                CaptchaUtil.isPathAvailable(pathUrl, RECOVER_V1_PASSWORD_URL) ||
+                CaptchaUtil.isPathAvailable(pathUrl, RECOVER_V2_PASSWORD_URL))) {
             preValidationResponse.setCaptchaValidationRequired(true);
         }
 
         // Handle recover with Email option.
-        if (pathUrl.equals(RECOVER_PASSWORD_URL)) {
+        if (pathUrl.equals(RECOVER_PASSWORD_URL) || pathUrl.equals(RECOVER_V1_PASSWORD_URL) ||
+                pathUrl.equals(RECOVER_V2_PASSWORD_URL)) {
             return preValidationResponse;
         }
 

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/UsernameRecoveryReCaptchaConnector.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/connector/recaptcha/UsernameRecoveryReCaptchaConnector.java
@@ -42,6 +42,8 @@ public class UsernameRecoveryReCaptchaConnector extends AbstractReCaptchaConnect
 
     private static final Log log = LogFactory.getLog(UsernameRecoveryReCaptchaConnector.class);
     private static final String RECOVER_USERNAME_URL = "/api/identity/recovery/v0.9/recover-username/";
+    private static final String RECOVER_V1_USERNAME_URL = "/api/users/v1/recovery/username/init";
+    private static final String RECOVER_V2_USERNAME_URL = "/api/users/v2/recovery/username/init";
     private final String PROPERTY_USERNAME_RECAPTCHA_ENABLE = "Recovery.ReCaptcha.Username.Enable";
     private IdentityGovernanceService identityGovernanceService;
 
@@ -62,7 +64,9 @@ public class UsernameRecoveryReCaptchaConnector extends AbstractReCaptchaConnect
 
         String path = ((HttpServletRequest) servletRequest).getRequestURI();
 
-        if (StringUtils.isBlank(path) || !(CaptchaUtil.isPathAvailable(path, RECOVER_USERNAME_URL))) {
+        if (StringUtils.isBlank(path) || !(CaptchaUtil.isPathAvailable(path, RECOVER_USERNAME_URL) ||
+                CaptchaUtil.isPathAvailable(path, RECOVER_V1_USERNAME_URL) ||
+                CaptchaUtil.isPathAvailable(path, RECOVER_V2_USERNAME_URL))) {
             return false;
         }
 
@@ -82,7 +86,9 @@ public class UsernameRecoveryReCaptchaConnector extends AbstractReCaptchaConnect
         String path = ((HttpServletRequest) servletRequest).getRequestURI();
         HttpServletResponse httpServletResponse = ((HttpServletResponse) servletResponse);
 
-        if (CaptchaUtil.isPathAvailable(path, RECOVER_USERNAME_URL)) {
+        if (CaptchaUtil.isPathAvailable(path, RECOVER_USERNAME_URL)
+                || CaptchaUtil.isPathAvailable(path, RECOVER_V1_USERNAME_URL)
+                || CaptchaUtil.isPathAvailable(path, RECOVER_V2_USERNAME_URL)) {
             httpServletResponse.setHeader("reCaptcha", "conditional");
             preValidationResponse.setCaptchaValidationRequired(true);
         }

--- a/components/org.wso2.carbon.identity.captcha/src/test/java/org/wso2/carbon/identity/captcha/connector/recaptcha/RecoveryReCaptchaConnectorTest.java
+++ b/components/org.wso2.carbon.identity.captcha/src/test/java/org/wso2/carbon/identity/captcha/connector/recaptcha/RecoveryReCaptchaConnectorTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.captcha.connector.recaptcha;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.captcha.connector.CaptchaPreValidationResponse;
+import org.wso2.carbon.identity.captcha.exception.CaptchaException;
+import org.wso2.carbon.identity.captcha.internal.CaptchaDataHolder;
+import org.wso2.carbon.identity.captcha.util.CaptchaUtil;
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+
+import java.util.Collections;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for recovery reCAPTCHA connectors.
+ */
+public class RecoveryReCaptchaConnectorTest {
+
+    private static final String RECOVER_V1_USERNAME_URL = "/api/users/v1/recovery/username/init";
+    private static final String RECOVER_V2_USERNAME_URL = "/api/users/v2/recovery/username/init";
+    private static final String RECOVER_V1_PASSWORD_URL = "/api/users/v1/recovery/password/init";
+    private static final String RECOVER_V2_PASSWORD_URL = "/api/users/v2/recovery/password/init";
+
+    @DataProvider(name = "usernameRecoveryApiPaths")
+    public Object[][] usernameRecoveryApiPaths() {
+
+        return new Object[][]{
+                {RECOVER_V1_USERNAME_URL},
+                {RECOVER_V2_USERNAME_URL}
+        };
+    }
+
+    @DataProvider(name = "passwordRecoveryApiPaths")
+    public Object[][] passwordRecoveryApiPaths() {
+
+        return new Object[][]{
+                {RECOVER_V1_PASSWORD_URL},
+                {RECOVER_V2_PASSWORD_URL}
+        };
+    }
+
+    @Test(dataProvider = "usernameRecoveryApiPaths")
+    public void testUsernameRecoveryConnectorCanHandleV1AndV2ApiPaths(String path) throws CaptchaException {
+
+        UsernameRecoveryReCaptchaConnector connector = new UsernameRecoveryReCaptchaConnector();
+        CaptchaDataHolder dataHolder = mock(CaptchaDataHolder.class);
+        HttpServletRequest request = getRequest(path);
+
+        try (MockedStatic<CaptchaDataHolder> dataHolderStatic = Mockito.mockStatic(CaptchaDataHolder.class);
+                MockedStatic<CaptchaUtil> captchaUtilStatic = Mockito.mockStatic(CaptchaUtil.class)) {
+            dataHolderStatic.when(CaptchaDataHolder::getInstance).thenReturn(dataHolder);
+            when(dataHolder.isForcefullyEnabledRecaptchaForAllTenants()).thenReturn(true);
+            mockPathAvailability(captchaUtilStatic);
+
+            assertTrue(connector.canHandle(request, mock(HttpServletResponse.class)));
+        }
+    }
+
+    @Test(dataProvider = "usernameRecoveryApiPaths")
+    public void testUsernameRecoveryConnectorPreValidateRequiresCaptchaForV1AndV2ApiPaths(String path)
+            throws CaptchaException {
+
+        UsernameRecoveryReCaptchaConnector connector = new UsernameRecoveryReCaptchaConnector();
+        HttpServletRequest request = getRequest(path);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        try (MockedStatic<CaptchaUtil> captchaUtilStatic = Mockito.mockStatic(CaptchaUtil.class)) {
+            mockPathAvailability(captchaUtilStatic);
+
+            CaptchaPreValidationResponse preValidationResponse = connector.preValidate(request, response);
+
+            assertTrue(preValidationResponse.isCaptchaValidationRequired());
+            Mockito.verify(response).setHeader("reCaptcha", "conditional");
+        }
+    }
+
+    @Test(dataProvider = "passwordRecoveryApiPaths")
+    public void testPasswordRecoveryConnectorCanHandleV1AndV2ApiPaths(String path) throws CaptchaException {
+
+        PasswordRecoveryReCaptchaConnector connector = new PasswordRecoveryReCaptchaConnector();
+        CaptchaDataHolder dataHolder = mock(CaptchaDataHolder.class);
+        HttpServletRequest request = getRequest(path);
+
+        try (MockedStatic<CaptchaDataHolder> dataHolderStatic = Mockito.mockStatic(CaptchaDataHolder.class);
+                MockedStatic<CaptchaUtil> captchaUtilStatic = Mockito.mockStatic(CaptchaUtil.class)) {
+            dataHolderStatic.when(CaptchaDataHolder::getInstance).thenReturn(dataHolder);
+            when(dataHolder.getReCaptchaBypassedApiEndpoints()).thenReturn(Collections.emptyList());
+            mockPathAvailability(captchaUtilStatic);
+
+            assertTrue(connector.canHandle(request, mock(HttpServletResponse.class)));
+        }
+    }
+
+    @Test(dataProvider = "passwordRecoveryApiPaths")
+    public void testPasswordRecoveryConnectorPreValidateRequiresCaptchaForV1AndV2ApiPaths(String path)
+            throws CaptchaException {
+
+        PasswordRecoveryReCaptchaConnector connector = new PasswordRecoveryReCaptchaConnector();
+        connector.init(mock(IdentityGovernanceService.class));
+        CaptchaDataHolder dataHolder = mock(CaptchaDataHolder.class);
+        HttpServletRequest request = getRequest(path);
+
+        try (MockedStatic<CaptchaDataHolder> dataHolderStatic = Mockito.mockStatic(CaptchaDataHolder.class);
+                MockedStatic<CaptchaUtil> captchaUtilStatic = Mockito.mockStatic(CaptchaUtil.class)) {
+            dataHolderStatic.when(CaptchaDataHolder::getInstance).thenReturn(dataHolder);
+            when(dataHolder.isForcefullyEnabledRecaptchaForAllTenants()).thenReturn(false);
+            captchaUtilStatic.when(() -> CaptchaUtil.isRecaptchaEnabledForConnector(
+                    any(IdentityGovernanceService.class), any(ServletRequest.class), anyString())).thenReturn(true);
+            mockPathAvailability(captchaUtilStatic);
+
+            CaptchaPreValidationResponse preValidationResponse =
+                    connector.preValidate(request, mock(HttpServletResponse.class));
+
+            assertTrue(preValidationResponse.isCaptchaValidationRequired());
+        }
+    }
+
+    private HttpServletRequest getRequest(String path) {
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn(path);
+        return request;
+    }
+
+    private void mockPathAvailability(MockedStatic<CaptchaUtil> captchaUtilStatic) {
+
+        captchaUtilStatic.when(() -> CaptchaUtil.isPathAvailable(anyString(), anyString()))
+                .thenAnswer(invocation -> invocation.getArgument(0).equals(invocation.getArgument(1)));
+    }
+}

--- a/components/org.wso2.carbon.identity.captcha/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.captcha/src/test/resources/testng.xml
@@ -31,6 +31,7 @@
     <test name="Captcha-Connector-Tests" preserve-order="true" parallel="false">
         <classes>
             <class name="org.wso2.carbon.identity.captcha.connector.recaptcha.AbstractOTPCaptchaConnectorTest"/>
+            <class name="org.wso2.carbon.identity.captcha.connector.recaptcha.RecoveryReCaptchaConnectorTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
### Proposed changes in this pull request

[List all changes you want to add here. If you fixed an issue, please
add a reference to that issue as well.]

$subject

## Related issues

- https://github.com/wso2/product-is/issues/28003

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Extended username and password recovery to support new API versions (v1 and v2) while preserving compatibility with existing endpoints
  * Enhanced security by requiring CAPTCHA verification for recovery requests on the newly supported API versions

* **Tests**
  * Added unit tests covering v1/v2 username and password recovery flows to validate CAPTCHA handling and behavior

* **Chores**
  * Minor attribution/copyright line update
<!-- end of auto-generated comment: release notes by coderabbit.ai -->