### PR TITLE
[master] Allow resend-code to regenerate confirmation code for SELF_SIGN_UP when recovery data is absent

### DIFF
--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImpl.java
@@ -191,22 +191,11 @@ public class ResendCodeApiServiceImpl extends ResendCodeApiService {
             } else if (RecoveryScenarios.SELF_SIGN_UP.toString().equals(recoveryScenario)
                     && (isUserInPendingSelfRegistrationState(resendCodeRequestDTO.getUser())
                             || isUserInPendingEmailVerificationState(resendCodeRequestDTO.getUser()))) {
-                String notificationType = IdentityRecoveryConstants.NOTIFICATION_TYPE_RESEND_ACCOUNT_CONFIRM;
-                try {
-                    boolean isSelfRegistrationEmailOTPEnabled = Boolean.parseBoolean(Utils.getSignUpConfigs(
-                            IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_EMAIL_OTP_ENABLE,
-                            resendCodeRequestDTO.getUser().getTenantDomain()));
-                    if (isSelfRegistrationEmailOTPEnabled) {
-                        notificationType = IdentityRecoveryConstants.NOTIFICATION_TYPE_ACCOUNT_CONFIRM_EMAIL_OTP;
-                    }
-                } catch (IdentityRecoveryException e) {
-                    LOG.error("Error while getting self registration send OTP in email configuration", e);
-                }
                 resendConfirmationManager = Utils.getResendConfirmationManager();
                 notificationResponseBean = setNotificationResponseBean(resendConfirmationManager,
                         RecoveryScenarios.SELF_SIGN_UP.toString(),
                         RecoverySteps.CONFIRM_SIGN_UP.toString(),
-                        notificationType,
+                        IdentityRecoveryConstants.NOTIFICATION_TYPE_RESEND_ACCOUNT_CONFIRM,
                         resendCodeRequestDTO);
             }
 

--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImpl.java
@@ -191,11 +191,22 @@ public class ResendCodeApiServiceImpl extends ResendCodeApiService {
             } else if (RecoveryScenarios.SELF_SIGN_UP.toString().equals(recoveryScenario)
                     && (isUserInPendingSelfRegistrationState(resendCodeRequestDTO.getUser())
                             || isUserInPendingEmailVerificationState(resendCodeRequestDTO.getUser()))) {
+                String notificationType = IdentityRecoveryConstants.NOTIFICATION_TYPE_RESEND_ACCOUNT_CONFIRM;
+                try {
+                    boolean isSelfRegistrationEmailOTPEnabled = Boolean.parseBoolean(Utils.getSignUpConfigs(
+                            IdentityRecoveryConstants.ConnectorConfig.SELF_REGISTRATION_EMAIL_OTP_ENABLE,
+                            resendCodeRequestDTO.getUser().getTenantDomain()));
+                    if (isSelfRegistrationEmailOTPEnabled) {
+                        notificationType = IdentityRecoveryConstants.NOTIFICATION_TYPE_ACCOUNT_CONFIRM_EMAIL_OTP;
+                    }
+                } catch (IdentityRecoveryException e) {
+                    LOG.error("Error while getting self registration send OTP in email configuration", e);
+                }
                 resendConfirmationManager = Utils.getResendConfirmationManager();
                 notificationResponseBean = setNotificationResponseBean(resendConfirmationManager,
                         RecoveryScenarios.SELF_SIGN_UP.toString(),
                         RecoverySteps.CONFIRM_SIGN_UP.toString(),
-                        IdentityRecoveryConstants.NOTIFICATION_TYPE_RESEND_ACCOUNT_CONFIRM,
+                        notificationType,
                         resendCodeRequestDTO);
             }
 

--- a/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/main/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImpl.java
@@ -188,6 +188,15 @@ public class ResendCodeApiServiceImpl extends ResendCodeApiService {
                         RecoverySteps.CONFIRM_PENDING_EMAIL_VERIFICATION.toString(),
                         IdentityRecoveryConstants.NOTIFICATION_TYPE_EMAIL_CONFIRM_OTP,
                         resendCodeRequestDTO);
