### PR TITLE
Add flow initiator for registration consent

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/ExecutorConsentUtils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/ExecutorConsentUtils.java
@@ -31,6 +31,8 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Flow;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineException;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineServerException;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
@@ -177,6 +179,18 @@ public class ExecutorConsentUtils {
                                           List<PurposePIICategoryBinding> purposeBindings, boolean isRejected)
             throws FlowEngineServerException {
 
+        Flow.InitiatingPersona initiatingPersona;
+        Flow existingFlow = IdentityContext.getThreadLocalIdentityContext().getCurrentFlow();
+        if (existingFlow != null) {
+            initiatingPersona = existingFlow.getInitiatingPersona();
+        } else {
+            initiatingPersona = Flow.InitiatingPersona.ADMIN;
+        }
+        Flow consentFlow = new Flow.Builder()
+                .name(Flow.Name.CONSENT_ADD)
+                .initiatingPersona(initiatingPersona)
+                .build();
+        IdentityContext.getThreadLocalIdentityContext().enterFlow(consentFlow);
         try {
             org.wso2.carbon.consent.mgt.core.ConsentManager consentManager =
                     IdentityRecoveryServiceDataHolder.getInstance().getConsentManager();
@@ -203,6 +217,8 @@ public class ExecutorConsentUtils {
             }
             throw FlowExecutionEngineUtils.handleServerException(ERROR_CODE_POLICY_CONSENT_FAILURE, e, purposeType,
                     Utils.maskIfRequired(subjectId));
+        } finally {
+            IdentityContext.getThreadLocalIdentityContext().exitFlow();
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -744,7 +744,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.11.107</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.139-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[7.3.6, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
This pull request introduces improvements to consent receipt handling by ensuring that consent operations are executed within a properly scoped flow context. It also updates the Carbon Identity Framework version to incorporate the latest changes.

Consent flow context management:

* Added logic in `ExecutorConsentUtils.java` to create and enter a new `CONSENT_ADD` flow with the correct initiating persona before adding a consent receipt. The flow is exited in a finally block to ensure proper cleanup. This helps maintain accurate flow state and auditing during consent operations. [[1]](diffhunk://#diff-9a3ef7f5a8fcc8f60e722567faa4dd58dc31bc357a56d0279b585d3e69f0a5bdR182-R193) [[2]](diffhunk://#diff-9a3ef7f5a8fcc8f60e722567faa4dd58dc31bc357a56d0279b585d3e69f0a5bdR220-R221)
* Imported `IdentityContext` and `Flow` classes in `ExecutorConsentUtils.java` to support the new flow context management logic.

Dependency update:

* Updated the `carbon.identity.framework.version` in `pom.xml` from `7.11.107` to `7.11.139-SNAPSHOT` to use the latest snapshot version of the Carbon Identity Framework.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consent receipt handling so it now preserves the current identity flow and cleans it up reliably, including when errors occur.

* **Chores**
  * Updated the identity framework version used by the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->