### PR TITLE
Add service provider uuid to events.

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -251,6 +251,9 @@ public class IdentityRecoveryConstants {
     public static final String TRUE = "true";
     public static final String FALSE = "false";
 
+    // Constants related to service provider.
+    public static final String SERVICE_PROVIDER_ID = "spId";
+
     private IdentityRecoveryConstants() {
 
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
@@ -58,6 +58,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.FLOW_TYPE;
@@ -320,6 +321,12 @@ public class ResendConfirmationManager {
                     properties.get(IdentityRecoveryConstants.RESEND_EMAIL_TEMPLATE_NAME));
         } else {
             properties.put(IdentityRecoveryConstants.TEMPLATE_TYPE, templateName);
+        }
+
+        if (!properties.containsKey(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID)) {
+            Optional<String> optionalServiceProviderUUID = Utils.resolveServiceProviderUUID(properties);
+            optionalServiceProviderUUID.ifPresent(s ->
+                    properties.put(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID, s));
         }
         Event identityMgtEvent = new Event(eventName, properties);
         try {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/FlowRegistrationCompletionHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/FlowRegistrationCompletionHandler.java
@@ -173,7 +173,7 @@ public class FlowRegistrationCompletionHandler extends AbstractEventHandler {
             if (isNotificationInternallyManaged && isNotificationClaimAvailable && isSelfRegistrationConfirmationNotify
                     && (notificationChannelVerified || !isEnableConfirmationOnCreation)) {
                 triggerAccountCreationNotification(user.getUserName(), user.getTenantDomain(),
-                        user.getUserStoreDomain());
+                        user.getUserStoreDomain(), Utils.getArbitraryProperties());
             }
 
             // Event is not published if account lock on creation is enabled as self registration is not complete yet.

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/UserSelfRegistrationHandler.java
@@ -55,6 +55,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.wso2.carbon.identity.recovery.util.SelfRegistrationUtils.getNotificationChannel;
 import static org.wso2.carbon.identity.recovery.util.SelfRegistrationUtils.handledNotificationChannelManagerException;
@@ -159,7 +160,7 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
                 if (!isAccountLockOnCreation && !isEnableConfirmationOnCreation && isNotificationInternallyManage
                         && isSelfRegistrationConfirmationNotify) {
                     triggerAccountCreationNotification(user.getUserName(), user.getTenantDomain(),
-                                                       user.getUserStoreDomain());
+                                                       user.getUserStoreDomain(), Utils.getArbitraryProperties());
                 }
                 // If notifications are externally managed, no send notifications.
                 if ((isAccountLockOnCreation || isEnableConfirmationOnCreation) && isNotificationInternallyManage) {
@@ -305,6 +306,11 @@ public class UserSelfRegistrationHandler extends AbstractEventHandler {
             properties.put(IdentityRecoveryConstants.CONFIRMATION_CODE, code);
         }
         properties.put(IdentityRecoveryConstants.TEMPLATE_TYPE, type);
+        if (!properties.containsKey(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID)) {
+            Optional<String> optionalServiceProviderUUID = Utils.resolveServiceProviderUUID(properties);
+            optionalServiceProviderUUID.ifPresent(s ->
+                    properties.put(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID, s));
+        }
         Event identityMgtEvent = new Event(eventName, properties);
         try {
             IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/username/UsernameRecoveryManagerImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/internal/service/impl/username/UsernameRecoveryManagerImpl.java
@@ -60,6 +60,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AUDIT_FAILED;
 
@@ -378,6 +379,11 @@ public class UsernameRecoveryManagerImpl implements UsernameRecoveryManager {
             }
             properties.put(IdentityRecoveryConstants.TEMPLATE_TYPE,
                     IdentityRecoveryConstants.NOTIFICATION_ACCOUNT_ID_RECOVERY);
+            if (!properties.containsKey(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID)) {
+                Optional<String> optionalServiceProviderUUID = Utils.resolveServiceProviderUUID(properties);
+                optionalServiceProviderUUID.ifPresent(s ->
+                        properties.put(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID, s));
+            }
             Event identityMgtEvent = new Event(eventName, properties);
             try {
                 IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/listener/FlowCompletionListener.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/listener/FlowCompletionListener.java
@@ -260,7 +260,7 @@ public class FlowCompletionListener extends AbstractFlowExecutionListener {
             if (Boolean.parseBoolean(Utils.getFlowCompletionConfig(Constants.FlowTypes.INVITED_USER_REGISTRATION,
                     tenantDomain, Constants.FlowCompletionConfig.IS_FLOW_COMPLETION_NOTIFICATION_ENABLED))) {
                 handleNotifications(user, recoveryScenario, notificationChannel, confirmationCode, internallyManaged,
-                        IdentityRecoveryConstants.ACCOUNT_ACTIVATION_SUCCESS);
+                        IdentityRecoveryConstants.ACCOUNT_ACTIVATION_SUCCESS, context.getApplicationId());
             }
             publishEvent(user, userClaims, confirmationCode, recoveryScenario,
                     IdentityEventConstants.Event.POST_ADD_NEW_PASSWORD);
@@ -328,7 +328,8 @@ public class FlowCompletionListener extends AbstractFlowExecutionListener {
             if (isEnableNotificationOnPasswordReset && isNotificationClaimAvailableInFlowUser) {
                 handleNotifications(user, IdentityRecoveryConstants.PASSWORD_RECOVERY_SCENARIO,
                         notificationChannel.getChannelType(), StringUtils.EMPTY, internallyManaged,
-                        IdentityRecoveryConstants.NOTIFICATION_TYPE_PASSWORD_RESET_SUCCESS);
+                        IdentityRecoveryConstants.NOTIFICATION_TYPE_PASSWORD_RESET_SUCCESS,
+                        context.getApplicationId());
             }
             publishEvent(user, null , StringUtils.EMPTY, IdentityRecoveryConstants.PASSWORD_RECOVERY_SCENARIO,
                     IdentityEventConstants.Event.POST_ADD_NEW_PASSWORD);
@@ -468,7 +469,7 @@ public class FlowCompletionListener extends AbstractFlowExecutionListener {
     }
 
     private void handleNotifications(User user, String recoveryScenario, String channel, String code,
-                                     boolean internallyManaged, String template)
+                                     boolean internallyManaged, String template, String serviceProviderUUID)
             throws IdentityRecoveryServerException {
 
         // If the notification is not internally managed and the channel is external, skip sending notifications.
@@ -478,7 +479,7 @@ public class FlowCompletionListener extends AbstractFlowExecutionListener {
         try {
             String eventName = IdentityEventConstants.Event.TRIGGER_NOTIFICATION;
             triggerNotification(user, recoveryScenario, channel,
-                    template, code, eventName);
+                    template, code, eventName, serviceProviderUUID);
         } catch (IdentityRecoveryException e) {
             String errorMsg = String.format("Error while sending account activation notification to user: %s",
                     user.getUserName());
@@ -487,7 +488,7 @@ public class FlowCompletionListener extends AbstractFlowExecutionListener {
     }
 
     private void triggerNotification(User user, String recoveryScenario, String channel, String template,
-                                     String code, String eventName)
+                                     String code, String eventName, String serviceProviderUUID)
             throws IdentityRecoveryException {
 
         HashMap<String, Object> props = new HashMap<>();
@@ -498,6 +499,9 @@ public class FlowCompletionListener extends AbstractFlowExecutionListener {
         props.put(IdentityEventConstants.EventProperty.RECOVERY_SCENARIO, recoveryScenario);
         props.put(IdentityRecoveryConstants.CONFIRMATION_CODE, code);
         props.put(IdentityRecoveryConstants.TEMPLATE_TYPE, template);
+        if (StringUtils.isNotBlank(serviceProviderUUID)) {
+            props.put(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID, serviceProviderUUID);
+        }
 
         Event event = new Event(eventName, props);
         try {

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -76,6 +76,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AUDIT_FAILED;
 import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.LOGIN_IDENTIFIER;
@@ -1187,6 +1188,12 @@ public class NotificationPasswordRecoveryManager {
             }
         }
         properties.put(IdentityRecoveryConstants.TEMPLATE_TYPE, templateName);
+
+        if (!properties.containsKey(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID)) {
+            Optional<String> serviceProviderUUID = Utils.resolveServiceProviderUUID(properties);
+            serviceProviderUUID.ifPresent(s ->
+                    properties.put(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID, s));
+        }
         Event identityMgtEvent = new Event(eventName, properties);
         try {
             IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/signup/UserSelfRegistrationManager.java
@@ -114,6 +114,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -744,7 +745,7 @@ public class UserSelfRegistrationManager {
                         (IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_NOTIFY_ACCOUNT_CONFIRMATION,
                                 user.getTenantDomain()));
                 if (isSelfRegistrationConfirmationNotify) {
-                    triggerNotification(user);
+                    triggerNotification(user, properties);
                 }
             }
 
@@ -2349,7 +2350,8 @@ public class UserSelfRegistrationManager {
                 dataObject, result);
     }
 
-    private void triggerNotification(User user) throws IdentityRecoveryServerException {
+    private void triggerNotification(User user, Map<String, String> metaProperties)
+            throws IdentityRecoveryServerException {
 
         String eventName = IdentityEventConstants.Event.TRIGGER_NOTIFICATION;
         HashMap<String, Object> properties = new HashMap<>();
@@ -2363,6 +2365,11 @@ public class UserSelfRegistrationManager {
         String selfSignUpConfirmationTime = simpleDateFormat.format(new Date(System.currentTimeMillis()));
         properties.put(IdentityEventConstants.EventProperty.SELF_SIGNUP_CONFIRM_TIME, selfSignUpConfirmationTime);
 
+        if (!properties.containsKey(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID)) {
+            Optional<String> serviceProviderUUID = Utils.resolveServiceProviderUUID(metaProperties);
+            serviceProviderUUID.ifPresent(s ->
+                    properties.put(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID, s));
+        }
         Event identityMgtEvent = new Event(eventName, properties);
         try {
             IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/SelfRegistrationUtils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/SelfRegistrationUtils.java
@@ -48,6 +48,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.wso2.carbon.CarbonConstants.DOMAIN_SEPARATOR;
 import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.CONFIRMATION_CODE;
@@ -167,6 +168,22 @@ public class SelfRegistrationUtils {
                                                           String userStoreDomain)
             throws IdentityRecoveryServerException {
 
+        triggerAccountCreationNotification(username, tenantDomain, userStoreDomain, null);
+    }
+
+    /**
+     * Trigger account creation notification.
+     *
+     * @param username        Username of the signed-up user.
+     * @param tenantDomain    Tenant domain of the signed-up user.
+     * @param userStoreDomain User store domain of the signed-up user.
+     * @param  props           Event properties to be included when triggering the notification.
+     * @throws IdentityRecoveryServerException Error while triggering the notification.
+     */
+    public static void triggerAccountCreationNotification(String username, String tenantDomain,
+                                                          String userStoreDomain, Property[] props)
+            throws IdentityRecoveryServerException {
+
         String eventName = IdentityEventConstants.Event.TRIGGER_NOTIFICATION;
 
         String serviceProviderUUID = (String) IdentityUtil.threadLocalProperties.get()
@@ -187,6 +204,16 @@ public class SelfRegistrationUtils {
         String selfSignUpConfirmationTime = simpleDateFormat.format(new Date(System.currentTimeMillis()));
         properties.put(IdentityEventConstants.EventProperty.SELF_SIGNUP_CONFIRM_TIME, selfSignUpConfirmationTime);
 
+        if (props != null) {
+            for (Property prop : props) {
+                properties.put(prop.getKey(), prop.getValue());
+            }
+        }
+        if (!properties.containsKey(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID)) {
+            Optional<String> optionalServiceProviderUUID = Utils.resolveServiceProviderUUID(properties);
+            optionalServiceProviderUUID.ifPresent(s ->
+                    properties.put(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID, s));
+        }
         Event identityMgtEvent = new Event(eventName, properties);
         try {
             IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);
@@ -315,6 +342,11 @@ public class SelfRegistrationUtils {
             }
         }
         properties.put(TEMPLATE_TYPE, emailTemplateName);
+        if (!properties.containsKey(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID)) {
+            Optional<String> optionalServiceProviderUUID = Utils.resolveServiceProviderUUID(properties);
+            optionalServiceProviderUUID.ifPresent(s ->
+                    properties.put(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID, s));
+        }
         Event identityMgtEvent = new Event(eventName, properties);
         try {
             IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -103,6 +103,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -2098,5 +2099,20 @@ public class Utils {
     public static FlowConfigDTO getFlowConfig(String flowType, String tenantDomain) throws FlowMgtServerException {
 
         return FlowMgtConfigUtils.getFlowConfig(flowType, tenantDomain);
+    }
+
+    /**
+     * Resolve the service provider uuid from the properties.
+     *
+     * @param properties Map of properties.
+     * @return Service provider uuid if exists, empty otherwise.
+     */
+    public static Optional<String> resolveServiceProviderUUID(Map<String, ?> properties) {
+
+        if (MapUtils.isEmpty(properties) || !properties.containsKey(IdentityRecoveryConstants.SERVICE_PROVIDER_ID)) {
+            return Optional.empty();
+        }
+        Object value = properties.get(IdentityRecoveryConstants.SERVICE_PROVIDER_ID);
+        return Optional.ofNullable(value instanceof String ? (String) value : null);
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/FlowRegistrationCompletionHandlerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/handler/FlowRegistrationCompletionHandlerTest.java
@@ -302,7 +302,9 @@ public class FlowRegistrationCompletionHandlerTest {
         selfRegistrationUtilsMockedStatic.when(() -> SelfRegistrationUtils.triggerNotification(
                 any(User.class), anyString(), anyString(), any(), anyString())).thenAnswer(invocation -> null);
         selfRegistrationUtilsMockedStatic.when(() -> SelfRegistrationUtils.triggerAccountCreationNotification(
-                anyString(), anyString(), anyString())).thenAnswer(invocation -> null);
+                anyString(), anyString(), anyString(),
+                any(org.wso2.carbon.identity.recovery.model.Property[].class)))
+                .thenAnswer(invocation -> null);
         selfRegistrationUtilsMockedStatic.when(() -> SelfRegistrationUtils.lockUserAccount(
                 any(Boolean.class), any(Boolean.class), anyString(), any(UserStoreManager.class), anyString()))
                 .thenAnswer(invocation -> null);
@@ -463,7 +465,8 @@ public class FlowRegistrationCompletionHandlerTest {
 
         // Verify account creation notification is triggered
         selfRegistrationUtilsMockedStatic.verify(() -> SelfRegistrationUtils.triggerAccountCreationNotification(
-                USER_NAME, TENANT_DOMAIN, DOMAIN_NAME), times(1));
+                eq(USER_NAME), eq(TENANT_DOMAIN), eq(DOMAIN_NAME),
+                any(org.wso2.carbon.identity.recovery.model.Property[].class)), times(1));
     }
 
     @Test
@@ -688,7 +691,8 @@ public class FlowRegistrationCompletionHandlerTest {
 
         // Verify account creation notification is triggered.
         selfRegistrationUtilsMockedStatic.verify(() -> SelfRegistrationUtils.triggerAccountCreationNotification(
-                USER_NAME, TENANT_DOMAIN, DOMAIN_NAME), times(1));
+                eq(USER_NAME), eq(TENANT_DOMAIN), eq(DOMAIN_NAME),
+                any(org.wso2.carbon.identity.recovery.model.Property[].class)), times(1));
     }
 
     @Test
@@ -772,7 +776,8 @@ public class FlowRegistrationCompletionHandlerTest {
 
         // Verify account creation notification is sent
         selfRegistrationUtilsMockedStatic.verify(() -> SelfRegistrationUtils.triggerAccountCreationNotification(
-                USER_NAME, TENANT_DOMAIN, DOMAIN_NAME), times(1));
+                eq(USER_NAME), eq(TENANT_DOMAIN), eq(DOMAIN_NAME),
+                any(org.wso2.carbon.identity.recovery.model.Property[].class)), times(1));
     }
 }
 

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/util/UtilsTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/util/UtilsTest.java
@@ -91,6 +91,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.util.Collections.emptyMap;
 import static junit.framework.Assert.fail;
@@ -1542,6 +1543,67 @@ public class UtilsTest {
 
         String result = Utils.getUserClaim(userStoreManager, user, claimUri);
         assertNull(result);
+    }
+
+    @Test
+    public void testResolveServiceProviderUUIDWithValidStringValue() {
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(IdentityRecoveryConstants.SERVICE_PROVIDER_ID, "test-sp-uuid");
+
+        Optional<String> result = Utils.resolveServiceProviderUUID(properties);
+
+        assertTrue(result.isPresent());
+        assertEquals(result.get(), "test-sp-uuid");
+    }
+
+    @Test
+    public void testResolveServiceProviderUUIDWithNullMap() {
+
+        Optional<String> result = Utils.resolveServiceProviderUUID(null);
+
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void testResolveServiceProviderUUIDWithEmptyMap() {
+
+        Optional<String> result = Utils.resolveServiceProviderUUID(new HashMap<>());
+
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void testResolveServiceProviderUUIDWithMissingKey() {
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("someOtherKey", "someValue");
+
+        Optional<String> result = Utils.resolveServiceProviderUUID(properties);
+
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void testResolveServiceProviderUUIDWithNullValue() {
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(IdentityRecoveryConstants.SERVICE_PROVIDER_ID, null);
+
+        Optional<String> result = Utils.resolveServiceProviderUUID(properties);
+
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void testResolveServiceProviderUUIDWithNonStringValue() {
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(IdentityRecoveryConstants.SERVICE_PROVIDER_ID, 12345);
+
+        Optional<String> result = Utils.resolveServiceProviderUUID(properties);
+
+        assertFalse(result.isPresent());
     }
 
     @Test(description = "Test getUserClaim() throws IdentityEventException when the user‑store lookup fails",


### PR DESCRIPTION
Related Issues:

- [x] https://github.com/wso2/product-is/issues/27039

This pull request enhances the notification handling in the identity recovery module by ensuring that the Service Provider UUID is consistently included in notification events. It introduces utility methods and refactors several notification triggers to support this functionality, improving traceability and integration with service providers.

**Notification event improvements:**

* Added logic to check for and include the Service Provider UUID (`SERVICE_PROVIDER_UUID`) in notification event properties across multiple managers and handlers, using the new `Utils.resolveServiceProviderUUID` method. This ensures that notifications are always associated with the correct service provider, improving event traceability. [[1]](diffhunk://#diff-af832e94e9b9d4cbb48b30eacdcf522aabaf00cd0647e297a93f9f5258f25facR325-R330) [[2]](diffhunk://#diff-8a0d606a915a355053e3ac3ab16564269874a60d46fa5bf2cee7591fceca8658R309-R313) [[3]](diffhunk://#diff-ea91581b02e03d5b073f694e824efefb2217804ed39aa6b7daa37c41c60538eaR382-R386) [[4]](diffhunk://#diff-05dbb6c8b02d068ab855408e0a25293c9f2a760c1ad9c008e08c05f5198b1c5dR1191-R1196) [[5]](diffhunk://#diff-2d6464e51a37ccddbc57324c279309b49e5f4a211bbad5932080fc9670118aa7R2368-R2372) [[6]](diffhunk://#diff-94a16a5c90fb33be919e377514056917909be3834c2ab3fa95fa238b875a58a0R207-R216)
* Refactored several notification trigger methods to accept and propagate additional properties, enabling more flexible event construction and supporting the inclusion of service provider details. [[1]](diffhunk://#diff-2d6464e51a37ccddbc57324c279309b49e5f4a211bbad5932080fc9670118aa7L747-R748) [[2]](diffhunk://#diff-2d6464e51a37ccddbc57324c279309b49e5f4a211bbad5932080fc9670118aa7L2352-R2354) [[3]](diffhunk://#diff-94a16a5c90fb33be919e377514056917909be3834c2ab3fa95fa238b875a58a0R171-R186)

**API and method signature changes:**

* Updated the signature of `SelfRegistrationUtils.triggerAccountCreationNotification` to accept an optional `Property[]` for event properties, and updated related calls to pass arbitrary properties as needed. [[1]](diffhunk://#diff-d89a9240e6d2d4dd3acf46ec3c4667eada01742a3187a5f828564b820dd86c8eL176-R176) [[2]](diffhunk://#diff-8a0d606a915a355053e3ac3ab16564269874a60d46fa5bf2cee7591fceca8658L162-R163) [[3]](diffhunk://#diff-94a16a5c90fb33be919e377514056917909be3834c2ab3fa95fa238b875a58a0R171-R186)

**Flow completion and listener enhancements:**

* Modified notification handling in `FlowCompletionListener` to accept and forward the service provider UUID, ensuring it is included in relevant events. [[1]](diffhunk://#diff-83d5c40f275a94ba7e316371cb16bf55a75e0ad5adae441d147b0fc633f742c2L263-R263) [[2]](diffhunk://#diff-83d5c40f275a94ba7e316371cb16bf55a75e0ad5adae441d147b0fc633f742c2L331-R332) [[3]](diffhunk://#diff-83d5c40f275a94ba7e316371cb16bf55a75e0ad5adae441d147b0fc633f742c2L471-R472) [[4]](diffhunk://#diff-83d5c40f275a94ba7e316371cb16bf55a75e0ad5adae441d147b0fc633f742c2L481-R482) [[5]](diffhunk://#diff-83d5c40f275a94ba7e316371cb16bf55a75e0ad5adae441d147b0fc633f742c2L490-R491) [[6]](diffhunk://#diff-83d5c40f275a94ba7e316371cb16bf55a75e0ad5adae441d147b0fc633f742c2R502-R504)

**Constants and imports:**

* Added a new constant `SERVICE_PROVIDER_ID` to `IdentityRecoveryConstants` and updated imports to support new functionality. [[1]](diffhunk://#diff-3040477809cbb5d4423ab760bacc6699f38ac48ad66cf64e7612cb5f1fd4176dR254-R256) [[2]](diffhunk://#diff-af832e94e9b9d4cbb48b30eacdcf522aabaf00cd0647e297a93f9f5258f25facR61) [[3]](diffhunk://#diff-8a0d606a915a355053e3ac3ab16564269874a60d46fa5bf2cee7591fceca8658R58) [[4]](diffhunk://#diff-ea91581b02e03d5b073f694e824efefb2217804ed39aa6b7daa37c41c60538eaR63) [[5]](diffhunk://#diff-05dbb6c8b02d068ab855408e0a25293c9f2a760c1ad9c008e08c05f5198b1c5dR79) [[6]](diffhunk://#diff-2d6464e51a37ccddbc57324c279309b49e5f4a211bbad5932080fc9670118aa7R117) [[7]](diffhunk://#diff-94a16a5c90fb33be919e377514056917909be3834c2ab3fa95fa238b875a58a0R51)

These changes collectively improve the robustness and extensibility of notification handling in the identity recovery process, making it easier to track and attribute actions to the correct service provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Enhanced identity recovery notifications to automatically include service provider identifiers across self-registration, password recovery, and account creation flows.

## Tests
* Added comprehensive unit tests for service provider UUID resolution utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->