### PR TITLE
Move password provisioning for recovery and ask password flows to user provisioning executor

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutor.java
@@ -18,62 +18,30 @@
 
 package org.wso2.carbon.identity.recovery.executor;
 
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.identity.application.common.model.User;
-import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
-import org.wso2.carbon.identity.core.context.IdentityContext;
-import org.wso2.carbon.identity.core.context.model.Flow;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.event.IdentityEventConstants;
-import org.wso2.carbon.identity.event.IdentityEventException;
-import org.wso2.carbon.identity.event.event.Event;
-import org.wso2.carbon.identity.flow.execution.engine.Constants;
-import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineException;
 import org.wso2.carbon.identity.flow.execution.engine.graph.AuthenticationExecutor;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
-import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
-import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
-import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
-import org.wso2.carbon.identity.recovery.util.Utils;
-import org.wso2.carbon.identity.recovery.util.ExecutorConsentUtils;
-import org.wso2.carbon.identity.user.action.api.constant.UserActionError;
-import org.wso2.carbon.identity.user.action.api.exception.UserActionExecutionClientException;
-import org.wso2.carbon.user.api.UserStoreException;
-import org.wso2.carbon.user.api.UserStoreManager;
-import org.wso2.carbon.user.core.UserRealm;
-import org.wso2.carbon.user.core.UserStoreClientException;
-import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
-import org.wso2.carbon.user.core.service.RealmService;
-import org.wso2.carbon.user.mgt.common.DefaultPasswordGenerator;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_VALIDATION_FAILURE;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_COMPLETE;
-import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_ERROR;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_USER_INPUT_REQUIRED;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.PASSWORD_KEY;
-import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.INVITED_USER_REGISTRATION;
-import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.PASSWORD_RECOVERY;
-import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.REGISTRATION;
-import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.CONFIRMATION_CODE;
-import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.CONFIRMATION_CODE_INPUT;
 
 /**
  * Executor to provision the password.
+ * The actual password provisioning (password recovery and invited user / ask password flows) has been moved
+ * into {@link UserProvisioningExecutor}. This executor is retained only so that existing flow definitions that
+ * still reference it keep working. It no longer updates the credential, it just captures the password into the
+ * flow user so that the downstream {@link UserProvisioningExecutor} can provision it.
  */
 public class PasswordProvisioningExecutor extends AuthenticationExecutor {
-
-    private static final Log LOG = LogFactory.getLog(PasswordProvisioningExecutor.class);
 
     @Override
     public String getName() {
@@ -104,152 +72,24 @@ public class PasswordProvisioningExecutor extends AuthenticationExecutor {
     @Override
     public ExecutorResponse execute(FlowExecutionContext context) {
 
-        Map<String, char[]> credentials;
+        // Capture the password into the flow user so the downstream UserProvisioningExecutor can provision
+        // it. The credential is intentionally not updated here anymore.
+        Map<String, char[]> credentials = context.getFlowUser().getUserCredentials();
         String passwordValue = context.getUserInputData() != null ? context.getUserInputData().get(PASSWORD_KEY) : null;
         if (StringUtils.isNotBlank(passwordValue)) {
-            credentials = new HashMap<>();
-            credentials.put(PASSWORD_KEY, passwordValue.toCharArray());
-            context.getFlowUser().setUserCredentials(credentials);
-        } else {
-            credentials = context.getFlowUser().getUserCredentials();
-            if (MapUtils.isEmpty(credentials)) {
-                return buildUserInputRequiredResponse();
+            // Preserve any other credential entries already set on the flow user.
+            Map<String, char[]> updatedCredentials = new HashMap<>();
+            if (credentials != null) {
+                updatedCredentials.putAll(credentials);
             }
+            updatedCredentials.put(PASSWORD_KEY, passwordValue.toCharArray());
+            context.getFlowUser().setUserCredentials(updatedCredentials);
+        } else if (credentials == null || ArrayUtils.isEmpty(credentials.get(PASSWORD_KEY))) {
+            // Password availability is decided by the password entry itself, not by map occupancy.
+            return buildUserInputRequiredResponse();
         }
 
-        if (REGISTRATION.getType().equalsIgnoreCase(context.getFlowType())) {
-            return new ExecutorResponse(STATUS_COMPLETE);
-        }
-
-        char[] password = credentials.getOrDefault(PASSWORD_KEY, new DefaultPasswordGenerator().generatePassword());
-        try {
-            if (PASSWORD_RECOVERY.getType().equalsIgnoreCase(context.getFlowType())) {
-                return handlePasswordRecoveryFlow(context, password);
-            } else if (INVITED_USER_REGISTRATION.getType().equalsIgnoreCase(context.getFlowType())) {
-                return handleAskPasswordFlow(context, password);
-            }
-            return new ExecutorResponse();
-        } finally {
-            Arrays.fill(password, '\0');
-        }
-    }
-
-    private ExecutorResponse handleAskPasswordFlow(FlowExecutionContext context, char[] password) {
-
-        String confirmationCode = (String) context.getProperty(CONFIRMATION_CODE_INPUT);
-        User user = Utils.resolveUserFromContext(context);
-        if (StringUtils.isBlank(confirmationCode) || user == null) {
-            return errorResponse(new ExecutorResponse(), "Required properties are missing in the context.");
-        }
-
-        String recoveryScenario = getStringProperty(context, IdentityRecoveryConstants.RECOVERY_SCENARIO);
-
-        try {
-            enterFlow();
-            int tenantId = IdentityTenantUtil.getTenantId(context.getTenantDomain());
-
-            handlePrePasswordUpdate(user, recoveryScenario, confirmationCode);
-
-            UserStoreManager userStoreManager = IdentityRecoveryServiceDataHolder.getInstance()
-                    .getRealmService().getTenantUserRealm(tenantId).getUserStoreManager();
-            userStoreManager.updateCredentialByAdmin(context.getFlowUser().getUsername(), password);
-            String userId = ((AbstractUserStoreManager) userStoreManager)
-                    .getUserIDFromUserName(context.getFlowUser().getUsername());
-            context.getFlowUser().setUserId(userId);
-            context.getFlowUser().setUserStoreDomain(user.getUserStoreDomain());
-
-            ExecutorConsentUtils.processUserConsent(getName(), context, context.getFlowUser(),
-                    user.getUserStoreDomain());
-
-            return new ExecutorResponse(STATUS_COMPLETE);
-        } catch (UserStoreException | IdentityEventException | IdentityRecoveryException | FlowEngineException e) {
-            ExecutorResponse errorResponse = handleClientExceptionForActionFailure(e);
-            if (errorResponse.getResult() != null) {
-                return errorResponse;
-            }
-
-            String maskedUsername = LoggerUtils.isLogMaskingEnable
-                    ? LoggerUtils.getMaskedContent(context.getFlowUser().getUsername())
-                    : context.getFlowUser().getUsername();
-            LOG.error("Error while updating password for user: " + maskedUsername, e);
-            return errorResponse(new ExecutorResponse(), e.getMessage());
-        } finally {
-            IdentityContext.getThreadLocalIdentityContext().exitFlow();
-        }
-    }
-
-    private String getStringProperty(FlowExecutionContext context, String key) {
-
-        Object value = context.getProperty(key);
-        return (value != null) ? value.toString() : null;
-    }
-
-    private void handlePrePasswordUpdate(User user, String recoveryScenario, String confirmationCode)
-            throws IdentityRecoveryException, IdentityEventException {
-
-        publishEvent(user, confirmationCode, IdentityEventConstants.Event.
-                PRE_ADD_NEW_PASSWORD, recoveryScenario);
-    }
-
-    private void enterFlow() {
-
-        Flow.InitiatingPersona initiatingPersona;
-        Flow existingFlow = IdentityContext.getThreadLocalIdentityContext().getCurrentFlow();
-
-        if (existingFlow != null) {
-            initiatingPersona = existingFlow.getInitiatingPersona();
-        } else {
-            initiatingPersona = Flow.InitiatingPersona.ADMIN;
-        }
-
-        Flow flow = new Flow.Builder()
-                .name(Flow.Name.INVITED_USER_REGISTRATION)
-                .initiatingPersona(initiatingPersona)
-                .build();
-
-        IdentityContext.getThreadLocalIdentityContext().enterFlow(flow);
-    }
-
-    private void publishEvent(User user, String code, String eventName, String recoveryScenario) throws
-            IdentityEventException {
-
-        HashMap<String, Object> properties = new HashMap<>();
-        properties.put(IdentityEventConstants.EventProperty.USER, user);
-        properties.put(IdentityEventConstants.EventProperty.USER_NAME, user.getUserName());
-        properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, user.getTenantDomain());
-        properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, user.getUserStoreDomain());
-        properties.put(IdentityEventConstants.EventProperty.RECOVERY_SCENARIO, recoveryScenario);
-        properties.put(CONFIRMATION_CODE, code);
-
-        Event identityMgtEvent = new Event(eventName, properties);
-        IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);
-    }
-
-    private ExecutorResponse handlePasswordRecoveryFlow(FlowExecutionContext context, char[] password) {
-
-        try {
-            UserRealm userRealm = getUserRealm(context.getTenantDomain());
-            if (userRealm == null) {
-                ExecutorResponse executorResponse = new ExecutorResponse(STATUS_ERROR);
-                executorResponse.setErrorMessage("User realm is not available for tenant");
-                return executorResponse;
-            }
-            UserStoreManager userStoreManager = userRealm.getUserStoreManager()
-                    .getSecondaryUserStoreManager(context.getFlowUser().getUserStoreDomain());
-            userStoreManager.updateCredentialByAdmin(context.getFlowUser().getUsername(), password);
-            return new ExecutorResponse(STATUS_COMPLETE);
-        } catch (UserStoreException e) {
-            ExecutorResponse errorResponse = handleClientExceptionForActionFailure(e);
-            if (errorResponse.getResult() != null) {
-                return errorResponse;
-            }
-
-            String maskedUsername = LoggerUtils.isLogMaskingEnable
-                    ? LoggerUtils.getMaskedContent(context.getFlowUser().getUsername())
-                    : context.getFlowUser().getUsername();
-            LOG.error("Error while updating password for user: " + maskedUsername, e);
-            return errorResponse(new ExecutorResponse(), e.getMessage());
-        }
+        return new ExecutorResponse(STATUS_COMPLETE);
     }
 
     /**
@@ -263,74 +103,4 @@ public class PasswordProvisioningExecutor extends AuthenticationExecutor {
         response.setRequiredData(Collections.singletonList(PASSWORD_KEY));
         return response;
     }
-
-    /**
-     * Creates an error response with the provided message.
-     *
-     * @param response ExecutorResponse to be modified with error details.
-     * @param message  Error message to be set in the response.
-     * @return Modified ExecutorResponse with error details.
-     */
-    private ExecutorResponse errorResponse(ExecutorResponse response, String message) {
-
-        response.setErrorMessage(message);
-        response.setResult(Constants.ExecutorStatus.STATUS_ERROR);
-        return response;
-    }
-
-    /**
-     * Creates a user error response with the provided details.
-     *
-     * @param response    ExecutorResponse to be modified with user error details.
-     * @param errorCode   Error code to be set in the response.
-     * @param message     User error message to be set in the response.
-     * @param description Description of the error to be set in the response.
-     * @param throwable   Throwable associated with the error.
-     * @return Modified ExecutorResponse with user error details.
-     */
-    private ExecutorResponse userErrorResponse(ExecutorResponse response, String errorCode, String message,
-                                               String description, Throwable throwable) {
-
-        response.setErrorCode(errorCode);
-        response.setErrorMessage(message);
-        response.setErrorDescription(description);
-        response.setThrowable(throwable);
-        response.setResult(Constants.ExecutorStatus.STATUS_USER_ERROR);
-        return response;
-    }
-
-    /**
-     * Retrieves the user realm for the given tenant domain.
-     *
-     * @param tenantDomain Tenant domain.
-     * @return UserRealm instance for the tenant.
-     * @throws UserStoreException If an error occurs while retrieving the user realm.
-     */
-    private UserRealm getUserRealm(String tenantDomain) throws UserStoreException {
-
-        RealmService realmService = IdentityRecoveryServiceDataHolder.getInstance().getRealmService();
-        int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
-        return (UserRealm) realmService.getTenantUserRealm(tenantId);
-    }
-
-    private ExecutorResponse handleClientExceptionForActionFailure(Exception e) {
-
-        ExecutorResponse response = new ExecutorResponse();
-        if (e instanceof UserStoreClientException &&
-                UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED
-                        .equals(((UserStoreClientException) e).getErrorCode())) {
-            Throwable cause = e.getCause();
-            while (cause != null) {
-                if (cause instanceof UserActionExecutionClientException) {
-                    return userErrorResponse(response,
-                            ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_VALIDATION_FAILURE.getCode(),
-                            ((UserActionExecutionClientException) cause).getError(),
-                            ((UserActionExecutionClientException) cause).getDescription(), cause);
-                }
-                cause = cause.getCause();
-            }
-        }
-        return response;
-    }
-
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
@@ -28,9 +28,14 @@ import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Flow;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.core.util.LambdaExceptionUtils;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.flow.execution.engine.Constants;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineClientException;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineException;
@@ -41,6 +46,7 @@ import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowUser;
 import org.wso2.carbon.identity.flow.execution.engine.util.FlowExecutionEngineUtils;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages;
 import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
 import org.wso2.carbon.identity.recovery.model.Property;
@@ -73,9 +79,11 @@ import java.util.UUID;
 import static java.util.Locale.ENGLISH;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.EMAIL_ADDRESS_CLAIM;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.MY_ACCOUNT_APPLICATION_NAME;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_ERROR;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.PASSWORD_KEY;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.STATUS_COMPLETE;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.USERNAME_CLAIM_URI;
+import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.INVITED_USER_REGISTRATION;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.REGISTRATION;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.DISPLAY_CLAIM_AVAILABILITY_CONFIG;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.DUPLICATE_CLAIMS_ERROR_CODE;
@@ -134,13 +142,21 @@ public class UserProvisioningExecutor implements Executor {
         }
 
         try {
-            // If the flow type is not registration, update the user profile.
+            // Provision the password before persisting the profile claims and consent.
+            ExecutorResponse passwordResponse = updateUserPassword(context);
+            if (passwordResponse != null) return passwordResponse;
+
             FlowUser user = updateUserProfile(context);
             // Only persist claims the user actually changed during this flow. The preloaded CONSOLE-profile
             // snapshot (which includes non-attribute claims like role/roles) must not be written back.
             Map<String, String> userClaims = filterUpdatedClaims(user);
 
-            String userStoreDomainName = resolveUserStoreDomain(user.getUsername());
+            // Persist the claims and consent against the same user store the credential update above
+            // resolved, only fall back to username-based resolution when no domain
+            // has been resolved for the flow user.
+            String userStoreDomainName = StringUtils.isNotBlank(user.getUserStoreDomain())
+                    ? user.getUserStoreDomain()
+                    : resolveUserStoreDomain(user.getUsername());
             UserStoreManager userStoreManager = getUserStoreManager(context.getTenantDomain(), userStoreDomainName,
                     context.getContextIdentifier(), context.getFlowType());
             String domainQualifiedName = IdentityUtil.addDomainToName(user.getUsername(), userStoreDomainName);
@@ -172,6 +188,136 @@ public class UserProvisioningExecutor implements Executor {
         } catch (FlowEngineException e) {
             return errorResponse(response, e);
         }
+    }
+
+    /**
+     * Provisions the password for password provisioning based flows.
+     *
+     * @param context  Flow execution context.
+     * @return {@code null} on success so the caller falls through to the user provisioning logic; a populated
+     * {@link ExecutorResponse} when the password provisioning could not be completed.
+     */
+    private ExecutorResponse updateUserPassword(FlowExecutionContext context) {
+
+        char[] password = resolvePassword(context);
+        if (password == null) {
+            return errorResponse(new ExecutorResponse(), "Password is required for password provisioning.");
+        }
+        try {
+            ExecutorResponse passwordResponse = handlePasswordProvisioning(context, password);
+            if (passwordResponse != null) return passwordResponse;
+        } finally {
+            Arrays.fill(password, '\0');
+        }
+        return null;
+    }
+
+    private ExecutorResponse handlePasswordProvisioning(FlowExecutionContext context, char[] password) {
+
+        FlowUser flowUser = context.getFlowUser();
+        try {
+            User user = Utils.resolveUserFromContext(context);
+            String preferredDomain = (user != null) ? user.getUserStoreDomain() : null;
+            String userStoreDomain = resolveCredentialUpdateDomain(flowUser, preferredDomain);
+            UserStoreManager userStoreManager = getUserStoreManager(context.getTenantDomain(), userStoreDomain,
+                    context.getContextIdentifier(), context.getFlowType());
+
+            ExecutorResponse preUpdateResponse = handlePrePasswordUpdate(context, user);
+            if (preUpdateResponse != null) return preUpdateResponse;
+
+            userStoreManager.updateCredentialByAdmin(flowUser.getUsername(), password);
+
+            // Populate the flow user identity so that post flow handling (e.g. building the auto-login
+            // assertion) resolves the correct user.
+            if (userStoreManager instanceof AbstractUserStoreManager) {
+                flowUser.setUserId(((AbstractUserStoreManager) userStoreManager)
+                        .getUserIDFromUserName(flowUser.getUsername()));
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug("User store manager of domain " + userStoreDomain + " cannot resolve user ids. " +
+                        "Leaving the flow user id unset.");
+            }
+
+            if (StringUtils.isBlank(flowUser.getUserStoreDomain())) {
+                flowUser.setUserStoreDomain(userStoreDomain);
+            }
+            return null;
+        } catch (UserStoreException | IdentityEventException | IdentityRecoveryException | FlowEngineException e) {
+            return buildPasswordUpdateErrorResponse(context, e);
+        }
+    }
+
+    private ExecutorResponse buildPasswordUpdateErrorResponse(FlowExecutionContext context, Exception e) {
+
+        ExecutorResponse errorResponse = buildClientErrorResponseForActionFailure(new ExecutorResponse(), e,
+                Constants.ErrorMessages.ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_VALIDATION_FAILURE.getCode());
+        if (errorResponse.getResult() != null) {
+            return errorResponse;
+        }
+        String maskedUsername = LoggerUtils.isLogMaskingEnable
+                ? LoggerUtils.getMaskedContent(context.getFlowUser().getUsername())
+                : context.getFlowUser().getUsername();
+        LOG.error("Error while updating password for user: " + maskedUsername, e);
+        return errorResponse(new ExecutorResponse(), e.getMessage());
+    }
+
+    private String getStringProperty(FlowExecutionContext context, String key) {
+
+        Object value = context.getProperty(key);
+        return (value != null) ? value.toString() : null;
+    }
+
+    private ExecutorResponse handlePrePasswordUpdate(FlowExecutionContext context, User user)
+            throws IdentityRecoveryException, IdentityEventException {
+
+        if (!INVITED_USER_REGISTRATION.getType().equalsIgnoreCase(context.getFlowType())) {
+            return null;
+        }
+        String confirmationCode = (String) context.getProperty(IdentityRecoveryConstants.CONFIRMATION_CODE_INPUT);
+        if (user == null || StringUtils.isBlank(confirmationCode)) {
+            return errorResponse(new ExecutorResponse(), "Required properties are missing in the context.");
+        }
+        String recoveryScenario = getStringProperty(context, IdentityRecoveryConstants.RECOVERY_SCENARIO);
+        enterFlow();
+        try {
+            publishEvent(user, confirmationCode, IdentityEventConstants.Event.PRE_ADD_NEW_PASSWORD, recoveryScenario);
+        } finally {
+            IdentityContext.getThreadLocalIdentityContext().exitFlow();
+        }
+        return null;
+    }
+
+    private void enterFlow() {
+
+        Flow.InitiatingPersona initiatingPersona;
+        Flow existingFlow = IdentityContext.getThreadLocalIdentityContext().getCurrentFlow();
+
+        if (existingFlow != null) {
+            initiatingPersona = existingFlow.getInitiatingPersona();
+        } else {
+            initiatingPersona = Flow.InitiatingPersona.ADMIN;
+        }
+
+        Flow flow = new Flow.Builder()
+                .name(Flow.Name.INVITED_USER_REGISTRATION)
+                .initiatingPersona(initiatingPersona)
+                .build();
+
+        IdentityContext.getThreadLocalIdentityContext().enterFlow(flow);
+    }
+
+    private void publishEvent(User user, String code, String eventName, String recoveryScenario)
+            throws IdentityEventException {
+
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put(IdentityEventConstants.EventProperty.USER, user);
+        properties.put(IdentityEventConstants.EventProperty.USER_NAME, user.getUserName());
+        properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, user.getTenantDomain());
+        properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, user.getUserStoreDomain());
+        properties.put(IdentityEventConstants.EventProperty.RECOVERY_SCENARIO, recoveryScenario);
+        properties.put(IdentityRecoveryConstants.CONFIRMATION_CODE, code);
+
+        Event identityMgtEvent = new Event(eventName, properties);
+        IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);
     }
 
     private ExecutorResponse handleRegistrationFlow(ExecutorResponse response, FlowExecutionContext context) {
@@ -217,7 +363,8 @@ public class UserProvisioningExecutor implements Executor {
             response.setResult(STATUS_COMPLETE);
             return response;
         } catch (UserStoreException e) {
-            response = buildClientErrorResponseForActionFailure(response, e);
+            response = buildClientErrorResponseForActionFailure(response, e,
+                    ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_VALIDATION_FAILURE.getCode());
             if (response.getResult() != null) {
                 return response;
             }
@@ -254,7 +401,16 @@ public class UserProvisioningExecutor implements Executor {
         }
     }
 
-    private ExecutorResponse buildClientErrorResponseForActionFailure(ExecutorResponse response, UserStoreException e) {
+    /**
+     * Maps a pre-update-password action validation failure to a user error response with the provided error code.
+     *
+     * @param response  ExecutorResponse to be populated on a match.
+     * @param e         Exception thrown by the user store operation.
+     * @param errorCode Error code to set on the mapped user error response.
+     * @return The response, populated as a user error when the failure matched.
+     */
+    private ExecutorResponse buildClientErrorResponseForActionFailure(ExecutorResponse response, Exception e,
+                                                                      String errorCode) {
 
         if (e instanceof UserStoreClientException &&
                 UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED
@@ -262,8 +418,7 @@ public class UserProvisioningExecutor implements Executor {
             Throwable cause = e.getCause();
             while (cause != null) {
                 if (cause instanceof UserActionExecutionClientException) {
-                    return userErrorResponse(response,
-                            ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_VALIDATION_FAILURE.getCode(),
+                    return userErrorResponse(response, errorCode,
                             ((UserActionExecutionClientException) cause).getError(),
                             ((UserActionExecutionClientException) cause).getDescription(), cause);
                 }
@@ -499,6 +654,20 @@ public class UserProvisioningExecutor implements Executor {
     }
 
     /**
+     * Creates an error response with the provided message.
+     *
+     * @param response ExecutorResponse to be modified with error details.
+     * @param message  Error message to be set in the response.
+     * @return Modified ExecutorResponse with error details.
+     */
+    private ExecutorResponse errorResponse(ExecutorResponse response, String message) {
+
+        response.setErrorMessage(message);
+        response.setResult(STATUS_ERROR);
+        return response;
+    }
+
+    /**
      * Creates an error response with the provided details.
      *
      * @param response ExecutorResponse to be modified with error details.
@@ -618,4 +787,59 @@ public class UserProvisioningExecutor implements Executor {
         }
         return result;
     }
+
+    /**
+     * Resolves the user store domain to run the credential update against.
+     *
+     * @param flowUser        Flow user whose credential is being updated.
+     * @param preferredDomain Domain to prefer when the flow user does not carry one; may be null.
+     * @return Resolved user store domain.
+     */
+    private String resolveCredentialUpdateDomain(FlowUser flowUser, String preferredDomain) {
+
+        if (StringUtils.isNotBlank(flowUser.getUserStoreDomain())) {
+            return flowUser.getUserStoreDomain();
+        }
+        if (StringUtils.isNotBlank(preferredDomain)) {
+            return preferredDomain;
+        }
+        return extractDomainFromUsername(flowUser.getUsername());
+    }
+
+    private String extractDomainFromUsername(String username) {
+
+        if (StringUtils.isNotBlank(username)) {
+            int separatorIndex = username.indexOf(UserCoreConstants.DOMAIN_SEPARATOR);
+            if (separatorIndex >= 0) {
+                return username.substring(0, separatorIndex).toUpperCase(ENGLISH);
+            }
+        }
+        return IdentityUtil.getPrimaryDomainName();
+    }
+
+    /**
+     * Resolves the password to provision.
+     */
+    private char[] resolvePassword(FlowExecutionContext context) {
+
+        Map<String, char[]> credentials = context.getFlowUser().getUserCredentials();
+        char[] storedPassword = credentials != null ? credentials.get(PASSWORD_KEY) : null;
+        if (ArrayUtils.isNotEmpty(storedPassword)) {
+            return Arrays.copyOf(storedPassword, storedPassword.length);
+        }
+        String passwordValue = context.getUserInputData() != null
+                ? context.getUserInputData().get(PASSWORD_KEY) : null;
+        if (StringUtils.isBlank(passwordValue)) {
+            return null;
+        }
+        char[] password = passwordValue.toCharArray();
+        Map<String, char[]> updatedCredentials = new HashMap<>();
+        if (credentials != null) {
+            updatedCredentials.putAll(credentials);
+        }
+        updatedCredentials.put(PASSWORD_KEY, Arrays.copyOf(password, password.length));
+        context.getFlowUser().setUserCredentials(updatedCredentials);
+        return password;
+    }
+
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/util/Utils.java
@@ -2050,7 +2050,7 @@ public class Utils {
                 return mapper.readValue((String) raw, User.class);
             }
             return mapper.convertValue(raw, User.class);
-        } catch (JsonProcessingException e) {
+        } catch (JsonProcessingException | IllegalArgumentException e) {
             log.warn("Failed to resolve User from context.", e);
             return null;
         }

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutorTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutorTest.java
@@ -19,75 +19,72 @@
 package org.wso2.carbon.identity.recovery.executor;
 
 import org.mockito.MockedStatic;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
-import org.wso2.carbon.identity.core.context.model.Flow;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.flow.execution.engine.Constants;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowUser;
 import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
-import org.wso2.carbon.user.core.UserRealm;
-import org.wso2.carbon.user.core.UserStoreException;
-import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
-import org.wso2.carbon.user.core.service.RealmService;
-import org.wso2.carbon.user.core.tenant.TenantManager;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
-import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.CONFIRMATION_CODE_INPUT;
-import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.RECOVERY_SCENARIO;
-import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.USER;
 
 /**
  * Unit tests for {@link PasswordProvisioningExecutor}.
+ * <p>
+ * The executor no longer updates the credential. It only captures the supplied password into the flow user so
+ * that the downstream {@link UserProvisioningExecutor} can provision it. These tests cover that capture
+ * behaviour and the metadata methods.
  */
 @WithCarbonHome
 public class PasswordProvisioningExecutorTest {
 
     private static final String PASSWORD_KEY = "password";
-    private static final String USERNAME = "test@wso2.com";
-    private static final String TENANT_DOMAIN = "carbon.super";
-    private static final String USER_ID = "abc123";
-    private static final String PASSWORD_RECOVERY = "PASSWORD_RECOVERY";
-    private static final int TENANT_ID = 1234;
+    private static final String PASSWORD_VALUE = "Password123";
 
     private PasswordProvisioningExecutor executor;
-    private MockedStatic<IdentityRecoveryServiceDataHolder> mockedDataHolderStatic;
-    private MockedStatic<IdentityTenantUtil> mockedIdentityTenantUtil;
 
     @BeforeMethod
     public void setUp() {
 
         executor = new PasswordProvisioningExecutor();
-        mockedDataHolderStatic = mockStatic(IdentityRecoveryServiceDataHolder.class);
-        mockedIdentityTenantUtil = mockStatic(IdentityTenantUtil.class);
     }
 
-    @AfterMethod
-    public void tearDown() {
+    @Test
+    public void testGetName() {
 
-        mockedDataHolderStatic.close();
-        mockedIdentityTenantUtil.close();
+        assertEquals(executor.getName(), "PasswordProvisioningExecutor");
+    }
+
+    @Test
+    public void testGetAMRValue() {
+
+        assertEquals(executor.getAMRValue(), "BasicAuthenticator");
+    }
+
+    @Test
+    public void testGetInitiationData() {
+
+        List<String> initiationData = executor.getInitiationData();
+        assertTrue(initiationData.contains(PASSWORD_KEY));
+    }
+
+    @Test
+    public void testRollback() {
+
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        assertNull(executor.rollback(context));
     }
 
     @Test
@@ -105,174 +102,102 @@ public class PasswordProvisioningExecutorTest {
         assertTrue(response.getRequiredData().contains(PASSWORD_KEY));
     }
 
-    @Test(dataProvider = "flowTypes")
-    public void testExecuteWithValidData(String flowType) throws Exception {
+    @Test
+    public void testExecuteCapturesPasswordFromUserInput() {
 
         FlowExecutionContext context = mock(FlowExecutionContext.class);
-        FlowUser flowUser = new FlowUser();
-        flowUser.setUsername(USERNAME);
-        flowUser.addClaims(new HashMap<>());
-        flowUser.setUserStoreDomain("PRIMARY");
-
-
         Map<String, String> userInputData = new HashMap<>();
-        userInputData.put(PASSWORD_KEY, "Password123");
-        userInputData.put("http://wso2.org/claims/givenname", "John");
-        userInputData.put(CONFIRMATION_CODE_INPUT, "valid-code");
-
+        userInputData.put(PASSWORD_KEY, PASSWORD_VALUE);
         when(context.getUserInputData()).thenReturn(userInputData);
-        when(context.getFlowType()).thenReturn(flowType);
-        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+
+        FlowUser flowUser = new FlowUser();
         when(context.getFlowUser()).thenReturn(flowUser);
 
-        if (Flow.Name.INVITED_USER_REGISTRATION.name().equals(flowType)) {
-            when(context.getProperty(CONFIRMATION_CODE_INPUT)).thenReturn("valid-code");
+        ExecutorResponse response = executor.execute(context);
 
-            User user = new User();
-            user.setUserName(USERNAME);
-            user.setTenantDomain(TENANT_DOMAIN);
-            user.setUserStoreDomain("PRIMARY");
-            when(context.getProperty(USER)).thenReturn(user);
-            when(context.getProperty(RECOVERY_SCENARIO)).thenReturn("SCENARIO");
+        // The password is captured into the flow user so the downstream executor can provision it.
+        assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_COMPLETE);
+        Map<String, char[]> credentials = flowUser.getUserCredentials();
+        assertEquals(new String(credentials.get(PASSWORD_KEY)), PASSWORD_VALUE);
+    }
 
-            // Mock IdentityTenantUtil for INVITED_USER_REGISTRATION flow
-            mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN))
-                    .thenReturn(TENANT_ID);
-        }
+    @Test
+    public void testExecuteWithExistingCredentialsAndNoUserInput() {
 
-        // Mocks for data holder and user store
-        IdentityRecoveryServiceDataHolder dataHolder = mock(IdentityRecoveryServiceDataHolder.class);
-        RealmService realmService = mock(RealmService.class);
-        UserRealm userRealm = mock(UserRealm.class);
-        AbstractUserStoreManager storeManager = mock(AbstractUserStoreManager.class);
-        TenantManager tenantManager = mock(TenantManager.class);
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        when(context.getUserInputData()).thenReturn(Collections.emptyMap());
 
-        mockedDataHolderStatic.when(IdentityRecoveryServiceDataHolder::getInstance).thenReturn(dataHolder);
-        when(dataHolder.getRealmService()).thenReturn(realmService);
+        FlowUser flowUser = new FlowUser();
+        Map<String, char[]> credentials = new HashMap<>();
+        credentials.put(PASSWORD_KEY, PASSWORD_VALUE.toCharArray());
+        flowUser.setUserCredentials(credentials);
+        when(context.getFlowUser()).thenReturn(flowUser);
 
-        if (Flow.Name.INVITED_USER_REGISTRATION.name().equals(flowType)) {
-            when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
-            when(userRealm.getUserStoreManager()).thenReturn(storeManager);
-        } else {
-            // For PASSWORD_RECOVERY flow
-            when(realmService.getTenantManager()).thenReturn(tenantManager);
-            when(tenantManager.getTenantId(TENANT_DOMAIN)).thenReturn(TENANT_ID);
-            when(realmService.getTenantUserRealm(TENANT_ID)).thenReturn(userRealm);
-            when(userRealm.getUserStoreManager()).thenReturn(storeManager);
-            when(storeManager.getSecondaryUserStoreManager(anyString())).thenReturn(storeManager);
-        }
+        ExecutorResponse response = executor.execute(context);
 
-        when(storeManager.getUserIDFromUserName(anyString())).thenReturn(USER_ID);
+        // Credentials already captured (e.g. by a previous step); no further input is required.
+        assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_COMPLETE);
+    }
 
-        IdentityEventService eventServiceMock = mock(IdentityEventService.class);
-        when(dataHolder.getIdentityEventService()).thenReturn(eventServiceMock);
+    @Test
+    public void testExecuteWithCredentialsLackingPasswordRequiresInput() {
+
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        when(context.getUserInputData()).thenReturn(Collections.emptyMap());
+
+        FlowUser flowUser = new FlowUser();
+        Map<String, char[]> credentials = new HashMap<>();
+        credentials.put("otherCredential", "value".toCharArray());
+        flowUser.setUserCredentials(credentials);
+        when(context.getFlowUser()).thenReturn(flowUser);
+
+        ExecutorResponse response = executor.execute(context);
+
+        // Password availability is decided by the password entry itself, not by map occupancy.
+        assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_USER_INPUT_REQUIRED);
+        assertTrue(response.getRequiredData().contains(PASSWORD_KEY));
+    }
+
+    @Test
+    public void testExecuteCapturePreservesOtherCredentialEntries() {
+
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        Map<String, String> userInputData = new HashMap<>();
+        userInputData.put(PASSWORD_KEY, PASSWORD_VALUE);
+        when(context.getUserInputData()).thenReturn(userInputData);
+
+        FlowUser flowUser = new FlowUser();
+        Map<String, char[]> credentials = new HashMap<>();
+        credentials.put("otherCredential", "value".toCharArray());
+        flowUser.setUserCredentials(credentials);
+        when(context.getFlowUser()).thenReturn(flowUser);
 
         ExecutorResponse response = executor.execute(context);
 
         assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_COMPLETE);
-        if (Flow.Name.INVITED_USER_REGISTRATION.name().equals(flowType)) {
-            assertEquals(flowUser.getUserId(), USER_ID);
+        // Capturing the password must not clear other credential entries already on the flow user.
+        assertEquals(new String(flowUser.getUserCredentials().get(PASSWORD_KEY)), PASSWORD_VALUE);
+        assertEquals(new String(flowUser.getUserCredentials().get("otherCredential")), "value");
+    }
+
+    @Test
+    public void testExecuteDoesNotTouchUserStore() {
+
+        try (MockedStatic<IdentityRecoveryServiceDataHolder> mockedDataHolder =
+                     mockStatic(IdentityRecoveryServiceDataHolder.class)) {
+            FlowExecutionContext context = mock(FlowExecutionContext.class);
+            Map<String, String> userInputData = new HashMap<>();
+            userInputData.put(PASSWORD_KEY, PASSWORD_VALUE);
+            when(context.getUserInputData()).thenReturn(userInputData);
+            when(context.getFlowType()).thenReturn("PASSWORD_RECOVERY");
+            when(context.getFlowUser()).thenReturn(new FlowUser());
+
+            ExecutorResponse response = executor.execute(context);
+
+            // Capture-only contract: even for recovery flows this executor never reaches the user store;
+            // the downstream UserProvisioningExecutor performs the credential update.
+            assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_COMPLETE);
+            mockedDataHolder.verifyNoInteractions();
         }
-        verify(storeManager).updateCredentialByAdmin(eq(USERNAME), any(char[].class));
-    }
-
-    @Test
-    public void testExecuteWithExceptionInUpdate() throws Exception {
-
-        FlowExecutionContext context = mock(FlowExecutionContext.class);
-        FlowUser flowUser = new FlowUser();
-        flowUser.setUsername(USERNAME);
-        flowUser.setUserStoreDomain("PRIMARY");
-
-        Map<String, String> userInputData = new HashMap<>();
-        userInputData.put(PASSWORD_KEY, "Password123");
-
-        when(context.getUserInputData()).thenReturn(userInputData);
-        when(context.getFlowType()).thenReturn(PASSWORD_RECOVERY);
-        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
-        when(context.getFlowUser()).thenReturn(flowUser);
-
-        IdentityRecoveryServiceDataHolder dataHolder = mock(IdentityRecoveryServiceDataHolder.class);
-        RealmService realmService = mock(RealmService.class);
-        UserRealm userRealm = mock(UserRealm.class);
-        AbstractUserStoreManager storeManager = mock(AbstractUserStoreManager.class);
-        TenantManager tenantManager = mock(TenantManager.class);
-
-        mockedDataHolderStatic.when(IdentityRecoveryServiceDataHolder::getInstance).thenReturn(dataHolder);
-        when(dataHolder.getRealmService()).thenReturn(realmService);
-        when(realmService.getTenantManager()).thenReturn(tenantManager);
-        when(tenantManager.getTenantId(TENANT_DOMAIN)).thenReturn(TENANT_ID);
-        when(realmService.getTenantUserRealm(TENANT_ID)).thenReturn(userRealm);
-        when(userRealm.getUserStoreManager()).thenReturn(storeManager);
-        when(storeManager.getSecondaryUserStoreManager(anyString())).thenReturn(storeManager);
-
-        doThrow(new UserStoreException("Error while updating credential"))
-                .when(storeManager).updateCredentialByAdmin(anyString(), any(char[].class));
-
-        ExecutorResponse response = executor.execute(context);
-
-        assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_ERROR);
-    }
-
-    @Test
-    public void testHandleAskPasswordFlowWithException() throws Exception {
-
-        FlowExecutionContext context = mock(FlowExecutionContext.class);
-        FlowUser flowUser = new FlowUser();
-        flowUser.setUsername(USERNAME);
-        flowUser.addClaims(new HashMap<>());
-        flowUser.setUserStoreDomain("PRIMARY");
-
-        Map<String, String> userInputData = new HashMap<>();
-        userInputData.put(PASSWORD_KEY, "Password123");
-        userInputData.put(CONFIRMATION_CODE_INPUT, "valid-code");
-
-        when(context.getUserInputData()).thenReturn(userInputData);
-        when(context.getFlowType()).thenReturn(Flow.Name.INVITED_USER_REGISTRATION.name());
-        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
-        when(context.getFlowUser()).thenReturn(flowUser);
-        when(context.getProperty(CONFIRMATION_CODE_INPUT)).thenReturn("valid-code");
-
-        User user = new User();
-        user.setUserName(USERNAME);
-        user.setTenantDomain(TENANT_DOMAIN);
-        user.setUserStoreDomain("PRIMARY");
-        when(context.getProperty(USER)).thenReturn(user);
-        when(context.getProperty(RECOVERY_SCENARIO)).thenReturn("SCENARIO");
-
-        // Mock IdentityTenantUtil
-        mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN))
-                .thenReturn(TENANT_ID);
-
-        // Mocks for data holder and user store
-        IdentityRecoveryServiceDataHolder dataHolder = mock(IdentityRecoveryServiceDataHolder.class);
-        RealmService realmService = mock(RealmService.class);
-        UserRealm userRealm = mock(UserRealm.class);
-        AbstractUserStoreManager storeManager = mock(AbstractUserStoreManager.class);
-
-        mockedDataHolderStatic.when(IdentityRecoveryServiceDataHolder::getInstance).thenReturn(dataHolder);
-        when(dataHolder.getRealmService()).thenReturn(realmService);
-        when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
-        when(userRealm.getUserStoreManager()).thenReturn(storeManager);
-
-        IdentityEventService eventServiceMock = mock(IdentityEventService.class);
-        when(dataHolder.getIdentityEventService()).thenReturn(eventServiceMock);
-
-        // Throw UserStoreException to trigger the catch block
-        doThrow(new UserStoreException("Error while updating credential"))
-                .when(storeManager).updateCredentialByAdmin(anyString(), any(char[].class));
-
-        ExecutorResponse response = executor.execute(context);
-
-        assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_ERROR);
-    }
-
-    @DataProvider(name = "flowTypes")
-    public Object[][] provideFlowTypes() {
-
-        return new Object[][]{
-                {Flow.Name.INVITED_USER_REGISTRATION.name()},
-                { PASSWORD_RECOVERY }
-        };
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutorTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutorTest.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineException;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
@@ -46,28 +47,31 @@ import org.wso2.carbon.identity.flow.execution.engine.util.FlowExecutionEngineUt
 import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
 import org.wso2.carbon.identity.user.action.api.exception.UserActionExecutionClientException;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
-import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.tenant.TenantManager;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -82,7 +86,11 @@ import static org.wso2.carbon.identity.flow.execution.engine.Constants.PASSWORD_
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.USERNAME_CLAIM_URI;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.PASSWORD_RECOVERY;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.REGISTRATION;
+import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.CONFIRMATION_CODE_INPUT;
+import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.RECOVERY_SCENARIO;
+import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.USER;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.DISPLAY_CLAIM_AVAILABILITY_CONFIG;
+import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.REGISTRATION_DEFAULT_USER_STORE_CONFIG;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_INVALID_USERNAME;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_USERNAME_ALREADY_EXISTS;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_USER_EXISTENCE_CHECK_FAILURE;
@@ -104,6 +112,8 @@ public class UserProvisioningExecutorTest {
     private static final String SECONDARY_DOMAIN = "SECONDARY";
     private static final String WSO2_CLAIM_DIALECT = "http://wso2.org/claims/";
     private static final int TENANT_ID = 1234;
+    private static final String EXTENSION_PASSWORD = "ExtensionPwd456!";
+    private static final String INPUT_PASSWORD = "UserInputPwd789!";
 
     private UserProvisioningExecutor executor;
     private MockedStatic<IdentityRecoveryServiceDataHolder> mockedDataHolder;
@@ -220,14 +230,312 @@ public class UserProvisioningExecutorTest {
         when(context.getContextIdentifier()).thenReturn(CONTEXT_ID);
         when(context.getProperty("isUsernamePatternValidationSkipped")).thenReturn(null);
 
+        // The ask-password (invited user registration) flow provisions the password before persisting claims.
+        when(context.getProperty(CONFIRMATION_CODE_INPUT)).thenReturn("valid-code");
+        when(context.getProperty(RECOVERY_SCENARIO)).thenReturn("SCENARIO");
+        User invitedUser = new User();
+        invitedUser.setUserName(USERNAME);
+        invitedUser.setTenantDomain(TENANT_DOMAIN);
+        invitedUser.setUserStoreDomain(PRIMARY_DOMAIN);
+        when(context.getProperty(USER)).thenReturn(invitedUser);
+
         // Setup mocks
         AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+        IdentityEventService eventService = mock(IdentityEventService.class);
+        when(IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService()).thenReturn(eventService);
 
         ExecutorResponse response = executor.execute(context);
 
         assertEquals(response.getResult(), STATUS_COMPLETE);
         verify(userStoreManager).setUserClaimValues(eq(PRIMARY_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + USERNAME),
                 eq(Collections.singletonMap(givenNameClaim, "John")), isNull());
+    }
+
+    @Test
+    public void testExecutePasswordRecoveryUpdatesCredential() throws Exception {
+
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        FlowUser flowUser = createTestFlowUser(USERNAME);
+
+        when(context.getFlowType()).thenReturn(PASSWORD_RECOVERY.getType());
+        when(context.getFlowUser()).thenReturn(flowUser);
+        when(context.getUserInputData()).thenReturn(new HashMap<>());
+        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+        when(context.getContextIdentifier()).thenReturn(CONTEXT_ID);
+        when(context.getProperty("isUsernamePatternValidationSkipped")).thenReturn(null);
+
+        AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_COMPLETE);
+        verify(userStoreManager).updateCredentialByAdmin(eq(USERNAME), any(char[].class));
+    }
+
+    @Test
+    public void testExecutePasswordRecoveryCredentialUpdateFailure() throws Exception {
+
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        FlowUser flowUser = createTestFlowUser(USERNAME);
+
+        when(context.getFlowType()).thenReturn(PASSWORD_RECOVERY.getType());
+        when(context.getFlowUser()).thenReturn(flowUser);
+        when(context.getUserInputData()).thenReturn(new HashMap<>());
+        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+        when(context.getContextIdentifier()).thenReturn(CONTEXT_ID);
+        when(context.getProperty("isUsernamePatternValidationSkipped")).thenReturn(null);
+
+        AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+        doThrow(new UserStoreException("Error while updating credential"))
+                .when(userStoreManager).updateCredentialByAdmin(anyString(), any(char[].class));
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_ERROR);
+    }
+
+    @Test
+    public void testExecuteAskPasswordUpdatesCredential() throws Exception {
+
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        FlowUser flowUser = createTestFlowUser(USERNAME);
+
+        when(context.getFlowType()).thenReturn("INVITED_USER_REGISTRATION");
+        when(context.getFlowUser()).thenReturn(flowUser);
+        when(context.getUserInputData()).thenReturn(new HashMap<>());
+        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+        when(context.getContextIdentifier()).thenReturn(CONTEXT_ID);
+        when(context.getProperty("isUsernamePatternValidationSkipped")).thenReturn(null);
+
+        when(context.getProperty(CONFIRMATION_CODE_INPUT)).thenReturn("valid-code");
+        when(context.getProperty(RECOVERY_SCENARIO)).thenReturn("SCENARIO");
+        User invitedUser = new User();
+        invitedUser.setUserName(USERNAME);
+        invitedUser.setTenantDomain(TENANT_DOMAIN);
+        invitedUser.setUserStoreDomain(PRIMARY_DOMAIN);
+        when(context.getProperty(USER)).thenReturn(invitedUser);
+
+        AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+        IdentityEventService eventService = mock(IdentityEventService.class);
+        when(IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService()).thenReturn(eventService);
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_COMPLETE);
+        verify(userStoreManager).updateCredentialByAdmin(eq(USERNAME), any(char[].class));
+    }
+
+    @Test
+    public void testExecuteAskPasswordCredentialUpdateFailure() throws Exception {
+
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        FlowUser flowUser = createTestFlowUser(USERNAME);
+
+        when(context.getFlowType()).thenReturn("INVITED_USER_REGISTRATION");
+        when(context.getFlowUser()).thenReturn(flowUser);
+        when(context.getUserInputData()).thenReturn(new HashMap<>());
+        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+        when(context.getContextIdentifier()).thenReturn(CONTEXT_ID);
+        when(context.getProperty("isUsernamePatternValidationSkipped")).thenReturn(null);
+
+        when(context.getProperty(CONFIRMATION_CODE_INPUT)).thenReturn("valid-code");
+        when(context.getProperty(RECOVERY_SCENARIO)).thenReturn("SCENARIO");
+        User invitedUser = new User();
+        invitedUser.setUserName(USERNAME);
+        invitedUser.setTenantDomain(TENANT_DOMAIN);
+        invitedUser.setUserStoreDomain(PRIMARY_DOMAIN);
+        when(context.getProperty(USER)).thenReturn(invitedUser);
+
+        AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+        IdentityEventService eventService = mock(IdentityEventService.class);
+        when(IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService()).thenReturn(eventService);
+        doThrow(new UserStoreException("Error while updating credential"))
+                .when(userStoreManager).updateCredentialByAdmin(anyString(), any(char[].class));
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_ERROR);
+    }
+
+    @Test
+    public void testExecutePasswordRecoveryPrefersFlowUserCredentialOverUserInput() throws Exception {
+
+        FlowUser flowUser = createRealFlowUser(EXTENSION_PASSWORD);
+        Map<String, String> userInputData = new HashMap<>();
+        userInputData.put(PASSWORD_KEY, INPUT_PASSWORD);
+        FlowExecutionContext context = createPasswordFlowContext(flowUser, PASSWORD_RECOVERY.getType(),
+                userInputData);
+
+        AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+        AtomicReference<String> provisionedPassword = capturePasswordOnUpdate(userStoreManager);
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_COMPLETE);
+        // The credential set on the flow user (e.g. by a flow extension) wins over the raw user input.
+        assertEquals(provisionedPassword.get(), EXTENSION_PASSWORD);
+    }
+
+    @Test
+    public void testExecuteAskPasswordPrefersFlowUserCredentialOverUserInput() throws Exception {
+
+        FlowUser flowUser = createRealFlowUser(EXTENSION_PASSWORD);
+        Map<String, String> userInputData = new HashMap<>();
+        userInputData.put(PASSWORD_KEY, INPUT_PASSWORD);
+        FlowExecutionContext context = createPasswordFlowContext(flowUser, "INVITED_USER_REGISTRATION",
+                userInputData);
+
+        AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+        stubAskPasswordProperties(context, PRIMARY_DOMAIN);
+        AtomicReference<String> provisionedPassword = capturePasswordOnUpdate(userStoreManager);
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_COMPLETE);
+        assertEquals(provisionedPassword.get(), EXTENSION_PASSWORD);
+    }
+
+    @Test
+    public void testExecutePasswordRecoveryFallsBackToUserInput() throws Exception {
+
+        FlowUser flowUser = createRealFlowUser(null);
+        Map<String, char[]> credentials = new HashMap<>();
+        credentials.put("otherCredential", "value".toCharArray());
+        flowUser.setUserCredentials(credentials);
+        Map<String, String> userInputData = new HashMap<>();
+        userInputData.put(PASSWORD_KEY, INPUT_PASSWORD);
+        FlowExecutionContext context = createPasswordFlowContext(flowUser, PASSWORD_RECOVERY.getType(),
+                userInputData);
+
+        AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+        AtomicReference<String> provisionedPassword = capturePasswordOnUpdate(userStoreManager);
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_COMPLETE);
+        assertEquals(provisionedPassword.get(), INPUT_PASSWORD);
+        // Capturing the fallback password must not clear other credential entries already on the flow user.
+        assertEquals(new String(flowUser.getUserCredentials().get("otherCredential")), "value");
+    }
+
+    @Test
+    public void testExecutePasswordRecoveryFailsWhenNoPasswordAvailable() throws Exception {
+
+        FlowUser flowUser = createRealFlowUser(null);
+        FlowExecutionContext context = createPasswordFlowContext(flowUser, PASSWORD_RECOVERY.getType(),
+                new HashMap<>());
+
+        AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_ERROR);
+        verify(userStoreManager, never()).updateCredentialByAdmin(anyString(), any(char[].class));
+    }
+
+    @Test
+    public void testExecuteAskPasswordPopulatesFlowUserIdentity() throws Exception {
+
+        FlowUser flowUser = createRealFlowUser(PASSWORD);
+        FlowExecutionContext context = createPasswordFlowContext(flowUser, "INVITED_USER_REGISTRATION",
+                new HashMap<>());
+
+        AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+        stubAskPasswordProperties(context, SECONDARY_DOMAIN);
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_COMPLETE);
+        // Post-flow handling (e.g. building the auto-login assertion) relies on the flow user's id and domain.
+        assertEquals(flowUser.getUserId(), USER_ID);
+        assertEquals(flowUser.getUserStoreDomain(), SECONDARY_DOMAIN);
+        // Resolved once for the credential update and once for the claim/consent persistence.
+        verify(userStoreManager, times(2)).getSecondaryUserStoreManager(SECONDARY_DOMAIN);
+    }
+
+    @Test
+    public void testExecuteAskPasswordPersistsClaimsInCredentialDomain() throws Exception {
+
+        FlowUser flowUser = createRealFlowUser(PASSWORD);
+        String givenNameClaim = WSO2_CLAIM_DIALECT + "givenname";
+        flowUser.addUpdatedClaim(givenNameClaim, "John");
+        FlowExecutionContext context = createPasswordFlowContext(flowUser, "INVITED_USER_REGISTRATION",
+                new HashMap<>());
+
+        AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+        stubAskPasswordProperties(context, SECONDARY_DOMAIN);
+        AbstractUserStoreManager secondaryStoreManager = mock(AbstractUserStoreManager.class);
+        when(userStoreManager.getSecondaryUserStoreManager(SECONDARY_DOMAIN)).thenReturn(secondaryStoreManager);
+        mockedIdentityUtil.when(() -> IdentityUtil.addDomainToName(USERNAME, SECONDARY_DOMAIN))
+                .thenReturn(SECONDARY_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + USERNAME);
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_COMPLETE);
+        // The credential update and the claim persistence must both target the credential's user store,
+        // not a domain recomputed from the unqualified username.
+        verify(secondaryStoreManager).updateCredentialByAdmin(eq(USERNAME), any(char[].class));
+        verify(secondaryStoreManager).setUserClaimValues(
+                eq(SECONDARY_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + USERNAME),
+                eq(Collections.singletonMap(givenNameClaim, "John")), isNull());
+    }
+
+    @Test
+    public void testExecutePasswordRecoveryIgnoresSelfRegistrationDefaultUserStore() throws Exception {
+
+        FlowUser flowUser = createRealFlowUser(PASSWORD);
+        FlowExecutionContext context = createPasswordFlowContext(flowUser, PASSWORD_RECOVERY.getType(),
+                new HashMap<>());
+
+        AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+        // The self-registration default user store config must not steer the recovery credential update.
+        mockedIdentityUtil.when(() -> IdentityUtil.getProperty(REGISTRATION_DEFAULT_USER_STORE_CONFIG))
+                .thenReturn("DECOY");
+        AbstractUserStoreManager decoyStoreManager = mock(AbstractUserStoreManager.class);
+        when(userStoreManager.getSecondaryUserStoreManager("DECOY")).thenReturn(decoyStoreManager);
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_COMPLETE);
+        verify(userStoreManager).updateCredentialByAdmin(eq(USERNAME), any(char[].class));
+        verify(decoyStoreManager, never()).updateCredentialByAdmin(anyString(), any(char[].class));
+    }
+
+    @Test
+    public void testExecutePasswordRecoveryNeverGeneratesRandomPassword() throws Exception {
+
+        FlowUser flowUser = createRealFlowUser(null);
+        Map<String, char[]> credentials = new HashMap<>();
+        credentials.put("otherCredential", "value".toCharArray());
+        flowUser.setUserCredentials(credentials);
+        FlowExecutionContext context = createPasswordFlowContext(flowUser, PASSWORD_RECOVERY.getType(),
+                new HashMap<>());
+
+        AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+
+        ExecutorResponse response = executor.execute(context);
+
+        // A credentials map without a password entry must return error, not provision a generated password.
+        assertEquals(response.getResult(), STATUS_ERROR);
+        verify(userStoreManager, never()).updateCredentialByAdmin(anyString(), any(char[].class));
+    }
+
+    @Test
+    public void testExecutePasswordRecoveryKeepsCredentialOnFailure() throws Exception {
+
+        FlowUser flowUser = createRealFlowUser(PASSWORD);
+        FlowExecutionContext context = createPasswordFlowContext(flowUser, PASSWORD_RECOVERY.getType(),
+                new HashMap<>());
+
+        AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+        doThrow(new UserStoreException("Error while updating credential"))
+                .when(userStoreManager).updateCredentialByAdmin(anyString(), any(char[].class));
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_ERROR);
+        // The stored credential stays intact (not consumed) so that a retry can provision it.
+        assertEquals(new String(flowUser.getUserCredentials().get(PASSWORD_KEY)), PASSWORD);
     }
 
     @Test
