### PR TITLE
Remove tenant event publisher and stream state on tenant unload

### DIFF
--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/TenantAwareAxis2ConfigurationContextObserver.java
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/TenantAwareAxis2ConfigurationContextObserver.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.tenant.resource.manager;
 
+import org.apache.axis2.context.ConfigurationContext;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -52,6 +53,37 @@ public class TenantAwareAxis2ConfigurationContextObserver extends AbstractAxis2C
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         log.info("Loading configuration context for tenant domain: " + tenantDomain);
         loadEventStreamAndPublisherConfigurations(tenantId);
+    }
+
+    /**
+     * Remove the in-memory event publisher and stream configurations of the tenant when its
+     * configuration context is unloaded (tenant idle eviction or shutdown).
+     *
+     * <p>The publisher and stream runtimes are re-created by {@link #creatingConfigurationContext(int)}
+     * the next time the tenant is loaded, so removing them here keeps the in-memory publisher state
+     * proportional to the set of currently loaded tenants instead of every tenant ever loaded.</p>
+     *
+     * @param configContext Configuration context of the tenant being unloaded.
+     */
+    @Override
+    public void terminatingConfigurationContext(ConfigurationContext configContext) {
+
+        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        log.info("Unloading event publisher and stream configurations for tenant domain: " + tenantDomain);
+        try {
+            TenantResourceManagerDataHolder.getInstance().getCarbonEventPublisherService()
+                    .removeEventPublisherConfigurations(tenantId);
+            TenantResourceManagerDataHolder.getInstance().getCarbonEventStreamService()
+                    .removeEventStreamConfigurations(tenantId);
+        } catch (Throwable e) {
+            /*
+             * Tenant unloading must never fail due to publisher cleanup; also tolerates running against
+             * an analytics-common version that does not expose the cleanup APIs yet (NoSuchMethodError).
+             */
+            log.warn("Error while removing event publisher and stream configurations for tenant domain: "
+                    + tenantDomain, e);
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem

`TenantAwareAxis2ConfigurationContextObserver` loads event publisher and stream configurations into memory on `creatingConfigurationContext` (tenant-specific publishers from the configuration store plus super-tenant fallbacks), but nothing removes them when the tenant configuration context is unloaded by carbon's idle-tenant eviction. Publisher runtimes, output adapter instances and stream junctions therefore accumulate for **every tenant ever loaded** since JVM start. In large multi-tenant deployments (e.g. 10k tenants with several publishers each) this retains on the order of GBs of heap that is only released on restart.

## Changes

Implements `terminatingConfigurationContext` to remove the tenant's in-memory event publisher and stream configurations via the new analytics-common APIs:
- `EventPublisherService#removeEventPublisherConfigurations(tenantId)`
- `EventStreamService#removeEventStreamConfigurations(tenantId)`

Carbon invokes the terminating observers within the tenant's carbon context flow, so the cleanup runs with the correct tenant identity. The configurations are re-created by the existing `creatingConfigurationContext` path on the next tenant access (which already destroys-and-redeploys on every load), so this adds no extra reload cost — it just makes in-memory eventing state proportional to the currently-loaded tenant set instead of every tenant ever loaded.

The cleanup is wrapped so that tenant unloading can never fail due to it; running against an older carbon-analytics-common that lacks the cleanup APIs degrades to a logged warning.

## Depends on

- wso2/carbon-analytics-common#923 — `carbon.analytics.common.version` needs to be bumped to a release containing it before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added caching on read operations for identity data store to improve performance.
  * Enhanced tenant resource cleanup during configuration context termination.

* **Bug Fixes**
  * Improved thread-local flag management in account suspension notification handling.
  * Simplified mobile and email verification logic by removing redundant feature flag dependencies.

* **Documentation**
  * Updated build prerequisites to require Java 21 or above.

* **Chores**
  * Updated project version to 1.15.10-SNAPSHOT.
  * Added CI/CD workflow trigger support for the `next` branch.
  * Updated kernel and identity framework dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->