### PR TITLE
Handle the CDS profile claim during user provisioning

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -254,6 +254,8 @@ public class IdentityRecoveryConstants {
     // Constants related to service provider.
     public static final String SERVICE_PROVIDER_ID = "spId";
 
+    public static final String CDS_PROFILE_ATTRIBUTE = "cdsProfile";
+
     private IdentityRecoveryConstants() {
 
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
@@ -281,6 +281,14 @@ public class UserProvisioningExecutor implements Executor {
                 }
             }
         });
+
+        Object anonymousProfileTracker = context.getProperty(Constants.ANONYMOUS_PROFILE_TRACKER);
+        if (anonymousProfileTracker != null) {
+            String cdsProfileClaimUri = WSO2_CLAIM_DIALECT + IdentityRecoveryConstants.CDS_PROFILE_ATTRIBUTE;
+            if (!user.getClaims().containsKey(cdsProfileClaimUri)) {
+                user.addUpdatedClaim(cdsProfileClaimUri, String.valueOf(anonymousProfileTracker));
+            }
+        }
         user.setUsername(resolveUsername(user, context));
         setUsernamePatternValidation(context);
         return user;

--- a/pom.xml
+++ b/pom.xml
@@ -744,7 +744,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.11.107</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.145</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request
- Add CDS profile claim URI when the `anonymous_profile_tracker` parameter is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced user provisioning with automatic CDS profile attribute handling: when anonymous profile tracking data is available during provisioning, the corresponding CDS profile claim is added to the user profile if it isn’t already present.
* **Maintenance**
  * Updated the underlying identity framework version to a newer release for continued compatibility and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->