+            } else if (RecoveryScenarios.SELF_SIGN_UP.toString().equals(recoveryScenario)
+                    && (isUserInPendingSelfRegistrationState(resendCodeRequestDTO.getUser())
+                            || isUserInPendingEmailVerificationState(resendCodeRequestDTO.getUser()))) {
+                resendConfirmationManager = Utils.getResendConfirmationManager();
+                notificationResponseBean = setNotificationResponseBean(resendConfirmationManager,
+                        RecoveryScenarios.SELF_SIGN_UP.toString(),
+                        RecoverySteps.CONFIRM_SIGN_UP.toString(),
+                        IdentityRecoveryConstants.NOTIFICATION_TYPE_RESEND_ACCOUNT_CONFIRM,
+                        resendCodeRequestDTO);
             }
 
             return notificationResponseBean;
@@ -436,6 +445,22 @@ public class ResendCodeApiServiceImpl extends ResendCodeApiService {
             return false;
         }
         return IdentityRecoveryConstants.PENDING_ASK_PASSWORD.equals(accountState);
+    }
+
+    /**
+     * Determines if a user's account is in a state where they need to complete self-registration.
+     *
+     * @param user User object containing user information.
+     * @return true if the user is in pending self-registration state, false otherwise.
+     */
+    private boolean isUserInPendingSelfRegistrationState(UserDTO user) {
+
+        String domainQualifiedUsername = UserCoreUtil.addDomainToName(user.getUsername(), user.getRealm());
+        String accountState = Utils.getAccountState(domainQualifiedUsername, user.getTenantDomain());
+        if (StringUtils.isBlank(accountState)) {
+            return false;
+        }
+        return IdentityRecoveryConstants.PENDING_SELF_REGISTRATION.equals(accountState);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.api.user.governance/src/test/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.api.user.governance/src/test/java/org/wso2/carbon/identity/user/endpoint/impl/ResendCodeApiServiceImplTest.java
@@ -243,6 +243,81 @@ public class ResendCodeApiServiceImplTest {
                 any());
     }
 
