### PR TITLE
Keep username claim domain-free during flow-based self registration

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
@@ -185,6 +185,8 @@ public class UserProvisioningExecutor implements Executor {
                     credentials.getOrDefault(PASSWORD_KEY, new DefaultPasswordGenerator().generatePassword());
 
             String userStoreDomainName = resolveUserStoreDomain(user.getUsername());
+            String usernameWithoutDomain = UserCoreUtil.removeDomainFromName(user.getUsername());
+            userClaims.put(USERNAME_CLAIM_URI, usernameWithoutDomain);
             UserStoreManager userStoreManager = getUserStoreManager(context.getTenantDomain(), userStoreDomainName,
                     context.getContextIdentifier(), context.getFlowType());
 
@@ -198,7 +200,7 @@ public class UserProvisioningExecutor implements Executor {
             Utils.setArbitraryProperties(notificationProperties);
 
             String[] userRoles = new String[]{IdentityRecoveryConstants.SELF_SIGNUP_ROLE};
-            userStoreManager.addUser(IdentityUtil.addDomainToName(user.getUsername(), userStoreDomainName),
+            userStoreManager.addUser(IdentityUtil.addDomainToName(usernameWithoutDomain, userStoreDomainName),
                     String.valueOf(password), userRoles, userClaims, null);
             String userid = ((AbstractUserStoreManager) userStoreManager).getUserIDFromUserName(user.getUsername());
             user.setUserStoreDomain(userStoreDomainName);

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutorTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutorTest.java
@@ -610,6 +610,7 @@ public class UserProvisioningExecutorTest {
         mockedIdentityUtil.when(IdentityUtil::getPrimaryDomainName).thenReturn(PRIMARY_DOMAIN);
         mockedIdentityUtil.when(() -> IdentityUtil.addDomainToName(anyString(), anyString()))
                 .thenReturn("Internal/testuser");
+        mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName(anyString())).thenReturn("testuser");
 
         ExecutorResponse response = executor.execute(context);
 
@@ -1346,6 +1347,7 @@ public class UserProvisioningExecutorTest {
         mockedIdentityUtil.when(IdentityUtil::getPrimaryDomainName).thenReturn(PRIMARY_DOMAIN);
         mockedIdentityUtil.when(() -> IdentityUtil.addDomainToName(anyString(), anyString()))
                 .thenReturn(PRIMARY_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + USERNAME);
+        mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName(anyString())).thenReturn(USERNAME);
 
         return userStoreManager;
     }


### PR DESCRIPTION
## Purpose
During a flow-based self-registration (`flowType = REGISTRATION`), submitting a domain-qualified username such as `LDAP/test2` (`<userStoreDomain>/<username>`) did not behave correctly:

- Onboarding failed with `Username and the username claim value should be same`.
- When the username claim was stripped upstream, the user was instead created in the PRIMARY user store rather than the intended secondary store.

The user store manager strips the domain off the `userName` argument before comparing it against the `http://wso2.org/claims/username` claim, so a domain-qualified claim value never matches. At the same time, the domain is what routes the user to the correct store, so it cannot simply be dropped everywhere.

## Related Issue
- N/A

## Implementation
In `UserProvisioningExecutor.handleRegistrationFlow(...)`:

- The user store domain is still resolved from the domain-qualified username (`resolveUserStoreDomain(user.getUsername())`) before any stripping, preserving routing to the secondary store.
- The `USERNAME_CLAIM_URI` value in the claims map is normalized to its domain-free form via `UserCoreUtil.removeDomainFromName(...)` so it matches the stripped `userName` the user store manager compares against.
- `addUser(...)` re-attaches the resolved domain with `IdentityUtil.addDomainToName(usernameWithoutDomain, userStoreDomainName)`, producing the same qualified routing name (e.g. `LDAP/test2`) so the user is created in the intended store.

No new imports were required. Non-domain-qualified usernames, email-as-username, and the random-UUID fallback continue to work unchanged, since `removeDomainFromName` is a no-op when no domain is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registration to consistently handle usernames that include domain prefixes by normalizing and saving the consistent username value throughout the sign-up flow.
  * Ensured the username used for account creation aligns with the normalized username stored in account details, preventing mismatches during profile setup and related recovery steps.
  * Updated automated tests to deterministically verify domain-stripping behavior during username handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->