@@ -690,8 +998,11 @@ public class UserProvisioningExecutorTest {
         AbstractUserStoreManager primaryStoreManager = mock(AbstractUserStoreManager.class);
         AbstractUserStoreManager secondaryStoreManager = mock(AbstractUserStoreManager.class);
 
+        TenantManager tenantManager = mock(TenantManager.class);
         mockedDataHolder.when(IdentityRecoveryServiceDataHolder::getInstance).thenReturn(dataHolder);
         when(dataHolder.getRealmService()).thenReturn(realmService);
+        when(realmService.getTenantManager()).thenReturn(tenantManager);
+        when(tenantManager.getTenantId(TENANT_DOMAIN)).thenReturn(TENANT_ID);
         when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
         when(userRealm.getUserStoreManager()).thenReturn(primaryStoreManager);
         when(primaryStoreManager.getSecondaryUserStoreManager(SECONDARY_DOMAIN)).thenReturn(secondaryStoreManager);
@@ -1342,6 +1653,12 @@ public class UserProvisioningExecutorTest {
         when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
         when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
         when(userStoreManager.getUserIDFromUserName(anyString())).thenReturn(USER_ID);
+        // Password recovery provisioning resolves the realm via the tenant manager and updates the credential
+        // through the secondary user store manager.
+        TenantManager tenantManager = mock(TenantManager.class);
+        when(realmService.getTenantManager()).thenReturn(tenantManager);
+        when(tenantManager.getTenantId(TENANT_DOMAIN)).thenReturn(TENANT_ID);
+        when(userStoreManager.getSecondaryUserStoreManager(any())).thenReturn(userStoreManager);
 
         mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN)).thenReturn(TENANT_ID);
         mockedIdentityUtil.when(IdentityUtil::getPrimaryDomainName).thenReturn(PRIMARY_DOMAIN);