+    @Test (description = "Test resendCodePost when recovery scenario is SELF_SIGN_UP, user is in " +
+            "PENDING_SELF_REGISTRATION state, and no userRecoveryData exists.")
+    public void testResendCodePostForSelfSignUpWithoutRecoveryDataAndPendingSelfRegistration() throws Exception {
+
+        ResendCodeRequestDTO requestDTO = createResendCodeRequestDTO(RecoveryScenarios.SELF_SIGN_UP.name());
+
+        mockedUtils.when(() -> Utils.getUserRecoveryData(any(), anyString())).thenReturn(null);
+        mockedUtils.when(() -> Utils.getAccountState(anyString(), anyString()))
+                .thenReturn(IdentityRecoveryConstants.PENDING_SELF_REGISTRATION);
+        mockedUtils.when(Utils::getResendConfirmationManager).thenReturn(resendConfirmationManager);
+
+        when(resendConfirmationManager.resendConfirmationCode(
+                any(), anyString(), anyString(), anyString(), any()))
+                .thenReturn(new NotificationResponseBean(createUser()));
+
+        Response response = resendCodeApiService.resendCodePost(requestDTO);
+
+        assertNotNull(response);
+        assertEquals(response.getStatus(), 201);
+
+        verify(resendConfirmationManager).resendConfirmationCode(
+                any(),
+                eq(RecoveryScenarios.SELF_SIGN_UP.toString()),
+                eq(RecoverySteps.CONFIRM_SIGN_UP.toString()),
+                eq(IdentityRecoveryConstants.NOTIFICATION_TYPE_RESEND_ACCOUNT_CONFIRM),
+                any());
+    }
+
+    @Test (description = "Test resendCodePost when recovery scenario is SELF_SIGN_UP, user is in " +
+            "PENDING_EMAIL_VERIFICATION state, and no userRecoveryData exists.")
+    public void testResendCodePostForSelfSignUpWithoutRecoveryDataAndPendingEmailVerification() throws Exception {
+
+        ResendCodeRequestDTO requestDTO = createResendCodeRequestDTO(RecoveryScenarios.SELF_SIGN_UP.name());
+
+        mockedUtils.when(() -> Utils.getUserRecoveryData(any(), anyString())).thenReturn(null);
+        mockedUtils.when(() -> Utils.getAccountState(anyString(), anyString()))
+                .thenReturn(IdentityRecoveryConstants.PENDING_EMAIL_VERIFICATION);
+        mockedUtils.when(Utils::getResendConfirmationManager).thenReturn(resendConfirmationManager);
+
+        when(resendConfirmationManager.resendConfirmationCode(
+                any(), anyString(), anyString(), anyString(), any()))
+                .thenReturn(new NotificationResponseBean(createUser()));
+
+        Response response = resendCodeApiService.resendCodePost(requestDTO);
+
+        assertNotNull(response);
+        assertEquals(response.getStatus(), 201);
+
+        verify(resendConfirmationManager).resendConfirmationCode(
+                any(),
+                eq(RecoveryScenarios.SELF_SIGN_UP.toString()),
+                eq(RecoverySteps.CONFIRM_SIGN_UP.toString()),
+                eq(IdentityRecoveryConstants.NOTIFICATION_TYPE_RESEND_ACCOUNT_CONFIRM),
+                any());
+    }
+
+    @Test (description = "Test resendCodePost when recovery scenario is SELF_SIGN_UP, no userRecoveryData " +
+            "exists, and user is NOT in a pending self-registration state — should return 400.")
+    public void testResendCodePostForSelfSignUpWithoutRecoveryDataAndNoMatchingPendingState() throws Exception {
+
+        ResendCodeRequestDTO requestDTO = createResendCodeRequestDTO(RecoveryScenarios.SELF_SIGN_UP.name());
+
+        mockedUtils.when(() -> Utils.getUserRecoveryData(any(), anyString())).thenReturn(null);
+        mockedUtils.when(() -> Utils.getAccountState(anyString(), anyString()))
+                .thenReturn(IdentityRecoveryConstants.PENDING_ASK_PASSWORD);
+
+        Response response = resendCodeApiService.resendCodePost(requestDTO);
+
+        assertNotNull(response);
+        assertEquals(response.getStatus(), 400);
+
+        verify(resendConfirmationManager, Mockito.never()).resendConfirmationCode(
+                any(), anyString(), anyString(), anyString(), any());
+    }
+
     private ResendCodeRequestDTO resendCodeRequestDTO() {
 
         ResendCodeRequestDTO resendCodeRequestDTO = new ResendCodeRequestDTO();

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
@@ -887,15 +887,6 @@ public class ResendConfirmationManager {
                 .equals(RecoveryScenarios.getRecoveryScenario(recoveryScenario))) && isPendingEmailVerificationState;
     }
 
