### PR TITLE
Add support for the captcha filter to skip captcha validation for console application with a configuration

### DIFF
--- a/components/org.wso2.carbon.identity.captcha/pom.xml
+++ b/components/org.wso2.carbon.identity.captcha/pom.xml
@@ -118,6 +118,14 @@
             <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
@@ -190,6 +198,8 @@
                             org.wso2.carbon.identity.event.handler; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.event.services; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.event.bean; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.mgt; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.common; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.governance.*;
                             version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.user.core.*; version="${carbon.kernel.package.import.version.range}",

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/filter/CaptchaFilter.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/filter/CaptchaFilter.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2026, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -30,9 +30,11 @@ import org.wso2.carbon.identity.captcha.connector.CaptchaPreValidationResponse;
 import org.wso2.carbon.identity.captcha.exception.CaptchaClientException;
 import org.wso2.carbon.identity.captcha.exception.CaptchaException;
 import org.wso2.carbon.identity.captcha.internal.CaptchaDataHolder;
+import org.wso2.carbon.identity.captcha.util.CaptchaConstants;
 import org.wso2.carbon.identity.captcha.util.CaptchaHttpServletRequestWrapper;
 import org.wso2.carbon.identity.captcha.util.CaptchaHttpServletResponseWrapper;
 import org.wso2.carbon.identity.captcha.util.CaptchaUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.io.IOException;
 import java.util.List;