@@ -1350,5 +1667,72 @@ public class UserProvisioningExecutorTest {
         mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName(anyString())).thenReturn(USERNAME);
 
         return userStoreManager;
+    }
+
+    /**
+     * Creates a real (non-mock) flow user so that credential capture, consumption and identity population
+     * can be asserted on actual state.
+     *
+     * @param password Password credential to preset on the flow user; {@code null} for no credentials.
+     * @return Flow user instance.
+     */
+    private FlowUser createRealFlowUser(String password) {
+
+        FlowUser flowUser = new FlowUser();
+        flowUser.setUsername(USERNAME);
+        flowUser.addClaim(USERNAME_CLAIM_URI, USERNAME);
+        if (password != null) {
+            Map<String, char[]> credentials = new HashMap<>();
+            credentials.put(PASSWORD_KEY, password.toCharArray());
+            flowUser.setUserCredentials(credentials);
+        }
+        return flowUser;
+    }
+
+    private FlowExecutionContext createPasswordFlowContext(FlowUser flowUser, String flowType,
+                                                           Map<String, String> userInputData) {
+
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        when(context.getFlowType()).thenReturn(flowType);
+        when(context.getFlowUser()).thenReturn(flowUser);
+        when(context.getUserInputData()).thenReturn(userInputData);
+        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+        when(context.getContextIdentifier()).thenReturn(CONTEXT_ID);
+        when(context.getProperty("isUsernamePatternValidationSkipped")).thenReturn(null);
+        return context;
+    }
+
+    /**
+     * Stubs the context properties required by the ask-password (invited user registration) flow. Must be
+     * called after {@link #setupUserStoreManagerMocks()} since it stubs the identity event service on the
+     * mocked data holder.
+     */
+    private void stubAskPasswordProperties(FlowExecutionContext context, String userStoreDomain) {
+
+        when(context.getProperty(CONFIRMATION_CODE_INPUT)).thenReturn("valid-code");
+        when(context.getProperty(RECOVERY_SCENARIO)).thenReturn("SCENARIO");
+        User invitedUser = new User();
+        invitedUser.setUserName(USERNAME);
+        invitedUser.setTenantDomain(TENANT_DOMAIN);
+        invitedUser.setUserStoreDomain(userStoreDomain);
+        when(context.getProperty(USER)).thenReturn(invitedUser);
+        when(IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService())
+                .thenReturn(mock(IdentityEventService.class));
+    }
+
+    /**
+     * Snapshots the password handed to {@code updateCredentialByAdmin} at invocation time. The executor
+     * zeroes its password copy after use, so a plain {@code ArgumentCaptor} would only observe the wiped
+     * array.
+     */
+    private AtomicReference<String> capturePasswordOnUpdate(AbstractUserStoreManager userStoreManager)
+            throws Exception {
+
+        AtomicReference<String> provisionedPassword = new AtomicReference<>();
+        doAnswer(invocation -> {
+            provisionedPassword.set(new String((char[]) invocation.getArguments()[1]));
+            return null;
+        }).when(userStoreManager).updateCredentialByAdmin(eq(USERNAME), any(char[].class));
+        return provisionedPassword;
     }
 }