-    /**
-     * Checks whether the given recovery scenario is a SELF_SIGN_UP flow for a user in a pending
-     * self-registration or email-verification state (i.e., no prior recovery data row exists).
-     *
-     * @param recoveryScenario Recovery scenario name
-     * @param user             User object
-     * @return true if the scenario is SELF_SIGN_UP and the account is in a pending sign-up state
-     * @throws IdentityRecoveryClientException If retrieving the account state fails
-     */
     private boolean isSelfSignUpFlow(String recoveryScenario, User user) throws IdentityRecoveryClientException {
 
         boolean isPendingSelfSignUpState = false;

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
@@ -536,7 +536,8 @@ public class ResendConfirmationManager {
         List<Property> propertyList = new ArrayList<>(Arrays.asList(properties));
 
         if (userRecoveryData == null &&
-                (isAskPasswordFlow(recoveryScenario, user) || isEmailVerificationFlow(recoveryScenario, user))) {
+                (isAskPasswordFlow(recoveryScenario, user) || isEmailVerificationFlow(recoveryScenario, user)
+                        || isSelfSignUpFlow(recoveryScenario, user))) {
             storedNotificationChannel = NotificationChannels.EMAIL_CHANNEL.getChannelType();
         } else if (!RecoveryScenarios.LITE_SIGN_UP.toString().equals(recoveryScenario)) {
             // Validate the previous confirmation code with the data retrieved by the user recovery information.
@@ -884,5 +885,18 @@ public class ResendConfirmationManager {
         return (RecoveryScenarios.EMAIL_VERIFICATION.equals(RecoveryScenarios.getRecoveryScenario(recoveryScenario))
                 || RecoveryScenarios.EMAIL_VERIFICATION_OTP
                 .equals(RecoveryScenarios.getRecoveryScenario(recoveryScenario))) && isPendingEmailVerificationState;
+    }
+
+    private boolean isSelfSignUpFlow(String recoveryScenario, User user) throws IdentityRecoveryClientException {
+
+        boolean isPendingSelfSignUpState = false;
+        String accountState = Utils.getAccountStateForUserNameWithoutUserDomain(user);
+        if (StringUtils.isNotBlank(accountState)) {
+            isPendingSelfSignUpState = IdentityRecoveryConstants.PENDING_SELF_REGISTRATION.equals(accountState)
+                    || IdentityRecoveryConstants.PENDING_EMAIL_VERIFICATION.equals(accountState);
+        }
+
+        return RecoveryScenarios.SELF_SIGN_UP.equals(RecoveryScenarios.getRecoveryScenario(recoveryScenario))
+                && isPendingSelfSignUpState;
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
@@ -889,14 +889,14 @@ public class ResendConfirmationManager {
 
     private boolean isSelfSignUpFlow(String recoveryScenario, User user) throws IdentityRecoveryClientException {
 
-        boolean isPendingSelfSignUpState = false;
-        String accountState = Utils.getAccountStateForUserNameWithoutUserDomain(user);
-        if (StringUtils.isNotBlank(accountState)) {
-            isPendingSelfSignUpState = IdentityRecoveryConstants.PENDING_SELF_REGISTRATION.equals(accountState)
-                    || IdentityRecoveryConstants.PENDING_EMAIL_VERIFICATION.equals(accountState);
+        if (!RecoveryScenarios.SELF_SIGN_UP.equals(RecoveryScenarios.getRecoveryScenario(recoveryScenario))) {
+            return false;
         }
-
-        return RecoveryScenarios.SELF_SIGN_UP.equals(RecoveryScenarios.getRecoveryScenario(recoveryScenario))
-                && isPendingSelfSignUpState;
+        String accountState = Utils.getAccountStateForUserNameWithoutUserDomain(user);
+        if (StringUtils.isBlank(accountState)) {
+            return false;
+        }
+        return IdentityRecoveryConstants.PENDING_SELF_REGISTRATION.equals(accountState)
+                || IdentityRecoveryConstants.PENDING_EMAIL_VERIFICATION.equals(accountState);
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManager.java
@@ -887,6 +887,15 @@ public class ResendConfirmationManager {
                 .equals(RecoveryScenarios.getRecoveryScenario(recoveryScenario))) && isPendingEmailVerificationState;
     }
 
+    /**
+     * Checks whether the given recovery scenario is a SELF_SIGN_UP flow for a user in a pending
+     * self-registration or email-verification state (i.e., no prior recovery data row exists).
+     *
+     * @param recoveryScenario Recovery scenario name
+     * @param user             User object
+     * @return true if the scenario is SELF_SIGN_UP and the account is in a pending sign-up state
+     * @throws IdentityRecoveryClientException If retrieving the account state fails
+     */
     private boolean isSelfSignUpFlow(String recoveryScenario, User user) throws IdentityRecoveryClientException {
 
         boolean isPendingSelfSignUpState = false;

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/confirmation/ResendConfirmationManagerTest.java
@@ -1001,6 +1001,136 @@ public class ResendConfirmationManagerTest {
         assertEquals(eventProperties.get(IdentityRecoveryConstants.SEND_TO), mobileNumber);
     }
 
+    @Test (description = "Test resend confirmation code for SELF_SIGN_UP scenario when recovery data is missing " +
+            "and the user is in pending self-registration state.")
+    public void testResendConfirmationCodeSelfSignUpWhenNoRecoveryDataAndPendingSelfRegistration() throws Exception {
+
+        User user = getUser();
+        Property[] properties = new Property[]{new Property("testKey", "testValue")};
+        String newCode = "new-code";
+
+        when(userRecoveryDataStore.loadWithoutCodeExpiryValidation(user,
+                RecoveryScenarios.SELF_SIGN_UP)).thenReturn(null);
+
+        mockedUtils.when(() -> Utils.getAccountStateForUserNameWithoutUserDomain(user))
+                .thenReturn(IdentityRecoveryConstants.PENDING_SELF_REGISTRATION);
+        mockedUtils.when(() -> Utils.generateSecretKey(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(newCode);
+        mockedUtils.when(() -> Utils.getSignUpConfigs(
+                IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
+                TEST_TENANT_DOMAIN)).thenReturn("true");
+
+        // Call the method to test.
+        NotificationResponseBean responseBean = resendConfirmationManager.resendConfirmationCode(
+                user,
+                RecoveryScenarios.SELF_SIGN_UP.toString(),
+                RecoverySteps.CONFIRM_SIGN_UP.toString(),
+                IdentityRecoveryConstants.NOTIFICATION_TYPE_RESEND_ACCOUNT_CONFIRM,
+                properties);
+
+        // Verify the response.
+        assertNotNull(responseBean);
+        assertEquals(NotificationChannels.EMAIL_CHANNEL.getChannelType(), responseBean.getNotificationChannel());
+
+        // Verify UserRecoveryData was stored properly.
+        ArgumentCaptor<UserRecoveryData> recoveryDataCaptor = ArgumentCaptor.forClass(UserRecoveryData.class);
+        verify(userRecoveryDataStore).store(recoveryDataCaptor.capture());
+        UserRecoveryData capturedRecoveryData = recoveryDataCaptor.getValue();
+
+        assertEquals(capturedRecoveryData.getRecoveryScenario(), RecoveryScenarios.SELF_SIGN_UP);
+        assertEquals(capturedRecoveryData.getRecoveryStep(), RecoverySteps.CONFIRM_SIGN_UP);
+        assertEquals(NotificationChannels.EMAIL_CHANNEL.getChannelType(), capturedRecoveryData.getRemainingSetIds());
+        assertEquals(capturedRecoveryData.getSecret(), newCode);
+
+        // Verify notification was triggered.
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(identityEventService).handleEvent(eventCaptor.capture());
+        Event capturedEvent = eventCaptor.getValue();
+        Map<String, Object> eventProperties = capturedEvent.getEventProperties();
+        assertEquals(eventProperties.get(IdentityRecoveryConstants.CONFIRMATION_CODE), newCode);
+        assertEquals(eventProperties.get(IdentityRecoveryConstants.TEMPLATE_TYPE),
+                IdentityRecoveryConstants.NOTIFICATION_TYPE_RESEND_ACCOUNT_CONFIRM);
+    }
+
+    @Test (description = "Test resend confirmation code for SELF_SIGN_UP scenario when recovery data is missing " +
+            "and the user is in pending email verification state.")
+    public void testResendConfirmationCodeSelfSignUpWhenNoRecoveryDataAndPendingEmailVerification() throws Exception {
+
+        User user = getUser();
+        Property[] properties = new Property[]{new Property("testKey", "testValue")};
+        String newCode = "new-code";
+
+        when(userRecoveryDataStore.loadWithoutCodeExpiryValidation(user,
+                RecoveryScenarios.SELF_SIGN_UP)).thenReturn(null);
+
+        mockedUtils.when(() -> Utils.getAccountStateForUserNameWithoutUserDomain(user))
+                .thenReturn(IdentityRecoveryConstants.PENDING_EMAIL_VERIFICATION);
+        mockedUtils.when(() -> Utils.generateSecretKey(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(newCode);
+        mockedUtils.when(() -> Utils.getSignUpConfigs(
+                IdentityRecoveryConstants.ConnectorConfig.SIGN_UP_NOTIFICATION_INTERNALLY_MANAGE,
+                TEST_TENANT_DOMAIN)).thenReturn("true");
+
+        // Call the method to test.
+        NotificationResponseBean responseBean = resendConfirmationManager.resendConfirmationCode(
+                user,
+                RecoveryScenarios.SELF_SIGN_UP.toString(),
+                RecoverySteps.CONFIRM_SIGN_UP.toString(),
+                IdentityRecoveryConstants.NOTIFICATION_TYPE_RESEND_ACCOUNT_CONFIRM,
+                properties);
+
+        // Verify the response.
+        assertNotNull(responseBean);
+        assertEquals(NotificationChannels.EMAIL_CHANNEL.getChannelType(), responseBean.getNotificationChannel());
+
+        // Verify UserRecoveryData was stored properly.
+        ArgumentCaptor<UserRecoveryData> recoveryDataCaptor = ArgumentCaptor.forClass(UserRecoveryData.class);
+        verify(userRecoveryDataStore).store(recoveryDataCaptor.capture());
+        UserRecoveryData capturedRecoveryData = recoveryDataCaptor.getValue();
+
+        assertEquals(capturedRecoveryData.getRecoveryScenario(), RecoveryScenarios.SELF_SIGN_UP);
+        assertEquals(capturedRecoveryData.getRecoveryStep(), RecoverySteps.CONFIRM_SIGN_UP);
+        assertEquals(NotificationChannels.EMAIL_CHANNEL.getChannelType(), capturedRecoveryData.getRemainingSetIds());
+        assertEquals(capturedRecoveryData.getSecret(), newCode);
+
+        // Verify notification was triggered.
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(identityEventService).handleEvent(eventCaptor.capture());
+        Event capturedEvent = eventCaptor.getValue();
+        Map<String, Object> eventProperties = capturedEvent.getEventProperties();
+        assertEquals(eventProperties.get(IdentityRecoveryConstants.CONFIRMATION_CODE), newCode);
+        assertEquals(eventProperties.get(IdentityRecoveryConstants.TEMPLATE_TYPE),
+                IdentityRecoveryConstants.NOTIFICATION_TYPE_RESEND_ACCOUNT_CONFIRM);
+    }
+
+    @Test (description = "Test that isSelfSignUpFlow checks the scenario before fetching account state — " +
+            "non-SELF_SIGN_UP scenario with PENDING_SELF_REGISTRATION state must throw OLD_CODE_NOT_FOUND.")
+    public void testResendConfirmationCodeNonSelfSignUpScenarioWithPendingStateThrows() throws Exception {
+
+        User user = getUser();
+        Property[] properties = new Property[]{};
+
+        when(userRecoveryDataStore.loadWithoutCodeExpiryValidation(user,
+                RecoveryScenarios.NOTIFICATION_BASED_PW_RECOVERY)).thenReturn(null);
+        mockedUtils.when(() -> Utils.getAccountStateForUserNameWithoutUserDomain(user))
+                .thenReturn(IdentityRecoveryConstants.PENDING_SELF_REGISTRATION);
+        mockUtilsErrors();
+
+        try {
+            resendConfirmationManager.resendConfirmationCode(
+                    user,
+                    RecoveryScenarios.NOTIFICATION_BASED_PW_RECOVERY.toString(),
+                    RecoverySteps.UPDATE_PASSWORD.toString(),
+                    IdentityRecoveryConstants.NOTIFICATION_TYPE_RESEND_PASSWORD_RESET,
+                    properties);
+            fail("Expected IdentityRecoveryClientException for null recovery data on non-SELF_SIGN_UP scenario.");
+        } catch (IdentityRecoveryClientException e) {
+            assertNotNull(e);
+        } catch (IdentityRecoveryException e) {
+            fail("Expected a client exception but got: " + e.getMessage());
+        }
+    }
+
     private static User getUser() {
 
         User user = new User();


### PR DESCRIPTION
## Root cause and fix

- The `resend-code` API (`/api/identity/user/v1.0/resend-code`) fails with HTTP 400 `"User recovery data is not found. Please re-initiate the recovery flow."` when no row exists in `IDN_RECOVERY_DATA` for the user (e.g. after a confirmation-code cleanup script runs or during interrupted self-signup flows). This was already fixed for `ASK_PASSWORD` and `EMAIL_VERIFICATION` scenarios on master; `SELF_SIGN_UP` was the remaining gap.
- Added SELF_SIGN_UP to the null-recovery-data bypass in `ResendCodeApiServiceImpl.doResendConfirmationCode`: when recovery data is absent and the user's account state is `PENDING_SR` or `PENDING_EV`, a fresh confirmation code is minted and the notification re-sent — matching the behaviour already in place for ask-password and email-verification flows.
- Extended `ResendConfirmationManager.resendAccountRecoveryNotification` to include a new `isSelfSignUpFlow()` check in the null-recovery-data condition so it defaults to EMAIL channel rather than throwing `OLD_CODE_NOT_FOUND`.

## Related

- https://github.com/wso2/product-is/issues/27799

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Users in pending self-registration or email verification states can now successfully resend confirmation codes.
* Self-signup recovery flow now correctly defaults to email notifications when recovery data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->