### PR TITLE
Remove tenant event publisher and stream state on tenant unload

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -7,7 +7,7 @@ name: PR Builder
 
 on:
   pull_request:
-    branches: [main, master]
+    branches: [main, master, next]
   workflow_dispatch:
 
 env:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 If you want to build **identity-governance** from the source code:
 
-1. Install Java 11 (or Java 17)
+1. Install Java 21 or above.
 2. Install Apache Maven 3.x.x (https://maven.apache.org/download.cgi#)
 3. Get a clone or download the source from this repository (https://github.com/wso2-extensions/identity-governance)
 4. Run the Maven command ``mvn clean install`` from the ``identity-governance`` directory.

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/handler/AccountSuspensionNotificationHandler.java
+++ b/components/org.wso2.carbon.identity.account.suspension.notification.task/src/main/java/org/wso2/carbon/identity/account/suspension/notification/task/handler/AccountSuspensionNotificationHandler.java
@@ -47,6 +47,7 @@ public class AccountSuspensionNotificationHandler extends AbstractEventHandler i
 
     private static final Log log = LogFactory.getLog(AccountSuspensionNotificationHandler.class);
     private static final String UPDATE_CONFIGURATION = "UPDATE_CONFIGURATION";
+    private static final String LAST_LOGIN_TIME_CLAIM_UPDATE = "LastLoginTimeClaimUpdate";
 
     @Override
     public void handleEvent(Event event) throws IdentityEventException {
@@ -86,9 +87,13 @@ public class AccountSuspensionNotificationHandler extends AbstractEventHandler i
                     userClaims.put(NotificationConstants.LAST_LOGIN_TIME, currentTime);
                 }
 
+                // Related to https://github.com/wso2/product-is/issues/25324
+                IdentityUtil.threadLocalProperties.get().put(LAST_LOGIN_TIME_CLAIM_UPDATE, true);
                 userStoreManager.setUserClaimValues(userName, userClaims, null);
             } catch (UserStoreException e) {
                 log.error("Error occurred while updating last login claim for user: ", e);
+            } finally {
+                IdentityUtil.threadLocalProperties.get().remove(LAST_LOGIN_TIME_CLAIM_UPDATE);
             }
         }
     }

--- a/components/org.wso2.carbon.identity.api.user.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.governance/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.user.governance</artifactId>
-    <version>1.15.9</version>
+    <version>1.15.10-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon -  User Rest Governance API</name>
     <description>WSO2 Carbon - User Rest Governance API</description>

--- a/components/org.wso2.carbon.identity.api.user.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.governance/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.user.governance</artifactId>
-    <version>1.15.6</version>
+    <version>1.15.7-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon -  User Rest Governance API</name>
     <description>WSO2 Carbon - User Rest Governance API</description>

--- a/components/org.wso2.carbon.identity.api.user.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.governance/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.user.governance</artifactId>
-    <version>1.15.7-SNAPSHOT</version>
+    <version>1.15.7</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon -  User Rest Governance API</name>
     <description>WSO2 Carbon - User Rest Governance API</description>

--- a/components/org.wso2.carbon.identity.api.user.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.governance/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.user.governance</artifactId>
-    <version>1.15.6-SNAPSHOT</version>
+    <version>1.15.6</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon -  User Rest Governance API</name>
     <description>WSO2 Carbon - User Rest Governance API</description>

--- a/components/org.wso2.carbon.identity.api.user.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.governance/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.user.governance</artifactId>
-    <version>1.15.8-SNAPSHOT</version>
+    <version>1.15.8</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon -  User Rest Governance API</name>
     <description>WSO2 Carbon - User Rest Governance API</description>

--- a/components/org.wso2.carbon.identity.api.user.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.governance/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.user.governance</artifactId>
-    <version>1.15.9-SNAPSHOT</version>
+    <version>1.15.9</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon -  User Rest Governance API</name>
     <description>WSO2 Carbon - User Rest Governance API</description>

--- a/components/org.wso2.carbon.identity.api.user.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.governance/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.user.governance</artifactId>
-    <version>1.15.7</version>
+    <version>1.15.8-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon -  User Rest Governance API</name>
     <description>WSO2 Carbon - User Rest Governance API</description>

--- a/components/org.wso2.carbon.identity.api.user.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.governance/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.user.governance</artifactId>
-    <version>1.15.8</version>
+    <version>1.15.9-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon -  User Rest Governance API</name>
     <description>WSO2 Carbon - User Rest Governance API</description>

--- a/components/org.wso2.carbon.identity.api.user.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.recovery/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.user.recovery</artifactId>
-    <version>1.15.6-SNAPSHOT</version>
+    <version>1.15.6</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon - Identity Management Recovery Rest API</name>
     <description>WSO2 Carbon - Identity Management Recovery Rest API</description>

--- a/components/org.wso2.carbon.identity.api.user.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.recovery/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.user.recovery</artifactId>
-    <version>1.15.8</version>
+    <version>1.15.9-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon - Identity Management Recovery Rest API</name>
     <description>WSO2 Carbon - Identity Management Recovery Rest API</description>

--- a/components/org.wso2.carbon.identity.api.user.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.recovery/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.user.recovery</artifactId>
-    <version>1.15.7</version>
+    <version>1.15.8-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon - Identity Management Recovery Rest API</name>
     <description>WSO2 Carbon - Identity Management Recovery Rest API</description>

--- a/components/org.wso2.carbon.identity.api.user.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.recovery/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.user.recovery</artifactId>
-    <version>1.15.6</version>
+    <version>1.15.7-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon - Identity Management Recovery Rest API</name>
     <description>WSO2 Carbon - Identity Management Recovery Rest API</description>

--- a/components/org.wso2.carbon.identity.api.user.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.recovery/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.user.recovery</artifactId>
-    <version>1.15.7-SNAPSHOT</version>
+    <version>1.15.7</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon - Identity Management Recovery Rest API</name>
     <description>WSO2 Carbon - Identity Management Recovery Rest API</description>

--- a/components/org.wso2.carbon.identity.api.user.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.recovery/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.user.recovery</artifactId>
-    <version>1.15.8-SNAPSHOT</version>
+    <version>1.15.8</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon - Identity Management Recovery Rest API</name>
     <description>WSO2 Carbon - Identity Management Recovery Rest API</description>

--- a/components/org.wso2.carbon.identity.api.user.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.recovery/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.user.recovery</artifactId>
-    <version>1.15.9</version>
+    <version>1.15.10-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon - Identity Management Recovery Rest API</name>
     <description>WSO2 Carbon - Identity Management Recovery Rest API</description>

--- a/components/org.wso2.carbon.identity.api.user.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.api.user.recovery/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.user.recovery</artifactId>
-    <version>1.15.9-SNAPSHOT</version>
+    <version>1.15.9</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon - Identity Management Recovery Rest API</name>
     <description>WSO2 Carbon - Identity Management Recovery Rest API</description>

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.attribute.handler/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.governance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.governance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.governance/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>org.wso2.carbon.tenant.mgt</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>javax.cache.wso2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.axis2.wso2</groupId>
             <artifactId>axis2</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.identity.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.governance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.governance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.governance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.governance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.governance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.governance/pom.xml
