### PR TITLE
Remove tenant event publisher and stream state on tenant unload

### DIFF
--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/TenantAwareAxis2ConfigurationContextObserver.java
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/TenantAwareAxis2ConfigurationContextObserver.java
@@ -59,10 +59,9 @@ public class TenantAwareAxis2ConfigurationContextObserver extends AbstractAxis2C
     /**
      * Remove the in-memory event publisher and stream configurations of the tenant when its
      * configuration context is unloaded (tenant idle eviction or shutdown).
-     *
-     * <p>The publisher and stream runtimes are re-created by {@link #creatingConfigurationContext(int)}
+     * The publisher and stream runtimes are re-created by {@link #creatingConfigurationContext(int)}
      * the next time the tenant is loaded, so removing them here keeps the in-memory publisher state
-     * proportional to the set of currently loaded tenants instead of every tenant ever loaded.</p>
+     * proportional to the set of currently loaded tenants instead of every tenant ever loaded.
      *
      * @param configContext Configuration context of the tenant being unloaded.
      */
@@ -91,12 +90,9 @@ public class TenantAwareAxis2ConfigurationContextObserver extends AbstractAxis2C
                     .removeEventPublisherConfigurations(tenantId);
             TenantResourceManagerDataHolder.getInstance().getCarbonEventStreamService()
                     .removeEventStreamConfigurations(tenantId);
-        } catch (Throwable e) {
-            /*
-             * Tenant unloading must never fail due to publisher cleanup; also tolerates running against
-             * an analytics-common version that does not expose the cleanup APIs yet (NoSuchMethodError).
-             */
-            log.warn("Error while removing event publisher and stream configurations for tenant domain: "
+        } catch (Exception e) {
+            // Tenant unloading must never fail due to publisher cleanup.
+            log.error("Error while removing event publisher and stream configurations for tenant domain: "
                     + tenantDomain, e);
         }
     }

--- a/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/TenantAwareAxis2ConfigurationContextObserver.java
+++ b/components/org.wso2.carbon.identity.tenant.resource.manager/src/main/java/org/wso2/carbon/identity/tenant/resource/manager/TenantAwareAxis2ConfigurationContextObserver.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.tenant.resource.manager;
 
+import org.apache.axis2.context.ConfigurationContext;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -28,6 +29,7 @@ import org.wso2.carbon.identity.tenant.resource.manager.constants.TenantResource
 import org.wso2.carbon.identity.tenant.resource.manager.internal.TenantResourceManagerDataHolder;
 import org.wso2.carbon.identity.tenant.resource.manager.util.ResourceUtils;
 import org.wso2.carbon.utils.AbstractAxis2ConfigurationContextObserver;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.List;
 
@@ -52,6 +54,51 @@ public class TenantAwareAxis2ConfigurationContextObserver extends AbstractAxis2C
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         log.info("Loading configuration context for tenant domain: " + tenantDomain);
         loadEventStreamAndPublisherConfigurations(tenantId);
+    }
+
+    /**
+     * Remove the in-memory event publisher and stream configurations of the tenant when its
+     * configuration context is unloaded (tenant idle eviction or shutdown).
+     *
+     * <p>The publisher and stream runtimes are re-created by {@link #creatingConfigurationContext(int)}
+     * the next time the tenant is loaded, so removing them here keeps the in-memory publisher state
+     * proportional to the set of currently loaded tenants instead of every tenant ever loaded.</p>
+     *
+     * @param configContext Configuration context of the tenant being unloaded.
+     */
+    @Override
+    public void terminatingConfigurationContext(ConfigurationContext configContext) {
+
+        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        /*
+         * Both tenant unload paths (idle eviction in TenantAxisUtils#cleanupTenants and tenant
+         * deactivation in TenantMgtUtil#unloadTenantConfigurations) invoke the terminating observers
+         * within the unloading tenant's carbon context flow. Guard regardless: with an unresolved
+         * tenant we cannot tell whose state to remove, and the super tenant's publishers are
+         * filesystem-deployed at startup and would not be re-created lazily.
+         */
+        if (tenantId == MultitenantConstants.INVALID_TENANT_ID
+                || tenantId == MultitenantConstants.SUPER_TENANT_ID) {
+            if (log.isDebugEnabled()) {
+                log.debug("Skipping event publisher and stream cleanup for tenant id: " + tenantId);
+            }
+            return;
+        }
+        log.info("Unloading event publisher and stream configurations for tenant domain: " + tenantDomain);
+        try {
+            TenantResourceManagerDataHolder.getInstance().getCarbonEventPublisherService()
+                    .removeEventPublisherConfigurations(tenantId);
+            TenantResourceManagerDataHolder.getInstance().getCarbonEventStreamService()
+                    .removeEventStreamConfigurations(tenantId);
+        } catch (Throwable e) {
+            /*
+             * Tenant unloading must never fail due to publisher cleanup; also tolerates running against
+             * an analytics-common version that does not expose the cleanup APIs yet (NoSuchMethodError).
+             */
+            log.warn("Error while removing event publisher and stream configurations for tenant domain: "
+                    + tenantDomain, e);
+        }
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -803,7 +803,7 @@
         <!-- Pax Logging Version -->
         <pax.logging.api.version>2.1.0-wso2v5</pax.logging.api.version>
 
-        <carbon.analytics.common.version>5.2.50</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.5.6</carbon.analytics.common.version>
         <carbon.analytics.common.version.range>[5.2.15,6.0.0)</carbon.analytics.common.version.range>
 
         <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>


### PR DESCRIPTION
Replaces #1138 (closed after a stale-base mishap; this one is a single commit on current master).

## Problem

`TenantAwareAxis2ConfigurationContextObserver` loads event publisher and stream configurations into memory on `creatingConfigurationContext` (tenant-specific publishers from the configuration store plus super-tenant fallbacks), but nothing removes them when the tenant's configuration context is unloaded. Publisher runtimes, output adapter instances and stream junctions therefore accumulate for **every tenant ever loaded** since JVM start. In large multi-tenant deployments (e.g. 10k tenants with several publishers each) this retains on the order of GBs of heap that is only released on restart.

All three unload triggers fire the terminating observers within the tenant's carbon context flow:
- idle eviction — `TenantAxisUtils#cleanupTenants` (carbon-kernel, scheduled every 60s, `tenant.idle.time` default 30 min)
- tenant deactivation / deletion — `TenantMgtUtil#unloadTenantConfigurations` (carbon-multitenancy)

## Changes

Implements `terminatingConfigurationContext` to remove the tenant's in-memory event publisher and stream configurations via the new carbon-analytics-common APIs:
- `EventPublisherService#removeEventPublisherConfigurations(tenantId)`
- `EventStreamService#removeEventStreamConfigurations(tenantId)`

The configurations are re-created by the existing `creatingConfigurationContext` path on the next tenant access (which already destroys-and-redeploys on every load), so this adds no extra reload cost — it just makes in-memory eventing state proportional to the currently-loaded tenant set instead of every tenant ever loaded.

Safety:
- Skips cleanup when the carbon context carries an invalid or super-tenant id (super-tenant publishers are filesystem-deployed at startup and are not lazily re-created).
- Wrapped so tenant unloading can never fail due to cleanup; running against an older carbon-analytics-common without the APIs degrades to a logged warning.

## Depends on

- wso2/carbon-analytics-common#923 — `carbon.analytics.common.version` needs to be bumped to a release containing it before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant unload handling to remove in-memory event publisher and stream configurations reliably, preventing leftover configurations and reducing tenant-unload failures.

* **Chores**
  * Updated analytics-related dependency to a newer version to improve compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->