### PR TITLE
[APIM] Add configuration to disable account confirmation validation

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -91,6 +91,9 @@ public class IdentityRecoveryConstants {
     public static final String FUNCTION_LOCKOUT_TIME_PROPERTY = "LockoutTime";
     public static final String FUNCTION_LOGIN_FAIL_TIMEOUT_RATIO_PROPERTY = "TimeoutRatio";
 
+    public static final String AUTH_POLICY_DISABLE_ACCOUNT_CONFIRMATION_VALIDATION_HANDLER =
+            "AuthenticationPolicy.DisableAccountConfirmationValidationHandler";
+
     public static final String MAX_ATTEMPTS_DEFAULT = "5";
     public static final String LOCKOUT_TIME_DEFAULT = "5";
     public static final String LOGIN_FAIL_TIMEOUT_RATIO_DEFAULT = "2";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -91,9 +91,6 @@ public class IdentityRecoveryConstants {
     public static final String FUNCTION_LOCKOUT_TIME_PROPERTY = "LockoutTime";
     public static final String FUNCTION_LOGIN_FAIL_TIMEOUT_RATIO_PROPERTY = "TimeoutRatio";
 
-    public static final String AUTH_POLICY_DISABLE_ACCOUNT_CONFIRMATION_VALIDATION_HANDLER =
-            "AuthenticationPolicy.DisableAccountConfirmationValidationHandler";
-
     public static final String MAX_ATTEMPTS_DEFAULT = "5";
     public static final String LOCKOUT_TIME_DEFAULT = "5";
     public static final String LOGIN_FAIL_TIMEOUT_RATIO_DEFAULT = "2";
@@ -503,6 +500,8 @@ public class IdentityRecoveryConstants {
 
     public static class ConnectorConfig {
 
+        public static final String DISABLE_ACCOUNT_CONFIRMATION_VALIDATION_HANDLER =
+                "AuthenticationPolicy.DisableAccountConfirmationValidationHandler";
         public static final String PASSWORD_RECOVERY_SMS_OTP_EXPIRY_TIME =
                 "Recovery.Notification.Password.ExpiryTime.smsOtp";
         public static final String PASSWORD_RECOVERY_SMS_OTP_REGEX = "Recovery.Notification.Password.smsOtp.Regex";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AccountConfirmationValidationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AccountConfirmationValidationHandler.java
@@ -61,6 +61,12 @@ public class AccountConfirmationValidationHandler extends AbstractEventHandler {
     @Override
     public void handleEvent(Event event) throws IdentityEventException {
 
+        // Added this check to skip account confirmation validation when the API Manager gateway runs without the
+        // APIM database that holds the tenant's Resident Identity Provider. In such scenarios the
+        // connector-config lookups below (Utils.getConnectorConfig -> IdentityGovernanceService.getConfiguration ->
+        // IdentityProviderManager.getResidentIdP) fail with "Could not find Resident Identity Provider for tenant",
+        // aborting POST_AUTHENTICATION. When there is no resident IdP to resolve these configs, this validation
+        // can be skipped.
         if (isAccountConfirmationValidationHandlerDisabled()) {
             if (log.isDebugEnabled()) {
                 log.debug("Account Confirmation Validation Handler is disabled via configuration. Skipping.");

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AccountConfirmationValidationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AccountConfirmationValidationHandler.java
@@ -61,6 +61,13 @@ public class AccountConfirmationValidationHandler extends AbstractEventHandler {
     @Override
     public void handleEvent(Event event) throws IdentityEventException {
 
+        if (isAccountConfirmationValidationHandlerDisabled()) {
+            if (log.isDebugEnabled()) {
+                log.debug("Account Confirmation Validation Handler is disabled via configuration. Skipping.");
+            }
+            return;
+        }
+
         Map<String, Object> eventProperties = event.getEventProperties();
         String userName = (String) eventProperties.get(IdentityEventConstants.EventProperty.USER_NAME);
         UserStoreManager userStoreManager = (UserStoreManager) eventProperties.get(IdentityEventConstants.EventProperty.USER_STORE_MANAGER);
@@ -205,6 +212,12 @@ public class AccountConfirmationValidationHandler extends AbstractEventHandler {
     private boolean isAuthPolicyAccountExistCheck() {
         String authPolicyAccountExistCheck = IdentityUtil.getProperty("AuthenticationPolicy.CheckAccountExist");
         return authPolicyAccountExistCheck == null || Boolean.parseBoolean(authPolicyAccountExistCheck);
+    }
+
+    private boolean isAccountConfirmationValidationHandlerDisabled() {
+        String disableHandler = IdentityUtil.getProperty(
+                "AuthenticationPolicy.DisableAccountConfirmationValidationHandler");
+        return disableHandler != null && Boolean.parseBoolean(disableHandler);
     }
 
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AccountConfirmationValidationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AccountConfirmationValidationHandler.java
@@ -222,7 +222,7 @@ public class AccountConfirmationValidationHandler extends AbstractEventHandler {
 
     private boolean isAccountConfirmationValidationHandlerDisabled() {
         String disableHandler = IdentityUtil.getProperty(
-                "AuthenticationPolicy.DisableAccountConfirmationValidationHandler");
+                IdentityRecoveryConstants.AUTH_POLICY_DISABLE_ACCOUNT_CONFIRMATION_VALIDATION_HANDLER);
         return disableHandler != null && Boolean.parseBoolean(disableHandler);
     }
 

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AccountConfirmationValidationHandler.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/AccountConfirmationValidationHandler.java
@@ -222,7 +222,7 @@ public class AccountConfirmationValidationHandler extends AbstractEventHandler {
 
     private boolean isAccountConfirmationValidationHandlerDisabled() {
         String disableHandler = IdentityUtil.getProperty(
-                IdentityRecoveryConstants.AUTH_POLICY_DISABLE_ACCOUNT_CONFIRMATION_VALIDATION_HANDLER);
+                IdentityRecoveryConstants.ConnectorConfig.DISABLE_ACCOUNT_CONFIRMATION_VALIDATION_HANDLER);
         return disableHandler != null && Boolean.parseBoolean(disableHandler);
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request
This pull request introduces a config to the `AccountConfirmationValidationHandler` to prevent failures during account confirmation validation when the API Manager gateway operates without access to the APIM database (which normally provides the tenant's Resident Identity Provider). The handler now checks a configuration property and can be disabled to avoid errors in such scenarios.

Key changes:

**Account Confirmation Validation Handler Improvements:**

* Added a check in the `handleEvent` method of `AccountConfirmationValidationHandler` to skip validation if the handler is disabled via the new `AuthenticationPolicy.DisableAccountConfirmationValidationHandler` configuration property, preventing failures when the Resident Identity Provider is unavailable.
* Introduced the private method `isAccountConfirmationValidationHandlerDisabled()` to encapsulate the logic for reading and interpreting the new configuration property.

Related issue : https://github.com/wso2/api-manager/issues/5023