+++ b/components/org.wso2.carbon.identity.governance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStore.java
@@ -145,7 +145,7 @@ public class InMemoryIdentityDataStore extends UserIdentityDataStore {
                     cachedUserIdentityDTO.getUserIdentityDataMap().putAll(userIdentityDTO.getUserIdentityDataMap());
                     identityDataStoreCache.addToCacheOnRead(key, cachedUserIdentityDTO, tenantId);
                 } else {
-                    identityDataStoreCache.addToCacheOnRead(key, userIdentityDTO, tenantId);
+                    identityDataStoreCache.addToCache(key, userIdentityDTO, tenantId);
                 }
             }
         } catch (UserStoreException e) {

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStore.java
@@ -136,7 +136,9 @@ public class InMemoryIdentityDataStore extends UserIdentityDataStore {
                 }
 
                 org.wso2.carbon.user.core.UserStoreManager store = (org.wso2.carbon.user.core.UserStoreManager) userStoreManager;
-                String domainName = store.getRealmConfiguration().getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
+                String domainName = store.getRealmConfiguration().getUserStoreProperty(
+                    UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME
+                );
 
                 IdentityDataStoreCacheKey key = new IdentityDataStoreCacheKey(domainName, userName);
                 int tenantId = userStoreManager.getTenantId();

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStore.java
@@ -97,6 +97,63 @@ public class InMemoryIdentityDataStore extends UserIdentityDataStore {
     }
 
     @Override
+    public void storeOnRead(UserIdentityClaim userIdentityDTO, UserStoreManager userStoreManager)
+            throws IdentityException {
+
+        try {
+            if (userIdentityDTO != null && userIdentityDTO.getUserName() != null) {
+                String userName = UserCoreUtil.removeDomainFromName(userIdentityDTO.getUserName());
+                if (userStoreManager instanceof org.wso2.carbon.user.core.UserStoreManager) {
+                    if (!IdentityUtil.isUserStoreCaseSensitive((org.wso2.carbon.user.core.UserStoreManager)
+                            userStoreManager)) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Case insensitive user store found. Changing username from : " + userName +
+                                    " to : " + userName.toLowerCase(Locale.ENGLISH));
+                        }
+                        userName = userName.toLowerCase(Locale.ENGLISH);
+                    } else if (!IdentityUtil.isUseCaseSensitiveUsernameForCacheKeys(
+                            (org.wso2.carbon.user.core.UserStoreManager) userStoreManager)) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Case insensitive username for cache key is used. Changing username from : "
+                                    + userName + " to : " + userName.toLowerCase(Locale.ENGLISH));
+                        }
+                        userName = userName.toLowerCase(Locale.ENGLISH);
+                    }
+                }
+
+                if (log.isDebugEnabled()) {
+                    StringBuilder data = new StringBuilder("{");
+                    if (userIdentityDTO.getUserIdentityDataMap() != null) {
+                        for (Map.Entry<String, String> entry : userIdentityDTO.getUserIdentityDataMap().entrySet()) {
+                            data.append("[").append(entry.getKey()).append(" = ").append(entry.getValue()).append("], ");
+                        }
+                    }
+                    if (data.indexOf(",") >= 0) {
+                        data.deleteCharAt(data.lastIndexOf(","));
+                    }
+                    data.append("}");
+                    log.debug("Storing UserIdentityClaimsDO to cache for user: " + userName + " with claims: " + data);
+                }
+
+                org.wso2.carbon.user.core.UserStoreManager store = (org.wso2.carbon.user.core.UserStoreManager) userStoreManager;
+                String domainName = store.getRealmConfiguration().getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
+
+                IdentityDataStoreCacheKey key = new IdentityDataStoreCacheKey(domainName, userName);
+                int tenantId = userStoreManager.getTenantId();
+                UserIdentityClaim cachedUserIdentityDTO = identityDataStoreCache.getValueFromCache(key, tenantId);
+                if (cachedUserIdentityDTO != null) {
+                    cachedUserIdentityDTO.getUserIdentityDataMap().putAll(userIdentityDTO.getUserIdentityDataMap());
+                    identityDataStoreCache.addToCacheOnRead(key, cachedUserIdentityDTO, tenantId);
+                } else {
+                    identityDataStoreCache.addToCacheOnRead(key, userIdentityDTO, tenantId);
+                }
+            }
+        } catch (UserStoreException e) {
+            log.error("Error while obtaining tenant ID from user store manager", e);
+        }
+    }
+
+    @Override
     public UserIdentityClaim load(String userName, UserStoreManager userStoreManager) {
 
         try {

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/JDBCIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/JDBCIdentityDataStore.java
@@ -231,7 +231,7 @@ public class JDBCIdentityDataStore extends InMemoryIdentityDataStore {
             dto = new UserIdentityClaim(userName, data);
             dto.setTenantId(tenantId);
             try {
-                super.store(dto, userStoreManager);
+                super.storeOnRead(dto, userStoreManager);
             } catch (IdentityException e) {
                 log.error("Error while reading user identity data", e);
             }

--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/UserIdentityDataStore.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/store/UserIdentityDataStore.java
@@ -65,6 +65,17 @@ public abstract class UserIdentityDataStore {
             throws IdentityException;
 
     /**
+     * Stores data during a READ operation.
+     *
+     * @param userIdentityDTO
+     * @param userStoreManager
+     */
+    public void storeOnRead(UserIdentityClaim userIdentityDTO, UserStoreManager userStoreManager)
+            throws IdentityException {
+        // By default, do nothing. Subclasses may override this method if needed.
+    }
+
+    /**
      * Loads
      *
      * @param userName

--- a/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStoreTest.java
+++ b/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStoreTest.java
@@ -75,6 +75,10 @@ public class InMemoryIdentityDataStoreTest {
     @BeforeMethod
     public void setUp() {
 
+        // CarbonContext's static initializer reads CARBON_HOME; set it before any static mock so
+        // PrivilegedCarbonContext can be instrumented without triggering a class-init failure.
+        System.setProperty(CarbonBaseConstants.CARBON_HOME,
+                Paths.get(System.getProperty("user.dir"), "target").toString());
         MockitoAnnotations.openMocks(this);
         mockedIdentityUtil = Mockito.mockStatic(IdentityUtil.class);
         mockedUserCoreUtil = Mockito.mockStatic(UserCoreUtil.class);
@@ -101,6 +105,11 @@ public class InMemoryIdentityDataStoreTest {
         identityClaimsMap.put("keyOne", "valueOne");
         identityClaimsMap.put("keyTwo", "valueTwo");
 
+        // Stub getThreadLocalCarbonContext before initPrivilegedCarbonContext() is called, otherwise the
+        // static mock returns null and the init helper throws an NPE.
+        mockedPrivilegedCarbonContext.when(PrivilegedCarbonContext::getThreadLocalCarbonContext)
+                .thenReturn(privilegedCarbonContext);
+
         initPrivilegedCarbonContext();
 
         Map<String, String> identityClaimsMapClone = new HashMap<>(identityClaimsMap);
@@ -109,12 +118,13 @@ public class InMemoryIdentityDataStoreTest {
         userIdentityClaim = mock(UserIdentityClaim.class);
         realmConfiguration = mock(RealmConfiguration.class);
         userIdentityDataStore = mock(InMemoryIdentityDataStore.class);
-        privilegedCarbonContext = mock(PrivilegedCarbonContext.class);
+
+        IdentityDataStoreCache mockCache = mock(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache);
 
         mockedIdentityUtil.when(() -> IdentityUtil.isUserStoreCaseSensitive(userStoreManager)).thenReturn(true);
         mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName("gayashan")).thenReturn("gayashan");
-        mockedPrivilegedCarbonContext.when(PrivilegedCarbonContext::getThreadLocalCarbonContext)
-                .thenReturn(privilegedCarbonContext);
 
         Mockito.when(userStoreManager.getTenantId()).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
         Mockito.when(userIdentityClaim.getUserName()).thenReturn("gayashan");

--- a/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStoreTest.java
+++ b/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStoreTest.java
@@ -199,9 +199,9 @@ public class InMemoryIdentityDataStoreTest {
 
         new InMemoryIdentityDataStore().storeOnRead(dto, usm);
 
-        verify(mockCache).addToCacheOnRead(any(IdentityDataStoreCacheKey.class), any(UserIdentityClaim.class),
+        verify(mockCache).addToCache(any(IdentityDataStoreCacheKey.class), any(UserIdentityClaim.class),
                 anyInt());
-        verify(mockCache, never()).addToCache(any(), any(), anyInt());
+        verify(mockCache, never()).addToCacheOnRead(any(), any(), anyInt());
     }
 
     @Test(description = "storeOnRead should merge claims with the cached entry and call addToCacheOnRead.")
@@ -270,7 +270,7 @@ public class InMemoryIdentityDataStoreTest {
 
         // Verify cache was called with the lowercased key.
         IdentityDataStoreCacheKey expectedKey = new IdentityDataStoreCacheKey("PRIMARY", "charlie");
-        verify(mockCache).addToCacheOnRead(
+        verify(mockCache).addToCache(
                 Mockito.eq(expectedKey),
                 any(UserIdentityClaim.class), anyInt());
     }
@@ -302,17 +302,19 @@ public class InMemoryIdentityDataStoreTest {
         new InMemoryIdentityDataStore().storeOnRead(dto, usm);
 
         IdentityDataStoreCacheKey expectedKey = new IdentityDataStoreCacheKey("PRIMARY", "dave");
-        verify(mockCache).addToCacheOnRead(
+        verify(mockCache).addToCache(
                 Mockito.eq(expectedKey),
                 any(UserIdentityClaim.class), anyInt());
     }
 
-    @Test(description = "storeOnRead should NOT call addToCache — only addToCacheOnRead is allowed.")
-    public void testStoreOnRead_neverCallsAddToCache() throws Exception {
+    @Test(description = "addToCache and addToCacheOnRead are mutually exclusive: " +
+            "no cached entry uses addToCache only; existing cached entry uses addToCacheOnRead only.")
+    public void testStoreOnRead_cacheMethods_areMutuallyExclusive() throws Exception {
 
-        IdentityDataStoreCache mockCache = mock(IdentityDataStoreCache.class);
+        // Branch 1: no cached entry — addToCache is called, addToCacheOnRead is never called.
+        IdentityDataStoreCache mockCache1 = mock(IdentityDataStoreCache.class);
         mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
-        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache1);
 
         JDBCUserStoreManager usm = mock(JDBCUserStoreManager.class);
         RealmConfiguration rc = mock(RealmConfiguration.class);
@@ -329,18 +331,29 @@ public class InMemoryIdentityDataStoreTest {
         when(usm.getRealmConfiguration()).thenReturn(rc);
         when(usm.getTenantId()).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
         when(rc.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME)).thenReturn("PRIMARY");
+        when(mockCache1.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(null);
 
-        // Test both branches: no cached entry, and with cached entry.
-        when(mockCache.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(null);
         new InMemoryIdentityDataStore().storeOnRead(dto, usm);
-        verify(mockCache, never()).addToCache(any(), any(), anyInt());
+
+        verify(mockCache1).addToCache(any(), any(), anyInt());
+        verify(mockCache1, never()).addToCacheOnRead(any(), any(), anyInt());
+
+        mockedIdentityDataStoreCache.close();
+
+        // Branch 2: cached entry exists — addToCacheOnRead is called, addToCache is never called.
+        IdentityDataStoreCache mockCache2 = mock(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache2);
 
         Map<String, String> cachedClaims = new HashMap<>();
         UserIdentityClaim cachedDto = mock(UserIdentityClaim.class);
         when(cachedDto.getUserIdentityDataMap()).thenReturn(cachedClaims);
-        when(mockCache.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(cachedDto);
+        when(mockCache2.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(cachedDto);
+
         new InMemoryIdentityDataStore().storeOnRead(dto, usm);
-        verify(mockCache, never()).addToCache(any(), any(), anyInt());
+
+        verify(mockCache2).addToCacheOnRead(any(), any(), anyInt());
+        verify(mockCache2, never()).addToCache(any(), any(), anyInt());
     }
 
     @Test(description = "The default storeOnRead in UserIdentityDataStore should be a no-op with no exception.")

--- a/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStoreTest.java
+++ b/components/org.wso2.carbon.identity.governance/src/test/java/org/wso2/carbon/identity/governance/store/InMemoryIdentityDataStoreTest.java
@@ -28,6 +28,8 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.governance.internal.cache.IdentityDataStoreCache;
+import org.wso2.carbon.identity.governance.internal.cache.IdentityDataStoreCacheKey;
 import org.wso2.carbon.identity.governance.model.UserIdentityClaim;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.UserCoreConstants;
@@ -40,7 +42,12 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 public class InMemoryIdentityDataStoreTest {
@@ -63,6 +70,7 @@ public class InMemoryIdentityDataStoreTest {
     MockedStatic<IdentityUtil> mockedIdentityUtil;
     MockedStatic<UserCoreUtil> mockedUserCoreUtil;
     MockedStatic<PrivilegedCarbonContext> mockedPrivilegedCarbonContext;
+    MockedStatic<IdentityDataStoreCache> mockedIdentityDataStoreCache;
 
     @BeforeMethod
     public void setUp() {
@@ -79,6 +87,10 @@ public class InMemoryIdentityDataStoreTest {
         mockedIdentityUtil.close();
         mockedUserCoreUtil.close();
         mockedPrivilegedCarbonContext.close();
+        if (mockedIdentityDataStoreCache != null) {
+            mockedIdentityDataStoreCache.close();
+            mockedIdentityDataStoreCache = null;
+        }
     }
 
     @Test(testName = "testStore", description = "Test whether the map in UserIdentityClaim object containing " +
@@ -117,6 +129,232 @@ public class InMemoryIdentityDataStoreTest {
                 "object has been modified.");
 
     }
+
+    // ── storeOnRead tests ─────────────────────────────────────────────────────
+
+    @Test(description = "storeOnRead should silently do nothing when the DTO is null.")
+    public void testStoreOnRead_withNullDTO_doesNothing() throws Exception {
+
+        IdentityDataStoreCache mockCache = mock(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache);
+
+        InMemoryIdentityDataStore store = new InMemoryIdentityDataStore();
+        store.storeOnRead(null, mock(JDBCUserStoreManager.class));
+
+        verify(mockCache, never()).addToCacheOnRead(any(), any(), anyInt());
+        verify(mockCache, never()).addToCache(any(), any(), anyInt());
+    }
+
+    @Test(description = "storeOnRead should silently do nothing when the userName inside the DTO is null.")
+    public void testStoreOnRead_withNullUserName_doesNothing() throws Exception {
+
+        IdentityDataStoreCache mockCache = mock(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache);
+
+        UserIdentityClaim dto = mock(UserIdentityClaim.class);
+        when(dto.getUserName()).thenReturn(null);
+
+        InMemoryIdentityDataStore store = new InMemoryIdentityDataStore();
+        store.storeOnRead(dto, mock(JDBCUserStoreManager.class));
+
+        verify(mockCache, never()).addToCacheOnRead(any(), any(), anyInt());
+        verify(mockCache, never()).addToCache(any(), any(), anyInt());
+    }
+
+    @Test(description = "storeOnRead should store directly via addToCacheOnRead when no entry exists in cache.")
+    public void testStoreOnRead_noCachedEntry_storesDirectly() throws Exception {
+
+        IdentityDataStoreCache mockCache = mock(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache);
+
+        JDBCUserStoreManager usm = mock(JDBCUserStoreManager.class);
+        RealmConfiguration rc = mock(RealmConfiguration.class);
+        UserIdentityClaim dto = mock(UserIdentityClaim.class);
+        Map<String, String> claims = new HashMap<>();
+        claims.put("claimKey", "claimVal");
+
+        mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName("alice")).thenReturn("alice");
+        mockedIdentityUtil.when(() -> IdentityUtil.isUserStoreCaseSensitive(usm)).thenReturn(true);
+        mockedIdentityUtil.when(() -> IdentityUtil.isUseCaseSensitiveUsernameForCacheKeys(usm)).thenReturn(true);
+
+        when(dto.getUserName()).thenReturn("alice");
+        when(dto.getUserIdentityDataMap()).thenReturn(claims);
+        when(usm.getRealmConfiguration()).thenReturn(rc);
+        when(usm.getTenantId()).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+        when(rc.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME)).thenReturn("PRIMARY");
+        when(mockCache.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(null);
+
+        new InMemoryIdentityDataStore().storeOnRead(dto, usm);
+
+        verify(mockCache).addToCacheOnRead(any(IdentityDataStoreCacheKey.class), any(UserIdentityClaim.class),
+                anyInt());
+        verify(mockCache, never()).addToCache(any(), any(), anyInt());
+    }
+
+    @Test(description = "storeOnRead should merge claims with the cached entry and call addToCacheOnRead.")
+    public void testStoreOnRead_existingCachedEntry_mergesAndCallsAddToCacheOnRead() throws Exception {
+
+        IdentityDataStoreCache mockCache = mock(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache);
+
+        JDBCUserStoreManager usm = mock(JDBCUserStoreManager.class);
+        RealmConfiguration rc = mock(RealmConfiguration.class);
+
+        Map<String, String> newClaims = new HashMap<>();
+        newClaims.put("newKey", "newVal");
+        UserIdentityClaim dto = mock(UserIdentityClaim.class);
+        when(dto.getUserName()).thenReturn("bob");
+        when(dto.getUserIdentityDataMap()).thenReturn(newClaims);
+
+        Map<String, String> existingClaims = new HashMap<>();
+        existingClaims.put("existingKey", "existingVal");
+        UserIdentityClaim cachedDto = mock(UserIdentityClaim.class);
+        when(cachedDto.getUserIdentityDataMap()).thenReturn(existingClaims);
+
+        mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName("bob")).thenReturn("bob");
+        mockedIdentityUtil.when(() -> IdentityUtil.isUserStoreCaseSensitive(usm)).thenReturn(true);
+        mockedIdentityUtil.when(() -> IdentityUtil.isUseCaseSensitiveUsernameForCacheKeys(usm)).thenReturn(true);
+
+        when(usm.getRealmConfiguration()).thenReturn(rc);
+        when(usm.getTenantId()).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+        when(rc.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME)).thenReturn("PRIMARY");
+        when(mockCache.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(cachedDto);
+
+        new InMemoryIdentityDataStore().storeOnRead(dto, usm);
+
+        // Existing map should have had newClaims merged in.
+        assertEquals(existingClaims.get("newKey"), "newVal");
+        verify(mockCache).addToCacheOnRead(any(IdentityDataStoreCacheKey.class), any(UserIdentityClaim.class),
+                anyInt());
+        verify(mockCache, never()).addToCache(any(), any(), anyInt());
+    }
+
+    @Test(description = "storeOnRead should lowercase the username when the user store is case-insensitive.")
+    public void testStoreOnRead_caseInsensitiveUserStore_lowercasesUsername() throws Exception {
+
+        IdentityDataStoreCache mockCache = mock(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache);
+
+        JDBCUserStoreManager usm = mock(JDBCUserStoreManager.class);
+        RealmConfiguration rc = mock(RealmConfiguration.class);
+        UserIdentityClaim dto = mock(UserIdentityClaim.class);
+        Map<String, String> claims = new HashMap<>();
+
+        mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName("Charlie")).thenReturn("Charlie");
+        // Case-insensitive store: isUserStoreCaseSensitive returns false.
+        mockedIdentityUtil.when(() -> IdentityUtil.isUserStoreCaseSensitive(usm)).thenReturn(false);
+
+        when(dto.getUserName()).thenReturn("Charlie");
+        when(dto.getUserIdentityDataMap()).thenReturn(claims);
+        when(usm.getRealmConfiguration()).thenReturn(rc);
+        when(usm.getTenantId()).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+        when(rc.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME)).thenReturn("PRIMARY");
+        when(mockCache.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(null);
+
+        new InMemoryIdentityDataStore().storeOnRead(dto, usm);
+
+        // Verify cache was called with the lowercased key.
+        IdentityDataStoreCacheKey expectedKey = new IdentityDataStoreCacheKey("PRIMARY", "charlie");
+        verify(mockCache).addToCacheOnRead(
+                Mockito.eq(expectedKey),
+                any(UserIdentityClaim.class), anyInt());
+    }
+
+    @Test(description = "storeOnRead should lowercase the username when case-sensitive cache keys are disabled.")
+    public void testStoreOnRead_caseInsensitiveCacheKey_lowercasesUsername() throws Exception {
+
+        IdentityDataStoreCache mockCache = mock(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache);
+
+        JDBCUserStoreManager usm = mock(JDBCUserStoreManager.class);
+        RealmConfiguration rc = mock(RealmConfiguration.class);
+        UserIdentityClaim dto = mock(UserIdentityClaim.class);
+        Map<String, String> claims = new HashMap<>();
+
+        mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName("Dave")).thenReturn("Dave");
+        // Store is case-sensitive, but cache key is not.
+        mockedIdentityUtil.when(() -> IdentityUtil.isUserStoreCaseSensitive(usm)).thenReturn(true);
+        mockedIdentityUtil.when(() -> IdentityUtil.isUseCaseSensitiveUsernameForCacheKeys(usm)).thenReturn(false);
+
+        when(dto.getUserName()).thenReturn("Dave");
+        when(dto.getUserIdentityDataMap()).thenReturn(claims);
+        when(usm.getRealmConfiguration()).thenReturn(rc);
+        when(usm.getTenantId()).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+        when(rc.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME)).thenReturn("PRIMARY");
+        when(mockCache.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(null);
+
+        new InMemoryIdentityDataStore().storeOnRead(dto, usm);
+
+        IdentityDataStoreCacheKey expectedKey = new IdentityDataStoreCacheKey("PRIMARY", "dave");
+        verify(mockCache).addToCacheOnRead(
+                Mockito.eq(expectedKey),
+                any(UserIdentityClaim.class), anyInt());
+    }
+
+    @Test(description = "storeOnRead should NOT call addToCache — only addToCacheOnRead is allowed.")
+    public void testStoreOnRead_neverCallsAddToCache() throws Exception {
+
+        IdentityDataStoreCache mockCache = mock(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache = Mockito.mockStatic(IdentityDataStoreCache.class);
+        mockedIdentityDataStoreCache.when(IdentityDataStoreCache::getInstance).thenReturn(mockCache);
+
+        JDBCUserStoreManager usm = mock(JDBCUserStoreManager.class);
+        RealmConfiguration rc = mock(RealmConfiguration.class);
+        UserIdentityClaim dto = mock(UserIdentityClaim.class);
+        Map<String, String> claims = new HashMap<>();
+        claims.put("k", "v");
+
+        mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName("eve")).thenReturn("eve");
+        mockedIdentityUtil.when(() -> IdentityUtil.isUserStoreCaseSensitive(usm)).thenReturn(true);
+        mockedIdentityUtil.when(() -> IdentityUtil.isUseCaseSensitiveUsernameForCacheKeys(usm)).thenReturn(true);
+
+        when(dto.getUserName()).thenReturn("eve");
+        when(dto.getUserIdentityDataMap()).thenReturn(claims);
+        when(usm.getRealmConfiguration()).thenReturn(rc);
+        when(usm.getTenantId()).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+        when(rc.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME)).thenReturn("PRIMARY");
+
+        // Test both branches: no cached entry, and with cached entry.
+        when(mockCache.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(null);
+        new InMemoryIdentityDataStore().storeOnRead(dto, usm);
+        verify(mockCache, never()).addToCache(any(), any(), anyInt());
+
+        Map<String, String> cachedClaims = new HashMap<>();
+        UserIdentityClaim cachedDto = mock(UserIdentityClaim.class);
+        when(cachedDto.getUserIdentityDataMap()).thenReturn(cachedClaims);
+        when(mockCache.getValueFromCache(any(IdentityDataStoreCacheKey.class), anyInt())).thenReturn(cachedDto);
+        new InMemoryIdentityDataStore().storeOnRead(dto, usm);
+        verify(mockCache, never()).addToCache(any(), any(), anyInt());
+    }
+
+    @Test(description = "The default storeOnRead in UserIdentityDataStore should be a no-op with no exception.")
+    public void testDefaultStoreOnRead_inBaseClass_doesNothing() throws Exception {
+
+        // Concrete minimal subclass to test the base default.
+        UserIdentityDataStore baseStore = new UserIdentityDataStore() {
+            @Override
+            public void store(UserIdentityClaim dto, org.wso2.carbon.user.api.UserStoreManager usm)
+                    throws org.wso2.carbon.identity.base.IdentityException { }
+            @Override
+            public UserIdentityClaim load(String userName, org.wso2.carbon.user.api.UserStoreManager usm) {
+                return null;
+            }
+            @Override
+            public void remove(String userName, org.wso2.carbon.user.api.UserStoreManager usm)
+                    throws org.wso2.carbon.identity.base.IdentityException { }
+        };
+
+        // Should complete without throwing.
+        baseStore.storeOnRead(mock(UserIdentityClaim.class), mock(UserStoreManager.class));
+    }
+
+    // ── store tests ───────────────────────────────────────────────────────────
 
     public static void initPrivilegedCarbonContext(String tenantDomain, int tenantID, String userName) throws Exception {
         String carbonHome = Paths.get(System.getProperty("user.dir"), "target").toString();

--- a/components/org.wso2.carbon.identity.governance/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.governance/src/test/resources/testng.xml
@@ -27,6 +27,7 @@
             <class name="org.wso2.carbon.identity.governance.listener.IdentityMgtEventListenerTest"/>
             <class name="org.wso2.carbon.identity.governance.listener.IdentityStoreEventListenerTest"/>
             <class name="org.wso2.carbon.identity.governance.util.IdentityDataStoreUtilTest"/>
+            <class name="org.wso2.carbon.identity.governance.store.InMemoryIdentityDataStoreTest"/>
             <class name="org.wso2.carbon.identity.governance.store.JDBCIdentityDataStoreTest"/>
             <class name="org.wso2.carbon.identity.governance.listener.NotificationTemplateManagerTest"></class>
             <class name="org.wso2.carbon.identity.governance.internal.service.impl.notification.DefaultNotificationChannelManagerTest"/>

--- a/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
+++ b/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
+++ b/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
+++ b/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
+++ b/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
+++ b/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
+++ b/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
+++ b/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
+++ b/components/org.wso2.carbon.identity.idle.account.identification/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.resolver.regex/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/org.wso2.carbon.identity.multi.attribute.login.service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.multi.attribute.login/pom.xml
+++ b/components/org.wso2.carbon.identity.multi.attribute.login/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.password.expiry/pom.xml
+++ b/components/org.wso2.carbon.identity.password.expiry/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.expiry/pom.xml
+++ b/components/org.wso2.carbon.identity.password.expiry/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.expiry/pom.xml
+++ b/components/org.wso2.carbon.identity.password.expiry/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.expiry/pom.xml
+++ b/components/org.wso2.carbon.identity.password.expiry/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.expiry/pom.xml
+++ b/components/org.wso2.carbon.identity.password.expiry/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.expiry/pom.xml
+++ b/components/org.wso2.carbon.identity.password.expiry/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.expiry/pom.xml
+++ b/components/org.wso2.carbon.identity.password.expiry/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.expiry/pom.xml
+++ b/components/org.wso2.carbon.identity.password.expiry/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.history/pom.xml
+++ b/components/org.wso2.carbon.identity.password.history/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.history/pom.xml
+++ b/components/org.wso2.carbon.identity.password.history/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.history/pom.xml
+++ b/components/org.wso2.carbon.identity.password.history/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.history/pom.xml
+++ b/components/org.wso2.carbon.identity.password.history/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.history/pom.xml
+++ b/components/org.wso2.carbon.identity.password.history/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.history/pom.xml
+++ b/components/org.wso2.carbon.identity.password.history/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.history/pom.xml
+++ b/components/org.wso2.carbon.identity.password.history/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.history/pom.xml
+++ b/components/org.wso2.carbon.identity.password.history/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.policy/pom.xml
+++ b/components/org.wso2.carbon.identity.password.policy/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.policy/pom.xml
+++ b/components/org.wso2.carbon.identity.password.policy/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.policy/pom.xml
+++ b/components/org.wso2.carbon.identity.password.policy/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.policy/pom.xml
+++ b/components/org.wso2.carbon.identity.password.policy/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.policy/pom.xml
+++ b/components/org.wso2.carbon.identity.password.policy/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.policy/pom.xml
+++ b/components/org.wso2.carbon.identity.password.policy/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.policy/pom.xml
+++ b/components/org.wso2.carbon.identity.password.policy/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.password.policy/pom.xml
+++ b/components/org.wso2.carbon.identity.password.policy/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.piicontroller/pom.xml
+++ b/components/org.wso2.carbon.identity.piicontroller/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.piicontroller/pom.xml
+++ b/components/org.wso2.carbon.identity.piicontroller/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.piicontroller/pom.xml
+++ b/components/org.wso2.carbon.identity.piicontroller/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.piicontroller/pom.xml
+++ b/components/org.wso2.carbon.identity.piicontroller/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.piicontroller/pom.xml
+++ b/components/org.wso2.carbon.identity.piicontroller/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.piicontroller/pom.xml
+++ b/components/org.wso2.carbon.identity.piicontroller/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.piicontroller/pom.xml
+++ b/components/org.wso2.carbon.identity.piicontroller/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.piicontroller/pom.xml
+++ b/components/org.wso2.carbon.identity.piicontroller/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery/pom.xml
+++ b/components/org.wso2.carbon.identity.recovery/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandler.java
@@ -119,17 +119,7 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
             claims = new HashMap<>();
         }
 
-        boolean supportMultipleMobileNumbers =
-                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
-
         boolean enable = isMobileVerificationOnUpdateEnabled(user.getTenantDomain());
-
-        if (!supportMultipleMobileNumbers) {
-            // Multiple mobile numbers per user support is disabled.
-            log.debug("Supporting multiple mobile numbers per user is disabled.");
-            claims.remove(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM);
-            claims.remove(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM);
-        }
 
         if (!enable) {
             // Mobile Number Verification feature is disabled.
@@ -150,7 +140,7 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
 
         if (IdentityEventConstants.Event.PRE_SET_USER_CLAIMS.equals(eventName)) {
             Utils.unsetThreadLocalIsOnlyVerifiedMobileNumbersUpdated();
-            if (supportMultipleMobileNumbers && !claims.containsKey(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM)) {
+            if (!claims.containsKey(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM)) {
                 Utils.setThreadLocalIsOnlyVerifiedMobileNumbersUpdated(true);
             }
             preSetUserClaimOnMobileNumberUpdate(claims, userStoreManager, user);
@@ -347,9 +337,6 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
             Utils.unsetThreadLocalToSkipSendingSmsOtpVerificationOnUpdate();
         }
 
-        boolean supportMultipleMobileNumbers =
-                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
-
         // Update multiple mobile numbers only if they’re in the claims map.
         // This avoids issues with updating the primary mobile number due to user store limitations on multiple
         // mobile numbers.
@@ -372,53 +359,47 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
         List<String> updatedVerifiedNumbersList = new ArrayList<>();
         List<String> updatedAllNumbersList;
 
-        if (supportMultipleMobileNumbers) {
-            List<String> exisitingVerifiedNumbersList = Utils.getMultiValuedClaim(userStoreManager, user,
-                    IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM);
-            updatedVerifiedNumbersList = claims.containsKey(IdentityRecoveryConstants.
-                    VERIFIED_MOBILE_NUMBERS_CLAIM) ? getListOfMobileNumbersFromString(claims.get(
-                    IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM)) : exisitingVerifiedNumbersList;
+        List<String> exisitingVerifiedNumbersList = Utils.getMultiValuedClaim(userStoreManager, user,
+                IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM);
+        updatedVerifiedNumbersList = claims.containsKey(IdentityRecoveryConstants.
+                VERIFIED_MOBILE_NUMBERS_CLAIM) ? getListOfMobileNumbersFromString(claims.get(
+                IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM)) : exisitingVerifiedNumbersList;
 
-            List<String> exisitingAllNumbersList = Utils.getMultiValuedClaim(userStoreManager, user,
-                    IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM);
-            updatedAllNumbersList = claims.containsKey(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM) ?
-                    getListOfMobileNumbersFromString(claims.get(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM)) :
-                    exisitingAllNumbersList;
+        List<String> exisitingAllNumbersList = Utils.getMultiValuedClaim(userStoreManager, user,
+                IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM);
+        updatedAllNumbersList = claims.containsKey(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM) ?
+                getListOfMobileNumbersFromString(claims.get(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM)) :
+                exisitingAllNumbersList;
 
             /*
             Finds the verification pending mobile number and remove it from the verified numbers list in the payload.
             */
-            if (mobileNumber == null && CollectionUtils.isNotEmpty(updatedVerifiedNumbersList)) {
-                mobileNumber = getVerificationPendingMobileNumber(exisitingVerifiedNumbersList,
-                        updatedVerifiedNumbersList);
-                updatedVerifiedNumbersList.remove(mobileNumber);
-            } else {
-                /*
-                 * When both primary mobile number and verified mobile numbers are provided, give the primary‑mobile
-                 * number change the precedence; leave the updated verified‑mobile numbers list exactly as it exists
-                 * in the user store.
-                 */
-                updatedVerifiedNumbersList = exisitingVerifiedNumbersList;
-            }
+        if (mobileNumber == null && CollectionUtils.isNotEmpty(updatedVerifiedNumbersList)) {
+            mobileNumber = getVerificationPendingMobileNumber(exisitingVerifiedNumbersList,
+                    updatedVerifiedNumbersList);
+            updatedVerifiedNumbersList.remove(mobileNumber);
+        } else {
+            /*
+             * When both primary mobile number and verified mobile numbers are provided, give the primary‑mobile
+             * number change the precedence; leave the updated verified‑mobile numbers list exactly as it exists
+             * in the user store.
+             */
+            updatedVerifiedNumbersList = exisitingVerifiedNumbersList;
+        }
 
             /*
             Finds the removed numbers from the existing mobile numbers list and remove them from the verified numbers
             list. As verified numbers list should not contain numbers that are not in the mobile numbers list.
             */
-            if (updatedAllNumbersList != null) {
-                updatedVerifiedNumbersList.removeIf(number -> !updatedAllNumbersList.contains(number));
-            }
+        if (updatedAllNumbersList != null) {
+            updatedVerifiedNumbersList.removeIf(number -> !updatedAllNumbersList.contains(number));
+        }
 
-            if (shouldUpdateMultiMobilesRelatedClaims) {
-                claims.put(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM,
-                        String.join(multiAttributeSeparator, updatedAllNumbersList));
-                claims.put(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM,
-                        String.join(multiAttributeSeparator, updatedVerifiedNumbersList));
-            }
-        } else {
-            updatedAllNumbersList = new ArrayList<>();
-            claims.remove(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM);
-            claims.remove(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM);
+        if (shouldUpdateMultiMobilesRelatedClaims) {
+            claims.put(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM,
+                    String.join(multiAttributeSeparator, updatedAllNumbersList));
+            claims.put(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM,
+                    String.join(multiAttributeSeparator, updatedVerifiedNumbersList));
         }
 
         if (StringUtils.isBlank(mobileNumber)) {
@@ -438,7 +419,7 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
             throw new IdentityEventException(error, e);
         }
 
-        if (supportMultipleMobileNumbers && updatedVerifiedNumbersList.contains(mobileNumber)) {
+        if (updatedVerifiedNumbersList.contains(mobileNumber)) {
             Utils.setThreadLocalToSkipSendingSmsOtpVerificationOnUpdate(
                     IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates
                             .SKIP_ON_ALREADY_VERIFIED_MOBILE_NUMBERS.toString());
@@ -449,7 +430,7 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
 
         if (StringUtils.equals(mobileNumber, existingMobileNumber)) {
 
-            if (supportMultipleMobileNumbers && shouldUpdateMultiMobilesRelatedClaims &&
+            if (shouldUpdateMultiMobilesRelatedClaims &&
                     !updatedAllNumbersList.contains(existingMobileNumber)) {
                 updatedAllNumbersList.add(existingMobileNumber);
                 claims.put(IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM,
@@ -467,7 +448,7 @@ public class MobileNumberVerificationHandler extends AbstractEventHandler {
                         .SkipMobileNumberVerificationOnUpdateStates.SKIP_ON_EXISTING_MOBILE_NUM.toString());
                 invalidatePendingMobileVerification(user, userStoreManager, claims);
 
-                if (supportMultipleMobileNumbers && shouldUpdateMultiMobilesRelatedClaims &&
+                if (shouldUpdateMultiMobilesRelatedClaims &&
                         !updatedVerifiedNumbersList.contains(existingMobileNumber)) {
                     updatedVerifiedNumbersList.add(existingMobileNumber);
                     claims.put(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM,

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandler.java
@@ -121,9 +121,6 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
             claims = new HashMap<>();
         }
 
-        boolean supportMultipleEmails =
-                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
-
         boolean enable = false;
 
         if (IdentityEventConstants.Event.PRE_ADD_USER.equals(eventName) ||
@@ -134,14 +131,6 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
                 IdentityEventConstants.Event.POST_SET_USER_CLAIMS.equals(eventName)) {
 
             enable = isEmailVerificationOnUpdateEnabled(user.getTenantDomain());
-
-            if (!supportMultipleEmails) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Supporting multiple email addresses per user is disabled.");
-                }
-                claims.remove(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM);
-                claims.remove(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM);
-            }
 
             if (!enable) {
                 /* We need to empty 'EMAIL_ADDRESS_PENDING_VALUE_CLAIM' because having a value in that claim implies
@@ -258,7 +247,7 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
 
         if (IdentityEventConstants.Event.PRE_SET_USER_CLAIMS.equals(eventName)) {
             Utils.unsetThreadLocalIsOnlyVerifiedEmailAddressesUpdated();
-            if (supportMultipleEmails && !claims.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM)) {
+            if (!claims.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM)) {
                 Utils.setThreadLocalIsOnlyVerifiedEmailAddressesUpdated(true);
             }
             preSetUserClaimsOnEmailUpdate(claims, userStoreManager, user);
@@ -551,8 +540,6 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
             Utils.unsetThreadLocalToSkipSendingEmailVerificationOnUpdate();
         }
 
-        boolean supportMultipleEmails =
-                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
         // Update multiple email address related claims only if they’re in the claims map.
         // This avoids issues with updating the primary email address due to user store limitations on multiple
         // email addresses.
@@ -578,74 +565,64 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
         String primaryEmail = getEmailClaimValue(user, userStoreManager);
 
         // Handle email addresses and verified email addresses claims.
-        if (supportMultipleEmails) {
-            List<String> existingVerifiedEmailAddresses = Utils.getMultiValuedClaim(userStoreManager, user,
+        List<String> existingVerifiedEmailAddresses = Utils.getMultiValuedClaim(userStoreManager, user,
                 IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM);
-            List<String> existingAllEmailAddresses = Utils.getMultiValuedClaim(userStoreManager, user,
-                    IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM);
+        List<String> existingAllEmailAddresses = Utils.getMultiValuedClaim(userStoreManager, user,
+                IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM);
 
-            if (isPrimaryEmailVerified(userStoreManager, user)) {
-                // Add primary email address to verifiedEmailAddress claim if not available.
-                if (existingAllEmailAddresses.contains(primaryEmail) &&
-                        !existingVerifiedEmailAddresses.contains(primaryEmail)) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Added primary email to verifiedEmailAddresses claim for user: " +
-                                maskIfRequired(user.getUserName()));
-                    }
-                    existingVerifiedEmailAddresses.add(primaryEmail);
+        if (isPrimaryEmailVerified(userStoreManager, user)) {
+            // Add primary email address to verifiedEmailAddress claim if not available.
+            if (existingAllEmailAddresses.contains(primaryEmail) &&
+                    !existingVerifiedEmailAddresses.contains(primaryEmail)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Added primary email to verifiedEmailAddresses claim for user: " +
+                            maskIfRequired(user.getUserName()));
                 }
+                existingVerifiedEmailAddresses.add(primaryEmail);
             }
+        }
 
-            updatedVerifiedEmailAddresses = claims.containsKey(IdentityRecoveryConstants.
-                    VERIFIED_EMAIL_ADDRESSES_CLAIM) ? getListOfEmailAddressesFromString(claims.get(
-                    IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM)) : existingVerifiedEmailAddresses;
-            updatedAllEmailAddresses = claims.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM) ?
-                    getListOfEmailAddressesFromString(claims.get(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM)) :
-                    existingAllEmailAddresses;
+        updatedVerifiedEmailAddresses = claims.containsKey(IdentityRecoveryConstants.
+                VERIFIED_EMAIL_ADDRESSES_CLAIM) ? getListOfEmailAddressesFromString(claims.get(
+                IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM)) : existingVerifiedEmailAddresses;
+        updatedAllEmailAddresses = claims.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM) ?
+                getListOfEmailAddressesFromString(claims.get(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM)) :
+                existingAllEmailAddresses;
 
-            if (updatedAllEmailAddresses == null) {
-                updatedAllEmailAddresses = new ArrayList<>();
-            }
-            if (updatedVerifiedEmailAddresses == null) {
-                updatedVerifiedEmailAddresses = new ArrayList<>();
-            }
+        if (updatedAllEmailAddresses == null) {
+            updatedAllEmailAddresses = new ArrayList<>();
+        }
+        if (updatedVerifiedEmailAddresses == null) {
+            updatedVerifiedEmailAddresses = new ArrayList<>();
+        }
 
-            // Find the verification pending email address and remove it from verified email addresses in the payload.
-            if (emailAddress == null && CollectionUtils.isNotEmpty(updatedVerifiedEmailAddresses)) {
-                emailAddress = getVerificationPendingEmailAddress(existingVerifiedEmailAddresses,
-                        updatedVerifiedEmailAddresses);
-                updatedVerifiedEmailAddresses.remove(emailAddress);
-            } else {
-                /*
-                 * When both primary email address and verified email addresses are provided, give the primary‑email
-                 * change the precedence; leave the updated verified‑emails list exactly as it exists in the
-                 * user store.
-                 */
-                updatedVerifiedEmailAddresses = existingVerifiedEmailAddresses;
-            }
+        // Find the verification pending email address and remove it from verified email addresses in the payload.
+        if (emailAddress == null && CollectionUtils.isNotEmpty(updatedVerifiedEmailAddresses)) {
+            emailAddress = getVerificationPendingEmailAddress(existingVerifiedEmailAddresses,
+                    updatedVerifiedEmailAddresses);
+            updatedVerifiedEmailAddresses.remove(emailAddress);
+        } else {
+            /*
+             * When both primary email address and verified email addresses are provided, give the primary‑email
+             * change the precedence; leave the updated verified‑emails list exactly as it exists in the
+             * user store.
+             */
+            updatedVerifiedEmailAddresses = existingVerifiedEmailAddresses;
+        }
 
             /*
             Find the removed numbers from the existing email addresses list and remove them from the verified email
             addresses list, as verified email addresses list should not contain email addresses that are not in the
             email addresses list.
             */
-            final List<String> tempUpdatedAllEmailAddresses = new ArrayList<>(updatedAllEmailAddresses);
-            updatedVerifiedEmailAddresses.removeIf(number -> !tempUpdatedAllEmailAddresses.contains(number));
+        final List<String> tempUpdatedAllEmailAddresses = new ArrayList<>(updatedAllEmailAddresses);
+        updatedVerifiedEmailAddresses.removeIf(number -> !tempUpdatedAllEmailAddresses.contains(number));
 
-            if (shouldUpdateMultiMobilesRelatedClaims) {
-                claims.put(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM,
-                        StringUtils.join(updatedVerifiedEmailAddresses, multiAttributeSeparator));
-                claims.put(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM,
-                        StringUtils.join(updatedAllEmailAddresses, multiAttributeSeparator));
-            }
-        } else {
-            /*
-            email addresses and verified email addresses should not be updated when support for multiple email
-            addresses is disabled.
-             */
-            claims.remove(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM);
-            claims.remove(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM);
-            updatedAllEmailAddresses = new ArrayList<>();
+        if (shouldUpdateMultiMobilesRelatedClaims) {
+            claims.put(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM,
+                    StringUtils.join(updatedVerifiedEmailAddresses, multiAttributeSeparator));
+            claims.put(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM,
+                    StringUtils.join(updatedAllEmailAddresses, multiAttributeSeparator));
         }
 
         if (StringUtils.isBlank(emailAddress)) {
@@ -654,7 +631,7 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
             return;
         }
 
-        if (supportMultipleEmails && updatedVerifiedEmailAddresses.contains(emailAddress)) {
+        if (updatedVerifiedEmailAddresses.contains(emailAddress)) {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("The email address to be updated: %s is already verified and contains" +
                         " in the verified email addresses list for user: %s in domain %s. Hence an email " +
@@ -670,7 +647,7 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
 
         if (emailAddress.equals(primaryEmail)) {
 
-            if (supportMultipleEmails && shouldUpdateMultiMobilesRelatedClaims &&
+            if (shouldUpdateMultiMobilesRelatedClaims &&
                     !updatedAllEmailAddresses.contains(primaryEmail)) {
                 updatedAllEmailAddresses.add(primaryEmail);
                 claims.put(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM,
@@ -688,7 +665,7 @@ public class UserEmailVerificationHandler extends AbstractEventHandler {
                         .SkipEmailVerificationOnUpdateStates.SKIP_ON_EXISTING_EMAIL.toString());
                 invalidatePendingEmailVerification(user, userStoreManager, claims);
 
-                if (supportMultipleEmails && shouldUpdateMultiMobilesRelatedClaims &&
+                if (shouldUpdateMultiMobilesRelatedClaims &&
                         !updatedVerifiedEmailAddresses.contains(primaryEmail)) {
                     updatedVerifiedEmailAddresses.add(primaryEmail);
                     claims.put(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM,

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -841,8 +841,6 @@ public class UserSelfRegistrationManager {
         HashMap<String, String> userClaims = getClaimsListToUpdate(user, verifiedChannelType,
                 externallyVerifiedClaim, recoveryData.getRecoveryScenario().toString());
 
-        boolean supportMultipleEmailsAndMobileNumbers =
-                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
         Map<String, String> userClaimsToBeAdded = new HashMap<>();
         Map<String, String> userClaimsToBeModified = new HashMap<>();
@@ -883,7 +881,7 @@ public class UserSelfRegistrationManager {
                 // Only update verified email addresses claim if the recovery scenario is
                 // EMAIL_VERIFICATION_ON_VERIFIED_LIST_UPDATE.
                 if (RecoveryScenarios.EMAIL_VERIFICATION_ON_VERIFIED_LIST_UPDATE.equals(
-                        recoveryData.getRecoveryScenario()) && supportMultipleEmailsAndMobileNumbers) {
+                        recoveryData.getRecoveryScenario())) {
                     try {
                         List<String> verifiedEmails = Utils.getMultiValuedClaim(userStoreManager, user,
                                 IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM);
@@ -951,8 +949,7 @@ public class UserSelfRegistrationManager {
                 if ((RecoveryScenarios.MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE.equals(
                             recoveryData.getRecoveryScenario())
                             || RecoveryScenarios.PROGRESSIVE_PROFILE_MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE
-                            .equals(recoveryData.getRecoveryScenario()))
-                        && supportMultipleEmailsAndMobileNumbers) {
+                            .equals(recoveryData.getRecoveryScenario()))) {
                     try {
                         List<String> existingVerifiedMobileNumbersList = Utils.getMultiValuedClaim(userStoreManager,
                                 user, IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM);
@@ -1218,9 +1215,6 @@ public class UserSelfRegistrationManager {
         Map<String, String> userClaimsToBeModified = new HashMap<>();
         Map<String, String> userClaimsToBeDeleted = new HashMap<>();
 
-        boolean supportMultipleEmailsAndMobileNumbers =
-                Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(user.getTenantDomain(), user.getUserStoreDomain());
-
         String pendingMobileNumberClaimValue = recoveryData.getRemainingSetIds();
         String primaryMobile = null;
 
@@ -1239,7 +1233,7 @@ public class UserSelfRegistrationManager {
             */
             if ((RecoveryScenarios.MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE.equals(recoveryData.getRecoveryScenario()
                     ) || RecoveryScenarios.PROGRESSIVE_PROFILE_MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE.equals(
-                    recoveryData.getRecoveryScenario())) && supportMultipleEmailsAndMobileNumbers) {
+                    recoveryData.getRecoveryScenario()))) {
                 try {
                     String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
                     List<String> existingVerifiedMobileNumbersList = Utils.getMultiValuedClaim(userStoreManager,

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -39,9 +39,6 @@ import org.wso2.carbon.identity.auth.attribute.handler.model.ValidationFailureRe
 import org.wso2.carbon.identity.auth.attribute.handler.model.ValidationResult;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
-import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
-import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
-import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
@@ -1524,75 +1521,6 @@ public class Utils {
 
         return Boolean.parseBoolean(IdentityUtil.getProperty
                 (IdentityRecoveryConstants.ConnectorConfig.USE_VERIFY_CLAIM_ON_UPDATE));
-    }
-
-    /**
-     * Check whether the supporting multiple email addresses and mobile numbers per user feature is enabled.
-     *
-     * @param tenantDomain   Tenant domain.
-     * @param userStoreDomain User store domain.
-     * @return True if the config is set to true, false otherwise.
-     */
-    public static boolean isMultiEmailsAndMobileNumbersPerUserEnabled(String tenantDomain, String userStoreDomain) {
-
-        if (!Boolean.parseBoolean(IdentityUtil.getProperty(
-                IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER))) {
-            return false;
-        }
-
-        if (StringUtils.isBlank(tenantDomain) || StringUtils.isBlank(userStoreDomain)) {
-            return false;
-        }
-
-        try {
-            List<LocalClaim> localClaims =
-                    IdentityRecoveryServiceDataHolder.getInstance().getClaimMetadataManagementService()
-                            .getLocalClaims(tenantDomain);
-
-            List<String> requiredClaims = Arrays.asList(
-                    IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM,
-                    IdentityRecoveryConstants.MOBILE_NUMBERS_CLAIM,
-                    IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM,
-                    IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM);
-
-            // Check if all required claims are valid for the user store.
-            return requiredClaims.stream().allMatch(claimUri ->
-                            isClaimSupportedForUserStore(localClaims, claimUri, userStoreDomain));
-        } catch (ClaimMetadataException e) {
-            log.error("Error while retrieving multiple emails and mobiles config.", e);
-            return false;
-        }
-    }
-
-    /**
-     * Check if a claim is supported and not excluded for a specific user store.
-     *
-     * @param localClaims     List of local claims.
-     * @param claimUri        URI of the claim to check.
-     * @param userStoreDomain User store domain to validate against.
-     * @return True if claim is supported and not excluded.
-     */
-    private static boolean isClaimSupportedForUserStore(List<LocalClaim> localClaims, String claimUri,
-                                                        String userStoreDomain) {
-
-        return localClaims.stream()
-            .filter(claim -> claimUri.equals(claim.getClaimURI()))
-            .anyMatch(claim -> {
-                Map<String, String> properties = claim.getClaimProperties();
-
-                // Check if claim is supported by default.
-                boolean isSupported = Boolean.parseBoolean(
-                        properties.getOrDefault(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY,
-                                Boolean.FALSE.toString()));
-
-                // Check if user store is not in excluded list.
-                String excludedUserStoreDomains = properties.get(ClaimConstants.EXCLUDED_USER_STORES_PROPERTY);
-                boolean isNotExcluded = StringUtils.isBlank(excludedUserStoreDomains) ||
-                        !Arrays.asList(excludedUserStoreDomains.toUpperCase().split(","))
-                                .contains(userStoreDomain.toUpperCase());
-
-                return isSupported && isNotExcluded;
-            });
     }
 
     /**

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/MobileNumberVerificationHandlerTest.java
@@ -171,34 +171,6 @@ public class MobileNumberVerificationHandlerTest {
         Assert.assertEquals(mobileNumberVerificationHandler.getFriendlyName(), "User Mobile Number Verification");
     }
 
-    @Test(description = "Verification disabled, Multi-attribute disabled, Change primary mobile")
-    public void testHandleEventVerificationDisabledMultiAttributeDisabled()
-            throws UserStoreException, IdentityEventException, IdentityRecoveryException {
-
-        Event event =
-                createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIM, null,
-                        null, null, NEW_MOBILE_NUMBER);
-        mockVerificationPendingMobileNumber();
-        mockUtilMethods(false, false, false);
-
-        mobileNumberVerificationHandler.handleEvent(event);
-
-        // Expectation: Any pending mobile verification should be invalidated.
-        verify(userRecoveryDataStore).invalidate(any(), eq(RecoveryScenarios.MOBILE_VERIFICATION_ON_UPDATE),
-                eq(RecoverySteps.VERIFY_MOBILE_NUMBER));
-        Map<String, String> userClaims = getUserClaimsFromEvent(event);
-        Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM),
-                StringUtils.EMPTY);
-
-        reset(userRecoveryDataStore);
-        // Case 2: User claims null.
-        Event event2 =
-                createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIM, null,
-                        null, null, null);
-        mobileNumberVerificationHandler.handleEvent(event2);
-        verify(userRecoveryDataStore, never()).invalidate(any(), eq(RecoveryScenarios.MOBILE_VERIFICATION_ON_UPDATE), any());
-    }
-
     @Test(description = "Verification disabled, Multi-attribute enabled, Change primary mobile")
     public void testHandleEventVerificationDisabledMultiAttributeEnabled()
             throws UserStoreException, IdentityEventException, IdentityRecoveryException {
@@ -206,7 +178,7 @@ public class MobileNumberVerificationHandlerTest {
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIM, null,
                 null, null, NEW_MOBILE_NUMBER);
         mockVerificationPendingMobileNumber();
-        mockUtilMethods(false, true, false);
+        mockUtilMethods(false, false);
 
         // New primary mobile number is not included in existing all mobile numbers list.
         List<String> allMobileNumbers = new ArrayList<>(Arrays.asList(EXISTING_NUMBER_1, EXISTING_NUMBER_2));
@@ -232,143 +204,10 @@ public class MobileNumberVerificationHandlerTest {
         Assert.assertFalse(userClaims3.containsKey(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM));
     }
 
-    @Test(description = "PRE_SET_USER_CLAIMS: Verification enabled, Multi-attribute disabled, Claims null")
-    public void testHandleEventVerificationEnabledMultiAttributeDisabledThreadLocal() throws Exception {
-
-        /*
-         Case 1: Claims null, skipSendingSmsOtpVerificationOnUpdate set to skip.
-         */
-        mockVerificationPendingMobileNumber();
-        mockUtilMethods(true, false, false);
-        Event event1 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, null,
-                null, null, null);
-
-        mobileNumberVerificationHandler.handleEvent(event1);
-        mockedUtils.verify(() -> Utils.setThreadLocalToSkipSendingSmsOtpVerificationOnUpdate(
-                eq(IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates
-                        .SKIP_ON_INAPPLICABLE_CLAIMS.toString())));
-
-        /*
-         Case 2: skipSendingSmsOtpVerificationOnUpdate set to skip.
-         */
-        // Case 2.1: skipSendingSmsOtpVerificationOnUpdate set to SKIP_ON_CONFIRM.
-        mockVerificationPendingMobileNumber();
-        Event event2 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, null,
-                null, null, NEW_MOBILE_NUMBER);
-        mockedUtils.when(Utils::getThreadLocalToSkipSendingSmsOtpVerificationOnUpdate)
-                .thenReturn(IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates
-                        .SKIP_ON_CONFIRM.toString());
-
-        mobileNumberVerificationHandler.handleEvent(event2);
-        Map<String, String> userClaims2 = getUserClaimsFromEvent(event2);
-        Assert.assertEquals(userClaims2.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM),
-                StringUtils.EMPTY);
-
-        // Case 2.2: skipSendingSmsOtpVerificationOnUpdate set to SKIP_ON_SMS_OTP_FLOW.
-        mockVerificationPendingMobileNumber();
-        Event event2_1 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, null,
-                null, null, NEW_MOBILE_NUMBER);
-        mockedUtils.when(Utils::getThreadLocalToSkipSendingSmsOtpVerificationOnUpdate)
-                .thenReturn(IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates
-                        .SKIP_ON_SMS_OTP_FLOW.toString());
-
-        mobileNumberVerificationHandler.handleEvent(event2_1);
-        Map<String, String> userClaims2_1 = getUserClaimsFromEvent(event2_1);
-        Assert.assertEquals(userClaims2_1.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM),
-                StringUtils.EMPTY);
-
-        /*
-         Case 3: skipSendingSmsOtpVerificationOnUpdate set to some value.
-         */
-        Event event3 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, null,
-                null, null, NEW_MOBILE_NUMBER);
-        mockedUtils.when(Utils::getThreadLocalToSkipSendingSmsOtpVerificationOnUpdate)
-                .thenReturn("test");
-
-        mobileNumberVerificationHandler.handleEvent(event3);
-        mockedUtils.verify(Utils::unsetThreadLocalToSkipSendingSmsOtpVerificationOnUpdate);
-    }
-
-    @Test(description = "PRE_SET_USER_CLAIMS: Verification enabled, Multi-attribute disabled, Change primary mobile")
-    public void testHandleEventVerificationEnabledMultiAttributeDisabled() throws Exception {
-
-        mockVerificationPendingMobileNumber();
-        mockUtilMethods(true, false, false);
-        Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, null,
-                null, null, NEW_MOBILE_NUMBER);
-
-        mobileNumberVerificationHandler.handleEvent(event);
-
-        Map<String, String> userClaims = getUserClaimsFromEvent(event);
-        Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM),
-                NEW_MOBILE_NUMBER);
-
-        /*
-         Case 2: New mobile number is same as existing verified primary mobile number.
-         */
-        mockExistingPrimaryMobileNumber(NEW_MOBILE_NUMBER);
-        Event event2 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, null,
-                null, null, NEW_MOBILE_NUMBER);
-        mockPrimaryMobileVerificationStatus(true);
-
-        mobileNumberVerificationHandler.handleEvent(event2);
-        Map<String, String> userClaims2 = getUserClaimsFromEvent(event2);
-        Assert.assertEquals(userClaims2.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM),
-                StringUtils.EMPTY);
-
-        /*
-         Case 3: New mobile number is same as existing unverified primary mobile number.
-         */
-        Event event3 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, null,
-                null, null, NEW_MOBILE_NUMBER);
-        mockPrimaryMobileVerificationStatus(false);
-
-        mobileNumberVerificationHandler.handleEvent(event3);
-        Map<String, String> userClaims3 = getUserClaimsFromEvent(event3);
-        Assert.assertEquals(userClaims3.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM),
-                NEW_MOBILE_NUMBER);
-
-        /*
-         Case 4: Enable userVerify and send verifyMobileClaim as false.
-         */
-        mockExistingPrimaryMobileNumber(EXISTING_NUMBER_1);
-        mockedUtils.when(Utils::isUseVerifyClaimEnabled).thenReturn(true);
-        Event event4 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, NEW_MOBILE_NUMBER);
-
-        mobileNumberVerificationHandler.handleEvent(event4);
-        mockedUtils.verify(() -> Utils.setThreadLocalToSkipSendingSmsOtpVerificationOnUpdate(
-                IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates
-                        .SKIP_ON_INAPPLICABLE_CLAIMS.toString()), atLeastOnce());
-
-        /*
-         Case 5: Mobile number claim is null.
-         */
-        Event event5 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, null);
-
-        mobileNumberVerificationHandler.handleEvent(event5);
-        mockedUtils.verify(() -> Utils.setThreadLocalToSkipSendingSmsOtpVerificationOnUpdate(
-                IdentityRecoveryConstants.SkipMobileNumberVerificationOnUpdateStates
-                        .SKIP_ON_INAPPLICABLE_CLAIMS.toString()), atLeastOnce());
-
-        /*
-         Case 6: Throw error when retrieving existing mobile number.
-         */
-        when(userStoreManager.getUserClaimValue(anyString(),
-                eq(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM), isNull()))
-                .thenThrow(new org.wso2.carbon.user.core.UserStoreException());
-        try {
-            mobileNumberVerificationHandler.handleEvent(event);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof IdentityEventException);
-        }
-    }
-
     @Test(description = "Verification enabled, Multi-attribute enabled, Update primary mobile not in verified list")
     public void testUpdatePrimaryMobileNotInVerifiedList() throws Exception {
 
-        mockUtilMethods(true, true, false);
+        mockUtilMethods(true, false);
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, null,
                 null, null, NEW_MOBILE_NUMBER);
         mockExistingVerifiedNumbersList(new ArrayList<>(Arrays.asList(EXISTING_NUMBER_1)));
@@ -400,7 +239,7 @@ public class MobileNumberVerificationHandlerTest {
     public void testUpdatePrimaryMobileInVerifiedList() throws Exception {
 
         mockVerificationPendingMobileNumber();
-        mockUtilMethods(true, true, false);
+        mockUtilMethods(true, false);
         String newVerifiedMobileNumbers = EXISTING_NUMBER_1 + "," + NEW_MOBILE_NUMBER;
         String newMobileNumbers = EXISTING_NUMBER_1 + "," + NEW_MOBILE_NUMBER;
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS,
@@ -420,7 +259,7 @@ public class MobileNumberVerificationHandlerTest {
     public void testAddNewMobileToVerifiedList() throws Exception {
 
         mockVerificationPendingMobileNumber();
-        mockUtilMethods(true, true, false);
+        mockUtilMethods(true, false);
         String newVerifiedMobileNumbers = EXISTING_NUMBER_1 + "," + NEW_MOBILE_NUMBER;
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS,
                 IdentityRecoveryConstants.FALSE,
@@ -494,7 +333,7 @@ public class MobileNumberVerificationHandlerTest {
 
         Event event = createEvent(IdentityEventConstants.Event.POST_SET_USER_CLAIMS, null,
                 null, null, null);
-        mockUtilMethods(true, true, false);
+        mockUtilMethods(true, false);
 
         MockedStatic<RecoveryScenarios> mockedStaticRecoveryScenarios = mockStatic(RecoveryScenarios.class);
         mockedStaticRecoveryScenarios.when(() ->
@@ -542,7 +381,7 @@ public class MobileNumberVerificationHandlerTest {
 
         Event event = createEvent(IdentityEventConstants.Event.POST_SET_USER_CLAIMS, null,
                 null, null, null);
-        mockUtilMethods(true, true, false);
+        mockUtilMethods(true, false);
 
         MockedStatic<RecoveryScenarios> mockedStaticRecoveryScenarios = mockStatic(RecoveryScenarios.class);
         mockedStaticRecoveryScenarios.when(() ->
@@ -612,21 +451,12 @@ public class MobileNumberVerificationHandlerTest {
         }
     }
 
-    @DataProvider(name = "multiAttributeEnabledData")
-    public Object[][] multiAttributeEnabledData() {
-
-        return new Object[][]{
-                {false},
-                {true}
-        };
-    }
-
-    @Test(description = "Test handling of primary mobile deletion — primary mobile set to EMPTY should clear" +
-            "phoneVerified claim.", dataProvider = "multiAttributeEnabledData")
-    public void testHandleEventPreSetUserClaimsPrimaryMobileDeletionClearsVerification(boolean multiAttributeEnabled)
+    @Test(description = "Test handling of primary mobile deletion — primary mobile set to EMPTY should clear " +
+            "phoneVerified claim.")
+    public void testHandleEventPreSetUserClaimsPrimaryMobileDeletionClearsVerification()
             throws IdentityEventException {
 
-        mockUtilMethods(true, multiAttributeEnabled, false);
+        mockUtilMethods(true, false);
 
         Map<String, Object> eventProperties = new HashMap<>();
         eventProperties.put(IdentityEventConstants.EventProperty.USER_NAME, TEST_USERNAME);
@@ -681,11 +511,8 @@ public class MobileNumberVerificationHandlerTest {
         return (Map<String, String>) eventProperties.get(IdentityEventConstants.EventProperty.USER_CLAIMS);
     }
 
-    private void mockUtilMethods(boolean mobileVerificationEnabled, boolean multiAttributeEnabled,
-                                 boolean useVerifyClaimEnabled) {
+    private void mockUtilMethods(boolean mobileVerificationEnabled, boolean useVerifyClaimEnabled) {
 
-        mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
-                .thenReturn(multiAttributeEnabled);
         mockedUtils.when(Utils::isUseVerifyClaimEnabled).thenReturn(useVerifyClaimEnabled);
         mockedUtils.when(() -> Utils.getConnectorConfig(
                         eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_NUM_VERIFICATION_ON_UPDATE),

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/UserEmailVerificationHandlerTest.java
@@ -160,55 +160,6 @@ public class UserEmailVerificationHandlerTest {
         Assert.assertEquals(userEmailVerificationHandler.getFriendlyName(), "User Email Verification");
     }
 
-    @Test(description = "Verification - Disabled, Multi attribute - Disabled")
-    public void testHandleEventPreSetUserClaimsVerificationDisabledMultiDisabled()
-            throws IdentityEventException, UserStoreException {
-
-        /*
-         Notification on email update is enabled.
-         Expected: Notification event should be triggered, pending email claim should be set to empty string.
-         */
-        Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, NEW_EMAIL);
-
-        mockUtilMethods(false, false, false,
-                true);
-        mockPrimaryEmail(EXISTING_EMAIL_1);
-        mockPendingVerificationEmail(EXISTING_EMAIL_2);
-
-        userEmailVerificationHandler.handleEvent(event);
-        verify(identityEventService).handleEvent(any());
-        Map<String, String> userClaims = getUserClaimsFromEvent(event);
-        Assert.assertEquals(userClaims.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM),
-                StringUtils.EMPTY);
-
-        // Case 2: Throw error when triggering event.
-        doThrow(new IdentityEventException("error")).when(identityEventService).handleEvent(any());
-        try {
-            userEmailVerificationHandler.handleEvent(event);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof IdentityEventException);
-        }
-
-        // Reset.
-        doNothing().when(identityEventService).handleEvent(any());
-
-        // Case 2: Throw UserStoreException when getting the primary email.
-        Event event2 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, NEW_EMAIL);
-        mockUtilMethods(false, false, false,
-                true);
-        mockPendingVerificationEmail(EXISTING_EMAIL_2);
-        when(userStoreManager.getUserClaimValue(anyString(), eq(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM),
-                any())).thenThrow(new UserStoreException("error"));
-
-        try {
-            userEmailVerificationHandler.handleEvent(event2);
-        } catch (Exception e) {
-            Assert.assertTrue(e instanceof IdentityEventException);
-        }
-    }
-
     @Test(description = "Verification - Disabled, Multi attribute - Enabled")
     public void testHandleEventPreSetUserClaimsVerificationDisabledMultiEnabled()
             throws IdentityEventException, IdentityRecoveryException, UserStoreException {
@@ -220,8 +171,7 @@ public class UserEmailVerificationHandlerTest {
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, null, NEW_EMAIL);
 
-        mockUtilMethods(false, true, false,
-                false);
+        mockUtilMethods(false, false, false);
         List<String> existingEmails = new ArrayList<>(Arrays.asList(EXISTING_EMAIL_1, EXISTING_EMAIL_2));
         mockExistingEmailAddressesList(existingEmails);
 
@@ -236,91 +186,12 @@ public class UserEmailVerificationHandlerTest {
         Event event2 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, emailsClaim, NEW_EMAIL);
 
-        mockUtilMethods(false, true, false,
-                false);
+        mockUtilMethods(false, false, false);
 
         userEmailVerificationHandler.handleEvent(event2);
         Map<String, String> userClaims2 = getUserClaimsFromEvent(event2);
         Assert.assertEquals(userClaims2.get(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM), NEW_EMAIL);
         Assert.assertEquals(userClaims2.get(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM), emailsClaim);
-    }
-
-    @Test(description = "Verification - Enabled, Multi attribute - Disabled")
-    public void testHandleEventPreSetUserClaimsVerificationEnabledMultiDisabled()
-            throws IdentityEventException, IdentityRecoveryException, UserStoreException {
-
-        Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, NEW_EMAIL);
-        mockUtilMethods(true, false, false,
-                false);
-        mockPendingVerificationEmail(EXISTING_EMAIL_1);
-
-        userEmailVerificationHandler.handleEvent(event);
-        Map<String, String> userClaimsC1 = getUserClaimsFromEvent(event);
-        Assert.assertEquals(userClaimsC1.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM), NEW_EMAIL);
-
-        // Case 2: Send SELF_SIGNUP_ROLE with the event.
-        mockPendingVerificationEmail(EXISTING_EMAIL_1);
-        String[] roleList = new String[]{IdentityRecoveryConstants.SELF_SIGNUP_ROLE};
-        Map<String, Object> additionalEventProperties = new HashMap<>();
-        additionalEventProperties.put(IdentityEventConstants.EventProperty.ROLE_LIST, roleList);
-        Event event2 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, NEW_EMAIL, additionalEventProperties, null);
-
-        userEmailVerificationHandler.handleEvent(event2);
-        Map<String, String> userClaimsC2 = getUserClaimsFromEvent(event2);
-        Assert.assertFalse(userClaimsC2.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM));
-
-        // Case 3: Try to change the primary email value with existing verified primary email value.
-        Event event3 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, NEW_EMAIL);
-        mockPendingVerificationEmail(EXISTING_EMAIL_1);
-        mockPrimaryEmail(NEW_EMAIL);
-        mockPrimaryEmailVerificationStatus(true);
-
-        userEmailVerificationHandler.handleEvent(event3);
-        Map<String, String> userClaimsC3 = getUserClaimsFromEvent(event3);
-        Assert.assertEquals(userClaimsC3.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM),
-                StringUtils.EMPTY);
-
-        // Case 4: Try to change the primary email value with existing unverified primary email value.
-        Event event4 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, NEW_EMAIL);
-        mockPendingVerificationEmail(EXISTING_EMAIL_1);
-        mockPrimaryEmail(NEW_EMAIL);
-        mockPrimaryEmailVerificationStatus(false);
-
-        userEmailVerificationHandler.handleEvent(event4);
-        Map<String, String> userClaimsC4 = getUserClaimsFromEvent(event4);
-        Assert.assertEquals(userClaimsC4.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM),
-                NEW_EMAIL);
-    }
-
-    @Test(description = "Verification - Enabled, Multi attribute - Disabled, User verify - Enabled")
-    public void testHandleEventPreSetUserClaimsVerificationEnabledMultiDisabledUserVerifyEnabled()
-            throws IdentityEventException, IdentityRecoveryException, UserStoreException {
-
-        Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.TRUE,
-                null, null, NEW_EMAIL);
-        mockUtilMethods(true, false, true,
-                false);
-        mockPendingVerificationEmail(EXISTING_EMAIL_1);
-
-        userEmailVerificationHandler.handleEvent(event);
-        Map<String, String> userClaimsC1 = getUserClaimsFromEvent(event);
-        Assert.assertEquals(userClaimsC1.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM), NEW_EMAIL);
-
-        // Case 2: verifyEmail claim is false.
-        Event event2 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
-                null, null, NEW_EMAIL);
-        mockUtilMethods(true, false, true,
-                false);
-        mockPendingVerificationEmail(EXISTING_EMAIL_1);
-
-        userEmailVerificationHandler.handleEvent(event2);
-        Map<String, String> userClaimsC2 = getUserClaimsFromEvent(event2);
-        Assert.assertEquals(userClaimsC2.get(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM),
-                StringUtils.EMPTY);
     }
 
     @Test(description = "Verification - Enabled, Multi attribute - Enabled, Change primary email which is not in the " +
@@ -334,8 +205,7 @@ public class UserEmailVerificationHandlerTest {
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, null, NEW_EMAIL);
 
-        mockUtilMethods(true, true, false,
-                false);
+        mockUtilMethods(true, false, false);
         List<String> existingEmails = new ArrayList<>(Arrays.asList(EXISTING_EMAIL_1, EXISTING_EMAIL_2));
         mockExistingEmailAddressesList(existingEmails);
 
@@ -360,8 +230,7 @@ public class UserEmailVerificationHandlerTest {
             Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                     null, null, NEW_EMAIL);
 
-            mockUtilMethods(true, true, false,
-                    false);
+            mockUtilMethods(true, false, false);
             List<String> existingEmails = new ArrayList<>(Arrays.asList(EXISTING_EMAIL_1, NEW_EMAIL));
             mockExistingEmailAddressesList(existingEmails);
 
@@ -390,7 +259,7 @@ public class UserEmailVerificationHandlerTest {
         Event event1 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 newVerifiedEmails1, null, null);
 
-        mockUtilMethods(true, true, false, false);
+        mockUtilMethods(true, false, false);
         List<String> existingEmails1 = new ArrayList<>(Arrays.asList(EXISTING_EMAIL_1));
         mockExistingEmailAddressesList(existingEmails1);
 
@@ -420,7 +289,7 @@ public class UserEmailVerificationHandlerTest {
         Event event2 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 newVerifiedEmails2, null, null);
 
-        mockUtilMethods(true, true, false, false);
+        mockUtilMethods(true, false, false);
         List<String> existingEmails2 = new ArrayList<>(Arrays.asList(EXISTING_EMAIL_1));
         mockExistingEmailAddressesList(existingEmails2);
 
@@ -447,7 +316,7 @@ public class UserEmailVerificationHandlerTest {
         */
         String newVerifiedEmails3 = String.format("%s,%s", EXISTING_EMAIL_1, NEW_EMAIL);
 
-        mockUtilMethods(true, true, false, false);
+        mockUtilMethods(true, false, false);
         List<String> existingEmails3 = new ArrayList<>(Arrays.asList(EXISTING_EMAIL_1));
         mockExistingEmailAddressesList(existingEmails3);
 
@@ -484,7 +353,7 @@ public class UserEmailVerificationHandlerTest {
         Event event5 = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 newVerifiedEmails5, null, null);
 
-        mockUtilMethods(true, true, false, false);
+        mockUtilMethods(true, false, false);
         mockExistingEmailAddressesList(new ArrayList<>());
         mockExistingVerifiedEmailAddressesList(new ArrayList<>());
 
@@ -507,8 +376,7 @@ public class UserEmailVerificationHandlerTest {
         Event event = createEvent(IdentityEventConstants.Event.PRE_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, EXISTING_EMAIL_1, null);
 
-        mockUtilMethods(true, true, false,
-                false);
+        mockUtilMethods(true, false, false);
         List<String> existingEmails = new ArrayList<>(Arrays.asList(EXISTING_EMAIL_1, EXISTING_EMAIL_2));
         mockExistingEmailAddressesList(existingEmails);
 
@@ -524,8 +392,7 @@ public class UserEmailVerificationHandlerTest {
     @Test
     public void testHandleEventThreadLocalValues() throws IdentityEventException, UserStoreException {
 
-        mockUtilMethods(true, false, false,
-                false);
+        mockUtilMethods(true, false, false);
         mockPendingVerificationEmail(EXISTING_EMAIL_1);
 
         // Case 1: Thread local value = SKIP_ON_CONFIRM.
@@ -570,8 +437,7 @@ public class UserEmailVerificationHandlerTest {
 
         Event event = createEvent(IdentityEventConstants.Event.POST_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, null, null);
-        mockUtilMethods(true, true, false,
-                true);
+        mockUtilMethods(true, false, true);
         mockPendingVerificationEmail(EXISTING_EMAIL_1);
 
         userEmailVerificationHandler.handleEvent(event);
@@ -580,8 +446,7 @@ public class UserEmailVerificationHandlerTest {
         // Case 2: Error is thrown when retrieving verification pending email.
         Event event1 = createEvent(IdentityEventConstants.Event.POST_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, null, null);
-        mockUtilMethods(true, true, false,
-                true);
+        mockUtilMethods(true, false, true);
         when(userStoreManager.getUserClaimValues(TEST_USERNAME, new String[]{
                 IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM}, null))
                 .thenThrow(new UserStoreException());
@@ -598,8 +463,7 @@ public class UserEmailVerificationHandlerTest {
 
         Event event = createEvent(IdentityEventConstants.Event.POST_SET_USER_CLAIMS, IdentityRecoveryConstants.FALSE,
                 null, null, null);
-        mockUtilMethods(true, true, false,
-                true);
+        mockUtilMethods(true, false, true);
         mockPendingVerificationEmail(EXISTING_EMAIL_1);
 
         // Case 1: Change primary email address.
@@ -737,21 +601,12 @@ public class UserEmailVerificationHandlerTest {
         }
     }
 
-    @DataProvider(name = "multiAttributeEnabledData")
-    public Object[][] multiAttributeEnabledData() {
-
-        return new Object[][]{
-                {false},
-                {true}
-        };
-    }
-
-    @Test(description = "Test handling of primary email deletion — primary email set to EMPTY should clear" +
-            "emailVerified claim", dataProvider = "multiAttributeEnabledData")
-    public void testHandleEventPreSetUserClaimsPrimaryEmailDeletionClearsVerification(boolean multiAttributeEnabled)
+    @Test(description = "Test handling of primary email deletion — primary email set to EMPTY should clear " +
+            "emailVerified claim")
+    public void testHandleEventPreSetUserClaimsPrimaryEmailDeletionClearsVerification()
             throws IdentityEventException {
 
-        mockUtilMethods(true, multiAttributeEnabled, false, false);
+        mockUtilMethods(true, false, false);
 
         Map<String, Object> eventProperties = new HashMap<>();
         eventProperties.put(IdentityEventConstants.EventProperty.USER_NAME, TEST_USERNAME);
@@ -807,11 +662,9 @@ public class UserEmailVerificationHandlerTest {
                 .thenReturn(String.valueOf(isVerified));
     }
 
-    private void mockUtilMethods(boolean emailVerificationEnabled, boolean multiAttributeEnabled,
-                                 boolean userVerifyClaimEnabled, boolean notificationOnEmailUpdate) {
+    private void mockUtilMethods(boolean emailVerificationEnabled, boolean userVerifyClaimEnabled,
+                                 boolean notificationOnEmailUpdate) {
 
-        mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
-                .thenReturn(multiAttributeEnabled);
         mockedUtils.when(Utils::isUseVerifyClaimEnabled).thenReturn(userVerifyClaimEnabled);
         mockGetConnectorConfig(IdentityRecoveryConstants.ConnectorConfig.ENABLE_EMAIL_VERIFICATION_ON_UPDATE,
                 emailVerificationEnabled);

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManagerTest.java
@@ -697,23 +697,7 @@ public class UserSelfRegistrationManagerTest {
         assertEquals(updatedVerificationPendingMobile, StringUtils.EMPTY);
         assertEquals(updatedPrimaryMobile, verificationPendingMobileNumber);
 
-        // Case 2: Multiple email and mobile per user is disabled.
-        mockMultiAttributeEnabled(false);
-        ArgumentCaptor<Map<String, String>> claimsCaptor2 = ArgumentCaptor.forClass(Map.class);
-
-        userSelfRegistrationManager.confirmVerificationCodeMe(TEST_CODE, new HashMap<>());
-
-        verify(userStoreManager, atLeastOnce()).setUserClaimValues(anyString(), claimsCaptor2.capture(), isNull());
-        Map<String, String> capturedClaims2 = claimsCaptor2.getValue();
-        String mobileNumberClaims =
-                capturedClaims2.get(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM);
-        String updatedVerificationPendingMobile2 =
-                capturedClaims.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM);
-
-        assertEquals(updatedVerificationPendingMobile2, StringUtils.EMPTY);
-        assertEquals(mobileNumberClaims, verificationPendingMobileNumber);
-
-        // Case 3: Wrong recovery step.
+        // Case 2: Wrong recovery step.
         UserRecoveryData userRecoveryData3 = new UserRecoveryData(user, TEST_RECOVERY_DATA_STORE_SECRET,
                 RecoveryScenarios.MOBILE_VERIFICATION_ON_UPDATE, RecoverySteps.VALIDATE_ALL_CHALLENGE_QUESTION);
         userRecoveryData.setRemainingSetIds(verificationPendingMobileNumber);
@@ -780,23 +764,7 @@ public class UserSelfRegistrationManagerTest {
 
         reset(userStoreManager);
 
-        // Case 3: Multiple email and mobile per user is disabled.
-        mockMultiAttributeEnabled(false);
-        ArgumentCaptor<Map<String, String>> claimsCaptor3 = ArgumentCaptor.forClass(Map.class);
-
-        userSelfRegistrationManager.confirmVerificationCodeMe(TEST_CODE, new HashMap<>());
-
-        verify(userStoreManager, atLeastOnce()).setUserClaimValues(anyString(), claimsCaptor3.capture(), isNull());
-        Map<String, String> capturedClaims3 = claimsCaptor3.getValue();
-        assertEquals(capturedClaims.get(IdentityRecoveryConstants.MOBILE_NUMBER_PENDING_VALUE_CLAIM),
-                StringUtils.EMPTY);
-        assertEquals(capturedClaims3.get(IdentityRecoveryConstants.MOBILE_NUMBER_CLAIM),
-                verificationPendingMobileNumber);
-        assertFalse(capturedClaims3.containsKey(IdentityRecoveryConstants.VERIFIED_MOBILE_NUMBERS_CLAIM));
-
-        reset(userStoreManager);
-        reset(userRecoveryDataStore);
-        // Case 4: When pending mobile number claim value is null.
+        // Case 3: When pending mobile number claim value is null.
         UserRecoveryData userRecoveryData2 = new UserRecoveryData(user, TEST_RECOVERY_DATA_STORE_SECRET,
                 RecoveryScenarios.MOBILE_VERIFICATION_ON_VERIFIED_LIST_UPDATE, RecoverySteps.VERIFY_MOBILE_NUMBER);
         userRecoveryData2.setRemainingSetIds(null);
@@ -883,24 +851,8 @@ public class UserSelfRegistrationManagerTest {
         assertFalse(capturedClaims.containsKey(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM));
 
         reset(userStoreManager);
-        // Case 2: Multiple email and mobile per user is disabled.
-        mockMultiAttributeEnabled(false);
-        mockGetUserClaimValue(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM, verificationPendingEmail);
 
-        userSelfRegistrationManager.getConfirmedSelfRegisteredUser(TEST_CODE, verifiedChannelType, verifiedChannelClaim,
-                metaProperties);
-
-        ArgumentCaptor<Map<String, String>> claimsCaptor2 = ArgumentCaptor.forClass(Map.class);
-        verify(userStoreManager).setUserClaimValues(anyString(), claimsCaptor2.capture(), isNull());
-
-        Map<String, String> capturedClaims2 = claimsCaptor2.getValue();
-        String emailAddressClaim =
-                capturedClaims2.get(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM);
-        assertEquals(emailAddressClaim, verificationPendingEmail);
-        assertFalse(capturedClaims2.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM));
-        assertFalse(capturedClaims2.containsKey(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM));
-
-        // Case 3 : Throws user store exception while getting user store manager.
+        // Case 2 : Throws user store exception while getting user store manager.
         when(userRealm.getUserStoreManager()).thenThrow(new org.wso2.carbon.user.core.UserStoreException());
         try {
             userSelfRegistrationManager.getConfirmedSelfRegisteredUser(TEST_CODE, verifiedChannelType,
@@ -988,22 +940,6 @@ public class UserSelfRegistrationManagerTest {
                 verificationPendingEmail);
 
         reset(userStoreManager);
-        // Case 2: Multiple email and mobile per user is disabled.
-        mockMultiAttributeEnabled(false);
-        mockGetUserClaimValue(IdentityRecoveryConstants.EMAIL_ADDRESS_PENDING_VALUE_CLAIM, verificationPendingEmail);
-
-        userSelfRegistrationManager.getConfirmedSelfRegisteredUser(TEST_CODE, verifiedChannelType, verifiedChannelClaim,
-                metaProperties);
-
-        ArgumentCaptor<Map<String, String>> claimsCaptor3 = ArgumentCaptor.forClass(Map.class);
-        verify(userStoreManager).setUserClaimValues(anyString(), claimsCaptor3.capture(), isNull());
-
-        Map<String, String> capturedClaims3 = claimsCaptor3.getValue();
-        String emailAddressClaim =
-                capturedClaims3.get(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM);
-        assertEquals(emailAddressClaim, verificationPendingEmail);
-        assertFalse(capturedClaims3.containsKey(IdentityRecoveryConstants.EMAIL_ADDRESSES_CLAIM));
-        assertFalse(capturedClaims3.containsKey(IdentityRecoveryConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM));
     }
 
     @Test
@@ -1103,8 +1039,6 @@ public class UserSelfRegistrationManagerTest {
         when(identityGovernanceService.getConfiguration(any(), anyString())).thenReturn(testProperties);
 
         try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class)) {
-            mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
-                    .thenReturn(true);
             mockedUtils.when(() -> Utils.getConnectorConfig(
                             eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER),
                             anyString()))
@@ -1133,8 +1067,6 @@ public class UserSelfRegistrationManagerTest {
         // Case 2: External Verified Channel type.
         verifiedChannelType = NotificationChannels.EXTERNAL_CHANNEL.getChannelType();
         try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class)) {
-            mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
-                    .thenReturn(true);
             mockedUtils.when(() -> Utils.getConnectorConfig(
                             eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER),
                             anyString()))
@@ -1156,8 +1088,6 @@ public class UserSelfRegistrationManagerTest {
 
         // Case 3: Throws user store exception while getting user claim values.
         try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class)) {
-            mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
-                    .thenReturn(true);
             mockedUtils.when(() -> Utils.getConnectorConfig(
                             eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER),
                             anyString()))
@@ -1181,8 +1111,6 @@ public class UserSelfRegistrationManagerTest {
         verifiedChannelType = NotificationChannels.SMS_CHANNEL.getChannelType();
         verifiedChannelClaim = "http://wso2.org/claims/invalid";
         try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class)) {
-            mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
-                    .thenReturn(true);
             mockedUtils.when(() -> Utils.getConnectorConfig(
                             eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER),
                             anyString()))
@@ -1228,8 +1156,6 @@ public class UserSelfRegistrationManagerTest {
         when(identityGovernanceService.getConfiguration(any(), anyString())).thenReturn(testProperties);
 
         try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class)) {
-            mockedUtils.when(() -> Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(anyString(), anyString()))
-                    .thenReturn(true);
             mockedUtils.when(() -> Utils.getConnectorConfig(
                             eq(IdentityRecoveryConstants.ConnectorConfig.ENABLE_MOBILE_VERIFICATION_BY_PRIVILEGED_USER),
                             anyString()))

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/util/UtilsTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/util/UtilsTest.java
@@ -36,9 +36,7 @@ import org.wso2.carbon.identity.auth.attribute.handler.exception.AuthAttributeHa
 import org.wso2.carbon.identity.auth.attribute.handler.model.ValidationFailureReason;
 import org.wso2.carbon.identity.auth.attribute.handler.model.ValidationResult;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
-import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
-import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
@@ -1436,62 +1434,6 @@ public class UtilsTest {
         } catch (Exception e) {
             assertTrue(e instanceof IdentityEventException);
         }
-    }
-
-    @Test
-    public void testIsMultiEmailsAndMobileNumbersPerUserEnabled() throws Exception {
-
-        // Mock ClaimMetadataManagementService
-        ClaimMetadataManagementService claimMetadataManagementService = mock(ClaimMetadataManagementService.class);
-        when(identityRecoveryServiceDataHolder.getClaimMetadataManagementService())
-                .thenReturn(claimMetadataManagementService);
-
-        // Case 1: When support_multi_emails_and_mobile_numbers_per_user config is false.
-        mockedStaticIdentityUtil.when(() -> IdentityUtil.getProperty(
-                        IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER))
-                .thenReturn("false");
-
-        boolean isEnabled = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
-        assertFalse(isEnabled);
-
-        // Case 2: When support_multi_emails_and_mobile_numbers_per_user config is true.
-        mockedStaticIdentityUtil.when(() -> IdentityUtil.getProperty(
-                        IdentityRecoveryConstants.ConnectorConfig.SUPPORT_MULTI_EMAILS_AND_MOBILE_NUMBERS_PER_USER))
-                .thenReturn("true");
-
-        Map<String, String> claimProperties2 = new HashMap<>();
-        claimProperties2.put(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY, Boolean.TRUE.toString());
-        when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN)).thenReturn(
-                returnMultiEmailAndMobileRelatedLocalClaims(claimProperties2));
-
-        isEnabled = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
-        assertTrue(isEnabled);
-
-        // Case 3: When support by default is disabled for feature related claims.
-        Map<String, String> claimProperties3 = new HashMap<>();
-        claimProperties3.put(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY, Boolean.FALSE.toString());
-        when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN)).thenReturn(
-                returnMultiEmailAndMobileRelatedLocalClaims(claimProperties3));
-
-        isEnabled = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
-        assertFalse(isEnabled);
-
-        // Case 4: When user store domain is excluded for feature related claims.
-        Map<String, String> claimProperties4 = new HashMap<>();
-        claimProperties4.put(ClaimConstants.SUPPORTED_BY_DEFAULT_PROPERTY, Boolean.TRUE.toString());
-        claimProperties4.put(ClaimConstants.EXCLUDED_USER_STORES_PROPERTY, USER_STORE_DOMAIN);
-        when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN)).thenReturn(
-                returnMultiEmailAndMobileRelatedLocalClaims(claimProperties4));
-
-        isEnabled = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
-        assertFalse(isEnabled);
-
-        // Case 5: When ClaimMetadataException is thrown.
-        when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN))
-                .thenThrow(new ClaimMetadataException("Test exception"));
-
-        isEnabled = Utils.isMultiEmailsAndMobileNumbersPerUserEnabled(TENANT_DOMAIN, USER_STORE_DOMAIN);
-        assertFalse(isEnabled);
     }
 
     @Test(description = "Test getUserClaim() returns the stored claim value if it exists in the user store.")

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/TenantAwareAxis2ConfigurationContextObserver.java
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/TenantAwareAxis2ConfigurationContextObserver.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.tenant.resource.manager;
 
+import org.apache.axis2.context.ConfigurationContext;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -52,6 +53,37 @@ public class TenantAwareAxis2ConfigurationContextObserver extends AbstractAxis2C
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         log.info("Loading configuration context for tenant domain: " + tenantDomain);
         loadEventStreamAndPublisherConfigurations(tenantId);
+    }
+
+    /**
+     * Remove the in-memory event publisher and stream configurations of the tenant when its
+     * configuration context is unloaded (tenant idle eviction or shutdown).
+     *
+     * <p>The publisher and stream runtimes are re-created by {@link #creatingConfigurationContext(int)}
+     * the next time the tenant is loaded, so removing them here keeps the in-memory publisher state
+     * proportional to the set of currently loaded tenants instead of every tenant ever loaded.</p>
+     *
+     * @param configContext Configuration context of the tenant being unloaded.
+     */
+    @Override
+    public void terminatingConfigurationContext(ConfigurationContext configContext) {
+
+        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        log.info("Unloading event publisher and stream configurations for tenant domain: " + tenantDomain);
+        try {
+            TenantResourceManagerDataHolder.getInstance().getCarbonEventPublisherService()
+                    .removeEventPublisherConfigurations(tenantId);
+            TenantResourceManagerDataHolder.getInstance().getCarbonEventStreamService()
+                    .removeEventStreamConfigurations(tenantId);
+        } catch (Throwable e) {
+            /*
+             * Tenant unloading must never fail due to publisher cleanup; also tolerates running against
+             * an analytics-common version that does not expose the cleanup APIs yet (NoSuchMethodError).
+             */
+            log.warn("Error while removing event publisher and stream configurations for tenant domain: "
+                    + tenantDomain, e);
+        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.user.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.export.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.export.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.export.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.export.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.export.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.export.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.export.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.export.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.export.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.export.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.export.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.export.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.export.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.export.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.export.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.export.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.onboard.core.service/pom.xml
+++ b/components/org.wso2.carbon.identity.user.onboard.core.service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.onboard.core.service/pom.xml
+++ b/components/org.wso2.carbon.identity.user.onboard.core.service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.onboard.core.service/pom.xml
+++ b/components/org.wso2.carbon.identity.user.onboard.core.service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.onboard.core.service/pom.xml
+++ b/components/org.wso2.carbon.identity.user.onboard.core.service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.onboard.core.service/pom.xml
+++ b/components/org.wso2.carbon.identity.user.onboard.core.service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.onboard.core.service/pom.xml
+++ b/components/org.wso2.carbon.identity.user.onboard.core.service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.onboard.core.service/pom.xml
+++ b/components/org.wso2.carbon.identity.user.onboard.core.service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.onboard.core.service/pom.xml
+++ b/components/org.wso2.carbon.identity.user.onboard.core.service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.user.rename.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.rename.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.user.rename.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.rename.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.user.rename.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.rename.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.user.rename.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.rename.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.user.rename.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.rename.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.user.rename.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.rename.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.user.rename.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.rename.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.user.rename.core/pom.xml
+++ b/components/org.wso2.carbon.identity.user.rename.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.account.suspension.notification.task.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.auth.attribute.handler.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.captcha.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.governance.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.governance.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.governance.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.governance.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.governance.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.governance.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.governance.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.governance.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.governance.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.idle.account.identification.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.multi.attribute.login.service.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.multi.attribute.login.service.server.feature/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.multi.attribute.login.service.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.multi.attribute.login.service.server.feature/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.multi.attribute.login.service.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.multi.attribute.login.service.server.feature/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.multi.attribute.login.service.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.multi.attribute.login.service.server.feature/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.multi.attribute.login.service.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.multi.attribute.login.service.server.feature/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.multi.attribute.login.service.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.multi.attribute.login.service.server.feature/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.multi.attribute.login.service.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.multi.attribute.login.service.server.feature/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.multi.attribute.login.service.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.multi.attribute.login.service.server.feature/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>identity-governance</artifactId>
         <groupId>org.wso2.carbon.identity.governance</groupId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.expiry.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.expiry.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.expiry.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.expiry.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.expiry.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.expiry.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.expiry.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.expiry.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.expiry.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.expiry.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.expiry.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.expiry.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.expiry.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.expiry.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.expiry.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.expiry.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.history.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.password.policy.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.piicontroller.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.recovery.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.tenant.resource.manager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.user.onboard.core.service.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.onboard.core.service.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.user.onboard.core.service.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.onboard.core.service.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.user.onboard.core.service.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.onboard.core.service.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.user.onboard.core.service.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.onboard.core.service.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.user.onboard.core.service.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.onboard.core.service.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.user.onboard.core.service.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.onboard.core.service.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.user.onboard.core.service.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.onboard.core.service.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.user.onboard.core.service.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.onboard.core.service.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.user.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7</version>
+        <version>1.15.8-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.user.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9</version>
+        <version>1.15.10-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.user.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8</version>
+        <version>1.15.9-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.user.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.9-SNAPSHOT</version>
+        <version>1.15.9</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.user.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6-SNAPSHOT</version>
+        <version>1.15.6</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.user.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.8-SNAPSHOT</version>
+        <version>1.15.8</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.user.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.7-SNAPSHOT</version>
+        <version>1.15.7</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.user.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.user.server.feature/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.governance</groupId>
         <artifactId>identity-governance</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.15.6</version>
+        <version>1.15.7-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.wso2.carbon.identity.governance</groupId>
     <artifactId>identity-governance</artifactId>
-    <version>1.15.8-SNAPSHOT</version>
+    <version>1.15.8</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Governance Module</name>
@@ -37,7 +37,7 @@
         <url>https://github.com/wso2-extensions/identity-governance.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-governance.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-governance.git</connection>
-        <tag>v1.1.0-SNAPSHOT</tag>
+        <tag>v1.15.8</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -738,14 +738,14 @@
         <identity.branding.preference.management.version>1.1.29</identity.branding.preference.management.version>
 
         <!--Carbon Kernel Version-->
-        <carbon.kernel.version>4.12.17-SNAPSHOT</carbon.kernel.version>
+        <carbon.kernel.version>4.12.15</carbon.kernel.version>
         <carbon.kernel.feature.version>4.9.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.10.99-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.106</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.wso2.carbon.identity.governance</groupId>
     <artifactId>identity-governance</artifactId>
-    <version>1.15.7-SNAPSHOT</version>
+    <version>1.15.7</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Governance Module</name>
@@ -37,7 +37,7 @@
         <url>https://github.com/wso2-extensions/identity-governance.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-governance.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-governance.git</connection>
-        <tag>v1.1.0-SNAPSHOT</tag>
+        <tag>v1.15.7</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.wso2.carbon.identity.governance</groupId>
     <artifactId>identity-governance</artifactId>
-    <version>1.15.7</version>
+    <version>1.15.8-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Governance Module</name>
@@ -37,7 +37,7 @@
         <url>https://github.com/wso2-extensions/identity-governance.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-governance.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-governance.git</connection>
-        <tag>v1.15.7</tag>
+        <tag>v1.1.0-SNAPSHOT</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.wso2.carbon.identity.governance</groupId>
     <artifactId>identity-governance</artifactId>
-    <version>1.15.9-SNAPSHOT</version>
+    <version>1.15.9</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Governance Module</name>
@@ -37,7 +37,7 @@
         <url>https://github.com/wso2-extensions/identity-governance.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-governance.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-governance.git</connection>
-        <tag>v1.1.0-SNAPSHOT</tag>
+        <tag>v1.15.9</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,12 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.wso2.carbon</groupId>
+                <artifactId>javax.cache.wso2</artifactId>
+                <version>${carbon.kernel.version}</version>
+            </dependency>
+
             <!--Orbit Dependencies-->
             <dependency>
                 <groupId>org.apache.axis2.wso2</groupId>
@@ -732,14 +738,14 @@
         <identity.branding.preference.management.version>1.1.29</identity.branding.preference.management.version>
 
         <!--Carbon Kernel Version-->
-        <carbon.kernel.version>4.10.67</carbon.kernel.version>
+        <carbon.kernel.version>4.12.17-SNAPSHOT</carbon.kernel.version>
         <carbon.kernel.feature.version>4.9.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.10.82</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.99-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.wso2.carbon.identity.governance</groupId>
     <artifactId>identity-governance</artifactId>
-    <version>1.15.6</version>
+    <version>1.15.7-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Governance Module</name>
@@ -37,7 +37,7 @@
         <url>https://github.com/wso2-extensions/identity-governance.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-governance.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-governance.git</connection>
-        <tag>v1.15.6</tag>
+        <tag>v1.1.0-SNAPSHOT</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.wso2.carbon.identity.governance</groupId>
     <artifactId>identity-governance</artifactId>
-    <version>1.15.9</version>
+    <version>1.15.10-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Governance Module</name>
@@ -37,7 +37,7 @@
         <url>https://github.com/wso2-extensions/identity-governance.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-governance.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-governance.git</connection>
-        <tag>v1.15.9</tag>
+        <tag>v1.1.0-SNAPSHOT</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,6 @@
                 <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>javax.cache.wso2</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.wso2.carbon.identity.governance</groupId>
     <artifactId>identity-governance</artifactId>
-    <version>1.15.8</version>
+    <version>1.15.9-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Governance Module</name>
@@ -37,7 +37,7 @@
         <url>https://github.com/wso2-extensions/identity-governance.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-governance.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-governance.git</connection>
-        <tag>v1.15.8</tag>
+        <tag>v1.1.0-SNAPSHOT</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.wso2.carbon.identity.governance</groupId>
     <artifactId>identity-governance</artifactId>
-    <version>1.15.6-SNAPSHOT</version>
+    <version>1.15.6</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Governance Module</name>
@@ -37,7 +37,7 @@
         <url>https://github.com/wso2-extensions/identity-governance.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-governance.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-governance.git</connection>
-        <tag>v1.1.0-SNAPSHOT</tag>
+        <tag>v1.15.6</tag>
     </scm>
 
 


### PR DESCRIPTION
## Problem

`TenantAwareAxis2ConfigurationContextObserver` loads event publisher and stream configurations into memory on `creatingConfigurationContext` (tenant-specific publishers from the configuration store plus super-tenant fallbacks), but nothing removes them when the tenant configuration context is unloaded by carbon's idle-tenant eviction. Publisher runtimes, output adapter instances and stream junctions therefore accumulate for **every tenant ever loaded** since JVM start. In large multi-tenant deployments (e.g. 10k tenants with several publishers each) this retains on the order of GBs of heap that is only released on restart.

## Changes

Implements `terminatingConfigurationContext` to remove the tenant's in-memory event publisher and stream configurations via the new analytics-common APIs:
- `EventPublisherService#removeEventPublisherConfigurations(tenantId)`
- `EventStreamService#removeEventStreamConfigurations(tenantId)`

Carbon invokes the terminating observers within the tenant's carbon context flow, so the cleanup runs with the correct tenant identity. The configurations are re-created by the existing `creatingConfigurationContext` path on the next tenant access (which already destroys-and-redeploys on every load), so this adds no extra reload cost — it just makes in-memory eventing state proportional to the currently-loaded tenant set instead of every tenant ever loaded.

The cleanup is wrapped so that tenant unloading can never fail due to it; running against an older carbon-analytics-common that lacks the cleanup APIs degrades to a logged warning.

## Depends on

- wso2/carbon-analytics-common#923 — `carbon.analytics.common.version` needs to be bumped to a release containing it before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added caching on read operations for identity data store to improve performance.
  * Enhanced tenant resource cleanup during configuration context termination.

* **Bug Fixes**
  * Improved thread-local flag management in account suspension notification handling.
  * Simplified mobile and email verification logic by removing redundant feature flag dependencies.

* **Documentation**
  * Updated build prerequisites to require Java 21 or above.

* **Chores**
  * Updated project version to 1.15.10-SNAPSHOT.
  * Added CI/CD workflow trigger support for the `next` branch.
  * Updated kernel and identity framework dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->