@@ -52,6 +54,7 @@ import javax.servlet.http.HttpServletResponse;
 public class CaptchaFilter implements Filter {
 
     private static final Log log = LogFactory.getLog(CaptchaFilter.class);
+    private static final String COMMON_AUTH_REQUEST_URI = "/commonauth";
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
@@ -68,7 +71,8 @@ public class CaptchaFilter implements Filter {
 
         try {
 
-            if (!CaptchaDataHolder.getInstance().isReCaptchaEnabled()) {
+            if (!CaptchaDataHolder.getInstance().isReCaptchaEnabled() ||
+                    isCaptchaDisabledForConsoleLogin(servletRequest)) {
                 filterChain.doFilter(servletRequest, servletResponse);
                 return;
             }
@@ -197,10 +201,54 @@ public class CaptchaFilter implements Filter {
     private void doFilter(CaptchaPreValidationResponse preValidationResponse, ServletRequest servletRequest,
                           ServletResponse servletResponse, FilterChain filterChain)
             throws IOException, ServletException {
-        if(preValidationResponse.getWrappedHttpServletRequest() != null) {
+        if (preValidationResponse.getWrappedHttpServletRequest() != null) {
             filterChain.doFilter(preValidationResponse.getWrappedHttpServletRequest(), servletResponse);
         } else {
             filterChain.doFilter(servletRequest, servletResponse);
         }
+    }
+
+    private boolean isCaptchaDisabledForConsoleLogin(ServletRequest servletRequest) {
+
+        if (!Boolean.parseBoolean(IdentityUtil.getProperty(CaptchaConstants.DISABLE_CAPTCHA_FOR_CONSOLE_LOGIN))) {
+            if (log.isDebugEnabled()) {
+                log.debug(CaptchaConstants.DISABLE_CAPTCHA_FOR_CONSOLE_LOGIN + " property is not enabled.");
+            }
+            return false;
+        }
+
+        if (!(servletRequest instanceof HttpServletRequest)) {
+            return false;
+        }
+
+        HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
+        if (!COMMON_AUTH_REQUEST_URI.equals(httpRequest.getRequestURI())) {
+            if (log.isDebugEnabled()) {
+                log.debug("Request URI: " + httpRequest.getRequestURI() + " is not a login request");
+            }
+            return false;
+        }
+
+        String sessionDataKey = servletRequest.getParameter(FrameworkUtils.SESSION_DATA_KEY);
+        if (sessionDataKey == null) {
+            return false;
+        }
+        AuthenticationContext context = FrameworkUtils.getAuthenticationContextFromCache(sessionDataKey);
+        if (context == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("Authentication context is not found in the cache for session data key: " + sessionDataKey);
+            }
+            return false;
+        }
+
+        if (context.getServiceProviderName() != null &&
+                context.getServiceProviderName().equals(CaptchaConstants.CONSOLE_APPLICATION_NAME)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Skipping captcha validation for Console application login.");
+            }
+            return true;
+        }
+
+        return false;
     }
 }

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaComponent.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaComponent.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2026, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -27,6 +27,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticationDataPublisher;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.captcha.connector.CaptchaConnector;
 import org.wso2.carbon.identity.captcha.connector.recaptcha.EmailOTPCaptchaConnector;
 import org.wso2.carbon.identity.captcha.connector.recaptcha.GenericAuthenticatorReCaptchaConnector;
@@ -214,5 +215,21 @@ public class CaptchaComponent {
     protected void unsetAccountLockService(AccountLockService accountLockService) {
 
         CaptchaDataHolder.getInstance().setAccountLockService(null);
+    }
+
+    @Reference(
+            name = "ApplicationManagementService",
+            service = org.wso2.carbon.identity.application.mgt.ApplicationManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetApplicationManagementService")
+    protected void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        CaptchaDataHolder.getInstance().setApplicationManagementService(applicationManagementService);
+    }
+
+    protected void unsetApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        CaptchaDataHolder.getInstance().setApplicationManagementService(null);
     }
 }

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaDataHolder.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/internal/CaptchaDataHolder.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2026, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.captcha.internal;
 
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.captcha.connector.CaptchaConnector;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
@@ -66,6 +67,8 @@ public class CaptchaDataHolder {
     private RealmService realmService;
 
     private AccountLockService accountLockService;
+
+    private ApplicationManagementService applicationManagementService;
 
     private List<CaptchaConnector> captchaConnectors = new ArrayList<>();
 
@@ -259,6 +262,16 @@ public class CaptchaDataHolder {
 
     public void setAccountLockService(AccountLockService accountLockService) {
         this.accountLockService = accountLockService;
+    }
+
+    public ApplicationManagementService getApplicationManagementService() {
+
+        return applicationManagementService;
+    }
+
+    public void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        this.applicationManagementService = applicationManagementService;
     }
 
     public boolean isForcefullyEnabledRecaptchaForAllTenants() {

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaConstants.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaConstants.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2026, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -69,6 +69,8 @@ public class CaptchaConstants {
 
     public static final String CAPTCHA_SUCCESS = "success";
     public static final String ENABLE_GENERIC_CAPTCHA_VALIDATION = "enable_captcha_validation";
+    public static final String DISABLE_CAPTCHA_FOR_CONSOLE_LOGIN = "Captcha.DisableForConsole.Login";
+    public static final String CONSOLE_APPLICATION_NAME = "Console";
     public static final String ENABLE_CAPTCHA_VALIDATION_FOR_LOCAL_OTP_AUTHENTICATORS
             = "Captcha.EnableCaptchaForLocalOTPAuthenticators";
     public static final String RE_CAPTCHA = "reCaptcha";

--- a/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaUtil.java
+++ b/components/org.wso2.carbon.identity.captcha/src/main/java/org/wso2/carbon/identity/captcha/util/CaptchaUtil.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2026, WSO2 LLC. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -35,6 +35,9 @@ import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.apache.hc.core5.net.URIBuilder;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.ApplicationBasicInfo;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
@@ -979,5 +982,49 @@ public class CaptchaUtil {
         failedRedirectUrls.add(ON_FAILED_LOGIN_REDIRECT_URL);
 
         return failedRedirectUrls;
+    }
+
+    /**
+     * Check whether captcha is disabled for the application.
+     * Currently, this method checks whether the captcha is disabled for the console application only.
+     *
+     * @param appId         Application ID of the application.
+     * @param tenantDomain  Tenant Domain of the application.
+     * @return True if captcha is disabled for the application, false otherwise.
+     */
+    public static boolean isCaptchaDisabledForApplication(String appId, String tenantDomain) {
+
+        if (appId == null || tenantDomain == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("Application ID or tenant domain is null. Hence returning false.");
+            }
+            return false;
+        }
+
+        if (!Boolean.parseBoolean(IdentityUtil.getProperty(CaptchaConstants.DISABLE_CAPTCHA_FOR_CONSOLE_LOGIN))) {
+            return false;
+        }
+
+        ApplicationManagementService appMgtService = CaptchaDataHolder.getInstance().getApplicationManagementService();
+        if (appMgtService == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("ApplicationManagementService is not available. Hence returning false.");
+            }
+            return false;
+        }
+
+        try {
+            ApplicationBasicInfo appInfo = appMgtService.getApplicationBasicInfoByResourceId(appId, tenantDomain);
+            if (appInfo == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Application basic info is null for app ID: " + appId + ". Hence returning false.");
+                }
+                return false;
+            }
+            return CaptchaConstants.CONSOLE_APPLICATION_NAME.equals(appInfo.getApplicationName());
+        } catch (IdentityApplicationManagementException e) {
+            log.error("Error occurred while retrieving application basic info for app ID: " + appId, e);
+            return false;
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.captcha/src/test/java/org/wso2/carbon/identity/captcha/filter/CaptchaFilterTest.java
+++ b/components/org.wso2.carbon.identity.captcha/src/test/java/org/wso2/carbon/identity/captcha/filter/CaptchaFilterTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.captcha.filter;
+
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.captcha.connector.CaptchaConnector;
+import org.wso2.carbon.identity.captcha.connector.CaptchaPreValidationResponse;
+import org.wso2.carbon.identity.captcha.exception.CaptchaException;
+import org.wso2.carbon.identity.captcha.internal.CaptchaDataHolder;
+import org.wso2.carbon.identity.captcha.util.CaptchaConstants;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+/**
+ * Unit tests for {@link CaptchaFilter}.
+ */
+public class CaptchaFilterTest {
+
+    private static final String SESSION_DATA_KEY_VALUE = "test-session-data-key";
+    private static final String COMMON_AUTH_URI = "/commonauth";
+    private static final String OTHER_URI = "/oauth2/authorize";
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @Mock
+    private CaptchaDataHolder captchaDataHolder;
+
+    @Mock
+    private CaptchaConnector captchaConnector;
+
+    @Mock
+    private CaptchaPreValidationResponse preValidationResponse;
+
+    private CaptchaFilter captchaFilter;
+    private MockedStatic<CaptchaDataHolder> captchaDataHolderStatic;
+    private MockedStatic<FrameworkUtils> frameworkUtilsStatic;
+    private MockedStatic<IdentityUtil> identityUtilStatic;
+    private AutoCloseable mocks;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        mocks = openMocks(this);
+        captchaFilter = new CaptchaFilter();
+        captchaDataHolderStatic = Mockito.mockStatic(CaptchaDataHolder.class);
+        frameworkUtilsStatic = Mockito.mockStatic(FrameworkUtils.class);
+        identityUtilStatic = Mockito.mockStatic(IdentityUtil.class);
+
+        captchaDataHolderStatic.when(CaptchaDataHolder::getInstance).thenReturn(captchaDataHolder);
+        when(captchaDataHolder.getReCaptchaRequestWrapUrls()).thenReturn("");
+        when(captchaDataHolder.getCaptchaConnectors()).thenReturn(Collections.singletonList(captchaConnector));
+
+        when(captchaConnector.canHandle(any(), any())).thenReturn(true);
+        when(captchaConnector.getPriority()).thenReturn(10);
+        when(captchaConnector.preValidate(any(), any())).thenReturn(preValidationResponse);
+        when(captchaConnector.verifyCaptcha(any(), any())).thenReturn(true);
+
+        when(preValidationResponse.isCaptchaValidationRequired()).thenReturn(true);
+        when(preValidationResponse.isEnableCaptchaForRequestPath()).thenReturn(false);
+        when(preValidationResponse.isPostValidationRequired()).thenReturn(false);
+        when(preValidationResponse.isMaxFailedLimitReached()).thenReturn(false);
+        when(preValidationResponse.getWrappedHttpServletRequest()).thenReturn(null);
+
+        frameworkUtilsStatic.when(() -> FrameworkUtils.getContextData(request)).thenReturn(null);
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+
+        captchaDataHolderStatic.close();
+        frameworkUtilsStatic.close();
+        identityUtilStatic.close();
+        if (mocks != null) {
+            mocks.close();
+        }
+    }
+
+    @Test(description = "When reCaptcha is globally disabled the filter must pass through immediately, " +
+            "regardless of any console-login property or URI")
+    public void testDoFilter_ReCaptchaGloballyDisabled_AlwaysPassThrough()
+            throws IOException, ServletException, CaptchaException {
+
+        when(captchaDataHolder.isReCaptchaEnabled()).thenReturn(false);
+        when(request.getRequestURI()).thenReturn(OTHER_URI);
+
+        captchaFilter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verify(captchaConnector, never()).verifyCaptcha(any(), any());
+    }
+
+    /**
+     * Tests {@code isCaptchaDisabledForConsoleLogin} with reCaptcha globally enabled.
+     * Because the early-exit condition is {@code !isReCaptchaEnabled() || isCaptchaDisabledForConsoleLogin(...)},
+     * with reCaptcha ON the only way to bypass captcha is via a valid console-login request.
+     *
+     * Each row: disableFlag, requestUri, sessionDataKey (null = absent), spName (null = no context), expectSkip.
+     */
+    @DataProvider(name = "consoleLoginBypassScenarios")
+    public Object[][] consoleLoginBypassScenarios() {
+
+        return new Object[][]{
+            // disableFlag, requestUri,      sessionDataKey,        spName,    expectSkip
+            {"true",  COMMON_AUTH_URI, SESSION_DATA_KEY_VALUE, "Console", true},   // all conditions met → bypass
+            {"false", COMMON_AUTH_URI, SESSION_DATA_KEY_VALUE, "Console", false},  // property disabled → no bypass
+            {"true",  OTHER_URI,       SESSION_DATA_KEY_VALUE, "Console", false},  // wrong URI → no bypass
+            {"true",  COMMON_AUTH_URI, null,                   "Console", false},  // no sessionDataKey → no bypass
+            {"true",  COMMON_AUTH_URI, SESSION_DATA_KEY_VALUE, null,      false},  // context not in cache → no bypass
+            {"true",  COMMON_AUTH_URI, SESSION_DATA_KEY_VALUE, "MyApp",   false},  // non-Console app → no bypass
+        };
+    }
+
+    @Test(description = "Verify console-login captcha bypass when reCaptcha is globally enabled",
+          dataProvider = "consoleLoginBypassScenarios")
+    public void testDoFilter_ReCaptchaEnabled_ConsoleLoginBypassBehavior(String disableFlag, String requestUri,
+                                                                         String sessionDataKey, String spName,
+                                                                         boolean expectSkip)
+            throws IOException, ServletException, CaptchaException {
+
+        // reCaptcha is globally enabled — bypass is only possible via isCaptchaDisabledForConsoleLogin.
+        when(captchaDataHolder.isReCaptchaEnabled()).thenReturn(true);
+        when(request.getRequestURI()).thenReturn(requestUri);
+        when(request.getParameter(FrameworkUtils.SESSION_DATA_KEY)).thenReturn(sessionDataKey);
+
+        AuthenticationContext context = null;
+        if (spName != null && sessionDataKey != null) {
+            context = mock(AuthenticationContext.class);
+            when(context.getServiceProviderName()).thenReturn(spName);
+        }
+        frameworkUtilsStatic.when(
+                () -> FrameworkUtils.getAuthenticationContextFromCache(SESSION_DATA_KEY_VALUE)).thenReturn(context);
+
+        identityUtilStatic.when(
+                () -> IdentityUtil.getProperty(CaptchaConstants.DISABLE_CAPTCHA_FOR_CONSOLE_LOGIN))
+                .thenReturn(disableFlag);
+
+        captchaFilter.doFilter(request, response, filterChain);
+
+        if (expectSkip) {
+            verify(filterChain).doFilter(request, response);
+            verify(captchaConnector, never()).verifyCaptcha(any(), any());
+        } else {
+            verify(captchaConnector).verifyCaptcha(any(), any());
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.captcha/src/test/java/org/wso2/carbon/identity/captcha/util/CaptchaUtilTest.java
+++ b/components/org.wso2.carbon.identity.captcha/src/test/java/org/wso2/carbon/identity/captcha/util/CaptchaUtilTest.java
@@ -22,9 +22,13 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.ApplicationBasicInfo;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.captcha.internal.CaptchaDataHolder;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 
@@ -34,6 +38,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertThrows;
 
 /**
@@ -48,6 +55,12 @@ public class CaptchaUtilTest {
     public void setUp() {
 
         MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        CaptchaDataHolder.getInstance().setApplicationManagementService(null);
     }
 
     private MockedStatic<IdentityUtil> stubLocalOtpCaptchaProp(String value) {
@@ -244,9 +257,65 @@ public class CaptchaUtilTest {
                                                       boolean expectedResult) {
         try (MockedStatic<IdentityUtil> mockedIdentityUtil = stubLocalOtpCaptchaProp(propertyValue)) {
             boolean actualResult = CaptchaUtil.isCaptchaValidationEnabledForLocalOTPAuthenticators();
-            Assert.assertEquals(actualResult, expectedResult, 
+            Assert.assertEquals(actualResult, expectedResult,
                     String.format("Local OTP captcha validation should return %s for scenario: %s (property value: '%s')",
                             expectedResult, description, propertyValue));
+        }
+    }
+
+    /**
+     * Provides test data for isCaptchaDisabledForApplication scenarios.
+     * Each array contains: appId, tenantDomain, disableFlagValue, appName (null = app not found), expectedResult
+     */
+    @DataProvider(name = "captchaDisabledForApplicationScenarios")
+    public Object[][] captchaDisabledForApplicationScenarios() {
+
+        return new Object[][]{
+            {null,    "carbon.super", "true",  "Console", false},  // null appId
+            {"appId", null,           "true",  "Console", false},  // null tenantDomain
+            {"appId", "carbon.super", "false", "Console", false},  // disable flag not set
+            {"appId", "carbon.super", "true",  "Console", true},   // Console app → skip captcha
+            {"appId", "carbon.super", "true",  "MyApp",   false},  // non-Console app → enforce captcha
+            {"appId", "carbon.super", "true",  null,      false},  // app not found
+        };
+    }
+
+    @Test(description = "Verify isCaptchaDisabledForApplication for various app ID, tenant and configuration scenarios",
+          dataProvider = "captchaDisabledForApplicationScenarios")
+    public void testIsCaptchaDisabledForApplication(String appId, String tenantDomain, String disableFlagValue,
+                                                    String appName, boolean expectedResult)
+            throws IdentityApplicationManagementException {
+
+        ApplicationManagementService mockAppMgtService = mock(ApplicationManagementService.class);
+        ApplicationBasicInfo mockAppInfo = null;
+        if (appName != null) {
+            mockAppInfo = mock(ApplicationBasicInfo.class);
+            when(mockAppInfo.getApplicationName()).thenReturn(appName);
+        }
+        when(mockAppMgtService.getApplicationBasicInfoByResourceId(any(), any())).thenReturn(mockAppInfo);
+        CaptchaDataHolder.getInstance().setApplicationManagementService(mockAppMgtService);
+
+        try (MockedStatic<IdentityUtil> mockedIdentityUtil = Mockito.mockStatic(IdentityUtil.class)) {
+            mockedIdentityUtil.when(
+                    () -> IdentityUtil.getProperty(CaptchaConstants.DISABLE_CAPTCHA_FOR_CONSOLE_LOGIN))
+                    .thenReturn(disableFlagValue);
+
+            boolean actualResult = CaptchaUtil.isCaptchaDisabledForApplication(appId, tenantDomain);
+            Assert.assertEquals(actualResult, expectedResult);
+        }
+    }
+
+    @Test(description = "Captcha must not be disabled when ApplicationManagementService is unavailable")
+    public void testIsCaptchaDisabledForApplication_ServiceUnavailable() {
+
+        CaptchaDataHolder.getInstance().setApplicationManagementService(null);
+
+        try (MockedStatic<IdentityUtil> mockedIdentityUtil = Mockito.mockStatic(IdentityUtil.class)) {
+            mockedIdentityUtil.when(
+                    () -> IdentityUtil.getProperty(CaptchaConstants.DISABLE_CAPTCHA_FOR_CONSOLE_LOGIN))
+                    .thenReturn("true");
+
+            Assert.assertFalse(CaptchaUtil.isCaptchaDisabledForApplication("appId", "carbon.super"));
         }
     }
 }

--- a/components/org.wso2.carbon.identity.captcha/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.captcha/src/test/resources/testng.xml
@@ -34,4 +34,9 @@
             <class name="org.wso2.carbon.identity.captcha.connector.recaptcha.RecoveryReCaptchaConnectorTest"/>
         </classes>
     </test>
+    <test name="Captcha-Filter-Tests" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.carbon.identity.captcha.filter.CaptchaFilterTest"/>
+        </classes>
+    </test>
 </suite>


### PR DESCRIPTION
### Proposed changes in this pull request

> $subject

### Related issue
- https://github.com/wso2/product-is/issues/26934

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CAPTCHA validation for console login can now be selectively disabled through configuration, enabling administrators to bypass reCAPTCHA requirements for console-specific authentication flows when needed.

* **Tests**
  * Added comprehensive test coverage for CAPTCHA bypass functionality across different configuration scenarios and authentication conditions to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->