### PR DESCRIPTION
## Purpose
In password recovery and invited user registration (ask password) flows, the password provisioning step re-read the raw user input when updating the user credential. When a flow extension configured after the password provisioning step overrode the credential on the flow user, that overridden value was discarded and the original user input was persisted instead. This change makes the provisioned credential reflect the value present on the flow user at provisioning time.

## Related Issue
- https://github.com/wso2/product-is/issues/28177

## Implementation
- Moved the password provisioning logic for the password recovery and invited user / ask password flows out of `PasswordProvisioningExecutor` and into `UserProvisioningExecutor`, so the credential update happens in a single place alongside the profile claim and consent persistence.
- `UserProvisioningExecutor` now prefers the credentials already set on the flow user and only falls back to the raw user input when the flow user has no credentials yet (e.g. a single-node flow where the executor itself collects the password). This prevents a later flow extension's credential from being clobbered.
- `PasswordProvisioningExecutor` is retained for backward compatibility with existing flow definitions that reference it. It no longer updates the credential; it only captures the password into the flow user so the downstream `UserProvisioningExecutor` can provision it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated password recovery and invited-user registration to follow a consistent two-step flow: capture/validate password input first, then provision it when needed.
  * If no usable password is available, the flow now requests required input instead of failing later.
  * During provisioning, the system prioritizes an existing stored password (when present), otherwise uses user-provided password, while preserving other credentials.
* **Bug Fixes**
  * Improved handling of malformed user data in flow context properties by treating additional deserialization failures as “no user available.”
* **Tests**
  * Expanded and refactored executor test coverage for capture-only behavior, precedence rules, successful/failed provisioning, claim persistence, and safe handling when password data is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->