### PR TITLE
Provision the user credential from the flow user in password recovery and ask password flows

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutor.java
@@ -20,60 +20,24 @@ package org.wso2.carbon.identity.recovery.executor;
 
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.identity.application.common.model.User;
-import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
-import org.wso2.carbon.identity.core.context.IdentityContext;
-import org.wso2.carbon.identity.core.context.model.Flow;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.event.IdentityEventConstants;
-import org.wso2.carbon.identity.event.IdentityEventException;
-import org.wso2.carbon.identity.event.event.Event;
-import org.wso2.carbon.identity.flow.execution.engine.Constants;
-import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineException;
 import org.wso2.carbon.identity.flow.execution.engine.graph.AuthenticationExecutor;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
-import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
-import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
-import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
-import org.wso2.carbon.identity.recovery.util.Utils;
-import org.wso2.carbon.identity.recovery.util.ExecutorConsentUtils;
-import org.wso2.carbon.identity.user.action.api.constant.UserActionError;
-import org.wso2.carbon.identity.user.action.api.exception.UserActionExecutionClientException;
-import org.wso2.carbon.user.api.UserStoreException;
-import org.wso2.carbon.user.api.UserStoreManager;
-import org.wso2.carbon.user.core.UserRealm;
-import org.wso2.carbon.user.core.UserStoreClientException;
-import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
-import org.wso2.carbon.user.core.service.RealmService;
-import org.wso2.carbon.user.mgt.common.DefaultPasswordGenerator;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.wso2.carbon.identity.flow.execution.engine.Constants.ErrorMessages.ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_VALIDATION_FAILURE;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_COMPLETE;
-import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_ERROR;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_USER_INPUT_REQUIRED;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.PASSWORD_KEY;
-import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.INVITED_USER_REGISTRATION;
-import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.PASSWORD_RECOVERY;
-import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.REGISTRATION;
-import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.CONFIRMATION_CODE;
-import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.CONFIRMATION_CODE_INPUT;
 
 /**
  * Executor to provision the password.
  */
 public class PasswordProvisioningExecutor extends AuthenticationExecutor {
-
-    private static final Log LOG = LogFactory.getLog(PasswordProvisioningExecutor.class);
 
     @Override
     public String getName() {
@@ -117,139 +81,7 @@ public class PasswordProvisioningExecutor extends AuthenticationExecutor {
             }
         }
 
-        if (REGISTRATION.getType().equalsIgnoreCase(context.getFlowType())) {
-            return new ExecutorResponse(STATUS_COMPLETE);
-        }
-
-        char[] password = credentials.getOrDefault(PASSWORD_KEY, new DefaultPasswordGenerator().generatePassword());
-        try {
-            if (PASSWORD_RECOVERY.getType().equalsIgnoreCase(context.getFlowType())) {
-                return handlePasswordRecoveryFlow(context, password);
-            } else if (INVITED_USER_REGISTRATION.getType().equalsIgnoreCase(context.getFlowType())) {
-                return handleAskPasswordFlow(context, password);
-            }
-            return new ExecutorResponse();
-        } finally {
-            Arrays.fill(password, '\0');
-        }
-    }
-
-    private ExecutorResponse handleAskPasswordFlow(FlowExecutionContext context, char[] password) {
-
-        String confirmationCode = (String) context.getProperty(CONFIRMATION_CODE_INPUT);
-        User user = Utils.resolveUserFromContext(context);
-        if (StringUtils.isBlank(confirmationCode) || user == null) {
-            return errorResponse(new ExecutorResponse(), "Required properties are missing in the context.");
-        }
-
-        String recoveryScenario = getStringProperty(context, IdentityRecoveryConstants.RECOVERY_SCENARIO);
-
-        try {
-            enterFlow();
-            int tenantId = IdentityTenantUtil.getTenantId(context.getTenantDomain());
-
-            handlePrePasswordUpdate(user, recoveryScenario, confirmationCode);
-
-            UserStoreManager userStoreManager = IdentityRecoveryServiceDataHolder.getInstance()
-                    .getRealmService().getTenantUserRealm(tenantId).getUserStoreManager();
-            userStoreManager.updateCredentialByAdmin(context.getFlowUser().getUsername(), password);
-            String userId = ((AbstractUserStoreManager) userStoreManager)
-                    .getUserIDFromUserName(context.getFlowUser().getUsername());
-            context.getFlowUser().setUserId(userId);
-            context.getFlowUser().setUserStoreDomain(user.getUserStoreDomain());
-
-            ExecutorConsentUtils.processUserConsent(getName(), context, context.getFlowUser(),
-                    user.getUserStoreDomain());
-
-            return new ExecutorResponse(STATUS_COMPLETE);
-        } catch (UserStoreException | IdentityEventException | IdentityRecoveryException | FlowEngineException e) {
-            ExecutorResponse errorResponse = handleClientExceptionForActionFailure(e);
-            if (errorResponse.getResult() != null) {
-                return errorResponse;
-            }
-
-            String maskedUsername = LoggerUtils.isLogMaskingEnable
-                    ? LoggerUtils.getMaskedContent(context.getFlowUser().getUsername())
-                    : context.getFlowUser().getUsername();
-            LOG.error("Error while updating password for user: " + maskedUsername, e);
-            return errorResponse(new ExecutorResponse(), e.getMessage());
-        } finally {
-            IdentityContext.getThreadLocalIdentityContext().exitFlow();
-        }
-    }
-
-    private String getStringProperty(FlowExecutionContext context, String key) {
-
-        Object value = context.getProperty(key);
-        return (value != null) ? value.toString() : null;
-    }
-
-    private void handlePrePasswordUpdate(User user, String recoveryScenario, String confirmationCode)
-            throws IdentityRecoveryException, IdentityEventException {
-
-        publishEvent(user, confirmationCode, IdentityEventConstants.Event.
-                PRE_ADD_NEW_PASSWORD, recoveryScenario);
-    }
-
-    private void enterFlow() {
-
-        Flow.InitiatingPersona initiatingPersona;
-        Flow existingFlow = IdentityContext.getThreadLocalIdentityContext().getCurrentFlow();
-
-        if (existingFlow != null) {
-            initiatingPersona = existingFlow.getInitiatingPersona();
-        } else {
-            initiatingPersona = Flow.InitiatingPersona.ADMIN;
-        }
-
-        Flow flow = new Flow.Builder()
-                .name(Flow.Name.INVITED_USER_REGISTRATION)
-                .initiatingPersona(initiatingPersona)
-                .build();
-
-        IdentityContext.getThreadLocalIdentityContext().enterFlow(flow);
-    }
-
-    private void publishEvent(User user, String code, String eventName, String recoveryScenario) throws
-            IdentityEventException {
-
-        HashMap<String, Object> properties = new HashMap<>();
-        properties.put(IdentityEventConstants.EventProperty.USER, user);
-        properties.put(IdentityEventConstants.EventProperty.USER_NAME, user.getUserName());
-        properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, user.getTenantDomain());
-        properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, user.getUserStoreDomain());
-        properties.put(IdentityEventConstants.EventProperty.RECOVERY_SCENARIO, recoveryScenario);
-        properties.put(CONFIRMATION_CODE, code);
-
-        Event identityMgtEvent = new Event(eventName, properties);
-        IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);
-    }
-
-    private ExecutorResponse handlePasswordRecoveryFlow(FlowExecutionContext context, char[] password) {
-
-        try {
-            UserRealm userRealm = getUserRealm(context.getTenantDomain());
-            if (userRealm == null) {
-                ExecutorResponse executorResponse = new ExecutorResponse(STATUS_ERROR);
-                executorResponse.setErrorMessage("User realm is not available for tenant");
-                return executorResponse;
-            }
-            UserStoreManager userStoreManager = userRealm.getUserStoreManager()
-                    .getSecondaryUserStoreManager(context.getFlowUser().getUserStoreDomain());
-            userStoreManager.updateCredentialByAdmin(context.getFlowUser().getUsername(), password);
-            return new ExecutorResponse(STATUS_COMPLETE);
-        } catch (UserStoreException e) {
-            ExecutorResponse errorResponse = handleClientExceptionForActionFailure(e);
-            if (errorResponse.getResult() != null) {
-                return errorResponse;
-            }
-
-            String maskedUsername = LoggerUtils.isLogMaskingEnable
-                    ? LoggerUtils.getMaskedContent(context.getFlowUser().getUsername())
-                    : context.getFlowUser().getUsername();
-            LOG.error("Error while updating password for user: " + maskedUsername, e);
-            return errorResponse(new ExecutorResponse(), e.getMessage());
-        }
+        return new ExecutorResponse(STATUS_COMPLETE);
     }
 
     /**
@@ -263,74 +95,4 @@ public class PasswordProvisioningExecutor extends AuthenticationExecutor {
         response.setRequiredData(Collections.singletonList(PASSWORD_KEY));
         return response;
     }
-
-    /**
-     * Creates an error response with the provided message.
-     *
-     * @param response ExecutorResponse to be modified with error details.
-     * @param message  Error message to be set in the response.
-     * @return Modified ExecutorResponse with error details.
-     */
-    private ExecutorResponse errorResponse(ExecutorResponse response, String message) {
-
-        response.setErrorMessage(message);
-        response.setResult(Constants.ExecutorStatus.STATUS_ERROR);
-        return response;
-    }
-
-    /**
-     * Creates a user error response with the provided details.
-     *
-     * @param response    ExecutorResponse to be modified with user error details.
-     * @param errorCode   Error code to be set in the response.
-     * @param message     User error message to be set in the response.
-     * @param description Description of the error to be set in the response.
-     * @param throwable   Throwable associated with the error.
-     * @return Modified ExecutorResponse with user error details.
-     */
-    private ExecutorResponse userErrorResponse(ExecutorResponse response, String errorCode, String message,
-                                               String description, Throwable throwable) {
-
-        response.setErrorCode(errorCode);
-        response.setErrorMessage(message);
-        response.setErrorDescription(description);
-        response.setThrowable(throwable);
-        response.setResult(Constants.ExecutorStatus.STATUS_USER_ERROR);
-        return response;
-    }
-
-    /**
-     * Retrieves the user realm for the given tenant domain.
-     *
-     * @param tenantDomain Tenant domain.
-     * @return UserRealm instance for the tenant.
-     * @throws UserStoreException If an error occurs while retrieving the user realm.
-     */
-    private UserRealm getUserRealm(String tenantDomain) throws UserStoreException {
-
-        RealmService realmService = IdentityRecoveryServiceDataHolder.getInstance().getRealmService();
-        int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
-        return (UserRealm) realmService.getTenantUserRealm(tenantId);
-    }
-
-    private ExecutorResponse handleClientExceptionForActionFailure(Exception e) {
-
-        ExecutorResponse response = new ExecutorResponse();
-        if (e instanceof UserStoreClientException &&
-                UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED
-                        .equals(((UserStoreClientException) e).getErrorCode())) {
-            Throwable cause = e.getCause();
-            while (cause != null) {
-                if (cause instanceof UserActionExecutionClientException) {
-                    return userErrorResponse(response,
-                            ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_VALIDATION_FAILURE.getCode(),
-                            ((UserActionExecutionClientException) cause).getError(),
-                            ((UserActionExecutionClientException) cause).getDescription(), cause);
-                }
-                cause = cause.getCause();
-            }
-        }
-        return response;
-    }
-
 }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
@@ -188,7 +188,9 @@ public class UserProvisioningExecutor implements Executor {
         }
     }
 
-    private void handleUserPasswordUpdate(Map<String, char[]> userCredentials, FlowUser flowUser, UserStoreManager userStoreManager, FlowExecutionContext context) throws FlowEngineException, UserStoreException {
+    private void handleUserPasswordUpdate(Map<String, char[]> userCredentials, FlowUser flowUser,
+                                          UserStoreManager userStoreManager, FlowExecutionContext context)
+            throws FlowEngineException, UserStoreException {
 
         if (INVITED_USER_REGISTRATION.getType().equalsIgnoreCase(context.getFlowType())) {
             String confirmationCode = (String) context.getProperty(CONFIRMATION_CODE_INPUT);
@@ -199,7 +201,7 @@ public class UserProvisioningExecutor implements Executor {
             String recoveryScenario = getRecoveryScenario(context);
             try {
                 enterFlow();
-                handlePrePasswordUpdate(context, user, recoveryScenario, confirmationCode);
+                handlePrePasswordUpdate(user, recoveryScenario, confirmationCode);
                 updateUserPassword(userCredentials, flowUser, userStoreManager);
                 String userId = ((AbstractUserStoreManager) userStoreManager)
                         .getUserIDFromUserName(flowUser.getUsername());
@@ -225,18 +227,14 @@ public class UserProvisioningExecutor implements Executor {
                     .equals(((UserStoreClientException) e).getErrorCode())) {
                 throw e;
             }
-            String maskedUsername = LoggerUtils.isLogMaskingEnable
-                    ? LoggerUtils.getMaskedContent(user.getUsername())
-                    : user.getUsername();
-            LOG.error("Error while updating password for user: " + maskedUsername, e);
             throw new FlowEngineException(null, e.getMessage(), null, e);
         } finally {
             Arrays.fill(password, '\0');
         }
     }
 
-    private void handleUserClaimUpdate(Map<String, String> userClaims,
-                                       FlowUser user, UserStoreManager userStoreManager, String userStoreDomainName) throws FlowEngineException, UserStoreException {
+    private void handleUserClaimUpdate(Map<String, String> userClaims, FlowUser user, UserStoreManager userStoreManager,
+                                       String userStoreDomainName) throws FlowEngineException, UserStoreException {
 
         String domainQualifiedName = IdentityUtil.addDomainToName(user.getUsername(), userStoreDomainName);
         if (!userClaims.isEmpty()) {
@@ -716,7 +714,8 @@ public class UserProvisioningExecutor implements Executor {
         IdentityContext.getThreadLocalIdentityContext().enterFlow(flow);
     }
 
-    private void handlePrePasswordUpdate(FlowExecutionContext context, User user, String recoveryScenario, String confirmationCode) throws FlowEngineException {
+    private void handlePrePasswordUpdate(User user, String recoveryScenario, String confirmationCode)
+            throws FlowEngineException {
 
         try {
             HashMap<String, Object> properties = new HashMap<>();
@@ -732,10 +731,6 @@ public class UserProvisioningExecutor implements Executor {
 
             IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);
         } catch (IdentityEventException e) {
-            String maskedUsername = LoggerUtils.isLogMaskingEnable
-                    ? LoggerUtils.getMaskedContent(context.getFlowUser().getUsername())
-                    : context.getFlowUser().getUsername();
-            LOG.error("Error while updating password for user: " + maskedUsername, e);
             throw new FlowEngineException(null, e.getMessage(), null, e);
         }
     }

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutor.java
@@ -28,9 +28,14 @@ import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Flow;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.core.util.LambdaExceptionUtils;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.flow.execution.engine.Constants;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineClientException;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineException;
@@ -76,7 +81,11 @@ import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.MY_A
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.PASSWORD_KEY;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.STATUS_COMPLETE;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.USERNAME_CLAIM_URI;
+import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.INVITED_USER_REGISTRATION;
+import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.PASSWORD_RECOVERY;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.REGISTRATION;
+import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.CONFIRMATION_CODE;
+import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.CONFIRMATION_CODE_INPUT;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.DISPLAY_CLAIM_AVAILABILITY_CONFIG;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.DUPLICATE_CLAIMS_ERROR_CODE;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.DUPLICATE_CLAIM_ERROR_CODE;
@@ -139,20 +148,25 @@ public class UserProvisioningExecutor implements Executor {
             // Only persist claims the user actually changed during this flow. The preloaded CONSOLE-profile
             // snapshot (which includes non-attribute claims like role/roles) must not be written back.
             Map<String, String> userClaims = filterUpdatedClaims(user);
+            Map<String, char[]> userCredentials = user.getUserCredentials();
 
             String userStoreDomainName = resolveUserStoreDomain(user.getUsername());
             UserStoreManager userStoreManager = getUserStoreManager(context.getTenantDomain(), userStoreDomainName,
                     context.getContextIdentifier(), context.getFlowType());
-            String domainQualifiedName = IdentityUtil.addDomainToName(user.getUsername(), userStoreDomainName);
-            if (!userClaims.isEmpty()) {
-                userStoreManager.setUserClaimValues(domainQualifiedName, userClaims, null);
-            }
+
+            handleUserPasswordUpdate(userCredentials, user, userStoreManager, context);
+            handleUserClaimUpdate(userClaims, user, userStoreManager, userStoreDomainName);
 
             ExecutorConsentUtils.processUserConsent(COMPONENT_ID, context, user, userStoreDomainName);
 
             response.setResult(STATUS_COMPLETE);
             return response;
         } catch (UserStoreException e) {
+            response = buildClientErrorResponseForActionFailure(response, e,
+                    Constants.ErrorMessages.ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_VALIDATION_FAILURE.getCode());
+            if (response.getResult() != null) {
+                return response;
+            }
             if (e instanceof UserStoreClientException) {
                 UserStoreClientException exception = (UserStoreClientException) e;
                 boolean displayClaimAvailability = Boolean.parseBoolean(
@@ -171,6 +185,62 @@ public class UserProvisioningExecutor implements Executor {
             return userErrorResponse(response, e);
         } catch (FlowEngineException e) {
             return errorResponse(response, e);
+        }
+    }
+
+    private void handleUserPasswordUpdate(Map<String, char[]> userCredentials, FlowUser flowUser, UserStoreManager userStoreManager, FlowExecutionContext context) throws FlowEngineException, UserStoreException {
+
+        if (INVITED_USER_REGISTRATION.getType().equalsIgnoreCase(context.getFlowType())) {
+            String confirmationCode = (String) context.getProperty(CONFIRMATION_CODE_INPUT);
+            User user = Utils.resolveUserFromContext(context);
+            if (StringUtils.isBlank(confirmationCode) || user == null) {
+                throw new FlowEngineException("Required properties are missing in the context.");
+            }
+            String recoveryScenario = getRecoveryScenario(context);
+            try {
+                enterFlow();
+                handlePrePasswordUpdate(context, user, recoveryScenario, confirmationCode);
+                updateUserPassword(userCredentials, flowUser, userStoreManager);
+                String userId = ((AbstractUserStoreManager) userStoreManager)
+                        .getUserIDFromUserName(flowUser.getUsername());
+                flowUser.setUserId(userId);
+                flowUser.setUserStoreDomain(user.getUserStoreDomain());
+            } finally {
+                IdentityContext.getThreadLocalIdentityContext().exitFlow();
+            }
+        } else if (PASSWORD_RECOVERY.getType().equalsIgnoreCase(context.getFlowType())) {
+            updateUserPassword(userCredentials, flowUser, userStoreManager);
+        }
+    }
+
+    private void updateUserPassword(Map<String, char[]> userCredentials, FlowUser user,
+                                    UserStoreManager userStoreManager)
+            throws UserStoreException, FlowEngineException {
+
+        char[] password = userCredentials.getOrDefault(PASSWORD_KEY, new DefaultPasswordGenerator().generatePassword());
+        try {
+            userStoreManager.updateCredentialByAdmin(user.getUsername(), password);
+        } catch (UserStoreException e) {
+            if (e instanceof UserStoreClientException && UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED
+                    .equals(((UserStoreClientException) e).getErrorCode())) {
+                throw e;
+            }
+            String maskedUsername = LoggerUtils.isLogMaskingEnable
+                    ? LoggerUtils.getMaskedContent(user.getUsername())
+                    : user.getUsername();
+            LOG.error("Error while updating password for user: " + maskedUsername, e);
+            throw new FlowEngineException(null, e.getMessage(), null, e);
+        } finally {
+            Arrays.fill(password, '\0');
+        }
+    }
+
+    private void handleUserClaimUpdate(Map<String, String> userClaims,
+                                       FlowUser user, UserStoreManager userStoreManager, String userStoreDomainName) throws FlowEngineException, UserStoreException {
+
+        String domainQualifiedName = IdentityUtil.addDomainToName(user.getUsername(), userStoreDomainName);
+        if (!userClaims.isEmpty()) {
+            userStoreManager.setUserClaimValues(domainQualifiedName, userClaims, null);
         }
     }
 
@@ -217,7 +287,8 @@ public class UserProvisioningExecutor implements Executor {
             response.setResult(STATUS_COMPLETE);
             return response;
         } catch (UserStoreException e) {
-            response = buildClientErrorResponseForActionFailure(response, e);
+            response = buildClientErrorResponseForActionFailure(response, e,
+                    ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_VALIDATION_FAILURE.getCode());
             if (response.getResult() != null) {
                 return response;
             }
@@ -254,7 +325,8 @@ public class UserProvisioningExecutor implements Executor {
         }
     }
 
-    private ExecutorResponse buildClientErrorResponseForActionFailure(ExecutorResponse response, UserStoreException e) {
+    private ExecutorResponse buildClientErrorResponseForActionFailure(ExecutorResponse response, UserStoreException e,
+                                                                      String errorCode) {
 
         if (e instanceof UserStoreClientException &&
                 UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED
@@ -263,7 +335,7 @@ public class UserProvisioningExecutor implements Executor {
             while (cause != null) {
                 if (cause instanceof UserActionExecutionClientException) {
                     return userErrorResponse(response,
-                            ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_VALIDATION_FAILURE.getCode(),
+                            errorCode,
                             ((UserActionExecutionClientException) cause).getError(),
                             ((UserActionExecutionClientException) cause).getDescription(), cause);
                 }
@@ -617,5 +689,54 @@ public class UserProvisioningExecutor implements Executor {
             }
         }
         return result;
+    }
+
+    private String getRecoveryScenario(FlowExecutionContext context) {
+
+        Object value = context.getProperty(IdentityRecoveryConstants.RECOVERY_SCENARIO);
+        return (value != null) ? value.toString() : null;
+    }
+
+    private void enterFlow() {
+
+        Flow.InitiatingPersona initiatingPersona;
+        Flow existingFlow = IdentityContext.getThreadLocalIdentityContext().getCurrentFlow();
+
+        if (existingFlow != null) {
+            initiatingPersona = existingFlow.getInitiatingPersona();
+        } else {
+            initiatingPersona = Flow.InitiatingPersona.ADMIN;
+        }
+
+        Flow flow = new Flow.Builder()
+                .name(Flow.Name.INVITED_USER_REGISTRATION)
+                .initiatingPersona(initiatingPersona)
+                .build();
+
+        IdentityContext.getThreadLocalIdentityContext().enterFlow(flow);
+    }
+
+    private void handlePrePasswordUpdate(FlowExecutionContext context, User user, String recoveryScenario, String confirmationCode) throws FlowEngineException {
+
+        try {
+            HashMap<String, Object> properties = new HashMap<>();
+            properties.put(IdentityEventConstants.EventProperty.USER, user);
+            properties.put(IdentityEventConstants.EventProperty.USER_NAME, user.getUserName());
+            properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, user.getTenantDomain());
+            properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, user.getUserStoreDomain());
+            properties.put(IdentityEventConstants.EventProperty.RECOVERY_SCENARIO, recoveryScenario);
+            properties.put(CONFIRMATION_CODE, confirmationCode);
+
+            Event identityMgtEvent = new Event(IdentityEventConstants.Event.
+                    PRE_ADD_NEW_PASSWORD, properties);
+
+            IdentityRecoveryServiceDataHolder.getInstance().getIdentityEventService().handleEvent(identityMgtEvent);
+        } catch (IdentityEventException e) {
+            String maskedUsername = LoggerUtils.isLogMaskingEnable
+                    ? LoggerUtils.getMaskedContent(context.getFlowUser().getUsername())
+                    : context.getFlowUser().getUsername();
+            LOG.error("Error while updating password for user: " + maskedUsername, e);
+            throw new FlowEngineException(null, e.getMessage(), null, e);
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutorTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/PasswordProvisioningExecutorTest.java
@@ -18,76 +18,70 @@
 
 package org.wso2.carbon.identity.recovery.executor;
 
-import org.mockito.MockedStatic;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.context.model.Flow;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.flow.execution.engine.Constants;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowUser;
-import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
-import org.wso2.carbon.user.core.UserRealm;
-import org.wso2.carbon.user.core.UserStoreException;
-import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
-import org.wso2.carbon.user.core.service.RealmService;
-import org.wso2.carbon.user.core.tenant.TenantManager;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
-import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.CONFIRMATION_CODE_INPUT;
-import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.RECOVERY_SCENARIO;
-import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.USER;
 
 /**
  * Unit tests for {@link PasswordProvisioningExecutor}.
+ * <p>
+ * The executor only captures the submitted password onto the flow user; the credential is persisted later by the
+ * terminal {@code UserProvisioningExecutor}. These tests assert that capture-only behavior.
  */
 @WithCarbonHome
 public class PasswordProvisioningExecutorTest {
 
     private static final String PASSWORD_KEY = "password";
-    private static final String USERNAME = "test@wso2.com";
-    private static final String TENANT_DOMAIN = "carbon.super";
-    private static final String USER_ID = "abc123";
     private static final String PASSWORD_RECOVERY = "PASSWORD_RECOVERY";
-    private static final int TENANT_ID = 1234;
 
     private PasswordProvisioningExecutor executor;
-    private MockedStatic<IdentityRecoveryServiceDataHolder> mockedDataHolderStatic;
-    private MockedStatic<IdentityTenantUtil> mockedIdentityTenantUtil;
 
     @BeforeMethod
     public void setUp() {
 
         executor = new PasswordProvisioningExecutor();
-        mockedDataHolderStatic = mockStatic(IdentityRecoveryServiceDataHolder.class);
-        mockedIdentityTenantUtil = mockStatic(IdentityTenantUtil.class);
     }
 
-    @AfterMethod
-    public void tearDown() {
+    @Test
+    public void testGetName() {
 
-        mockedDataHolderStatic.close();
-        mockedIdentityTenantUtil.close();
+        assertEquals(executor.getName(), "PasswordProvisioningExecutor");
+    }
+
+    @Test
+    public void testGetAMRValue() {
+
+        assertEquals(executor.getAMRValue(), "BasicAuthenticator");
+    }
+
+    @Test
+    public void testGetInitiationData() {
+
+        assertNotNull(executor.getInitiationData());
+        assertTrue(executor.getInitiationData().contains(PASSWORD_KEY));
+    }
+
+    @Test
+    public void testRollback() {
+
+        assertNull(executor.rollback(mock(FlowExecutionContext.class)));
     }
 
     @Test
@@ -106,165 +100,42 @@ public class PasswordProvisioningExecutorTest {
     }
 
     @Test(dataProvider = "flowTypes")
-    public void testExecuteWithValidData(String flowType) throws Exception {
+    public void testExecuteCapturesPasswordOntoFlowUser(String flowType) {
 
         FlowExecutionContext context = mock(FlowExecutionContext.class);
         FlowUser flowUser = new FlowUser();
-        flowUser.setUsername(USERNAME);
-        flowUser.addClaims(new HashMap<>());
-        flowUser.setUserStoreDomain("PRIMARY");
-
 
         Map<String, String> userInputData = new HashMap<>();
         userInputData.put(PASSWORD_KEY, "Password123");
-        userInputData.put("http://wso2.org/claims/givenname", "John");
-        userInputData.put(CONFIRMATION_CODE_INPUT, "valid-code");
 
         when(context.getUserInputData()).thenReturn(userInputData);
         when(context.getFlowType()).thenReturn(flowType);
-        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
         when(context.getFlowUser()).thenReturn(flowUser);
 
-        if (Flow.Name.INVITED_USER_REGISTRATION.name().equals(flowType)) {
-            when(context.getProperty(CONFIRMATION_CODE_INPUT)).thenReturn("valid-code");
+        ExecutorResponse response = executor.execute(context);
 
-            User user = new User();
-            user.setUserName(USERNAME);
-            user.setTenantDomain(TENANT_DOMAIN);
-            user.setUserStoreDomain("PRIMARY");
-            when(context.getProperty(USER)).thenReturn(user);
-            when(context.getProperty(RECOVERY_SCENARIO)).thenReturn("SCENARIO");
+        // Regardless of the flow type, the executor only captures the credential and completes; it does not
+        // update the user store.
+        assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_COMPLETE);
+        assertNotNull(flowUser.getUserCredentials().get(PASSWORD_KEY));
+        assertEquals(new String(flowUser.getUserCredentials().get(PASSWORD_KEY)), "Password123");
+    }
 
-            // Mock IdentityTenantUtil for INVITED_USER_REGISTRATION flow
-            mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN))
-                    .thenReturn(TENANT_ID);
-        }
+    @Test
+    public void testExecuteUsesExistingCredentialsWhenNoInput() {
 
-        // Mocks for data holder and user store
-        IdentityRecoveryServiceDataHolder dataHolder = mock(IdentityRecoveryServiceDataHolder.class);
-        RealmService realmService = mock(RealmService.class);
-        UserRealm userRealm = mock(UserRealm.class);
-        AbstractUserStoreManager storeManager = mock(AbstractUserStoreManager.class);
-        TenantManager tenantManager = mock(TenantManager.class);
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        FlowUser flowUser = new FlowUser();
+        Map<String, char[]> credentials = new HashMap<>();
+        credentials.put(PASSWORD_KEY, "Existing123".toCharArray());
+        flowUser.setUserCredentials(credentials);
 
-        mockedDataHolderStatic.when(IdentityRecoveryServiceDataHolder::getInstance).thenReturn(dataHolder);
-        when(dataHolder.getRealmService()).thenReturn(realmService);
-
-        if (Flow.Name.INVITED_USER_REGISTRATION.name().equals(flowType)) {
-            when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
-            when(userRealm.getUserStoreManager()).thenReturn(storeManager);
-        } else {
-            // For PASSWORD_RECOVERY flow
-            when(realmService.getTenantManager()).thenReturn(tenantManager);
-            when(tenantManager.getTenantId(TENANT_DOMAIN)).thenReturn(TENANT_ID);
-            when(realmService.getTenantUserRealm(TENANT_ID)).thenReturn(userRealm);
-            when(userRealm.getUserStoreManager()).thenReturn(storeManager);
-            when(storeManager.getSecondaryUserStoreManager(anyString())).thenReturn(storeManager);
-        }
-
-        when(storeManager.getUserIDFromUserName(anyString())).thenReturn(USER_ID);
-
-        IdentityEventService eventServiceMock = mock(IdentityEventService.class);
-        when(dataHolder.getIdentityEventService()).thenReturn(eventServiceMock);
+        when(context.getUserInputData()).thenReturn(Collections.emptyMap());
+        when(context.getFlowUser()).thenReturn(flowUser);
 
         ExecutorResponse response = executor.execute(context);
 
         assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_COMPLETE);
-        if (Flow.Name.INVITED_USER_REGISTRATION.name().equals(flowType)) {
-            assertEquals(flowUser.getUserId(), USER_ID);
-        }
-        verify(storeManager).updateCredentialByAdmin(eq(USERNAME), any(char[].class));
-    }
-
-    @Test
-    public void testExecuteWithExceptionInUpdate() throws Exception {
-
-        FlowExecutionContext context = mock(FlowExecutionContext.class);
-        FlowUser flowUser = new FlowUser();
-        flowUser.setUsername(USERNAME);
-        flowUser.setUserStoreDomain("PRIMARY");
-
-        Map<String, String> userInputData = new HashMap<>();
-        userInputData.put(PASSWORD_KEY, "Password123");
-
-        when(context.getUserInputData()).thenReturn(userInputData);
-        when(context.getFlowType()).thenReturn(PASSWORD_RECOVERY);
-        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
-        when(context.getFlowUser()).thenReturn(flowUser);
-
-        IdentityRecoveryServiceDataHolder dataHolder = mock(IdentityRecoveryServiceDataHolder.class);
-        RealmService realmService = mock(RealmService.class);
-        UserRealm userRealm = mock(UserRealm.class);
-        AbstractUserStoreManager storeManager = mock(AbstractUserStoreManager.class);
-        TenantManager tenantManager = mock(TenantManager.class);
-
-        mockedDataHolderStatic.when(IdentityRecoveryServiceDataHolder::getInstance).thenReturn(dataHolder);
-        when(dataHolder.getRealmService()).thenReturn(realmService);
-        when(realmService.getTenantManager()).thenReturn(tenantManager);
-        when(tenantManager.getTenantId(TENANT_DOMAIN)).thenReturn(TENANT_ID);
-        when(realmService.getTenantUserRealm(TENANT_ID)).thenReturn(userRealm);
-        when(userRealm.getUserStoreManager()).thenReturn(storeManager);
-        when(storeManager.getSecondaryUserStoreManager(anyString())).thenReturn(storeManager);
-
-        doThrow(new UserStoreException("Error while updating credential"))
-                .when(storeManager).updateCredentialByAdmin(anyString(), any(char[].class));
-
-        ExecutorResponse response = executor.execute(context);
-
-        assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_ERROR);
-    }
-
-    @Test
-    public void testHandleAskPasswordFlowWithException() throws Exception {
-
-        FlowExecutionContext context = mock(FlowExecutionContext.class);
-        FlowUser flowUser = new FlowUser();
-        flowUser.setUsername(USERNAME);
-        flowUser.addClaims(new HashMap<>());
-        flowUser.setUserStoreDomain("PRIMARY");
-
-        Map<String, String> userInputData = new HashMap<>();
-        userInputData.put(PASSWORD_KEY, "Password123");
-        userInputData.put(CONFIRMATION_CODE_INPUT, "valid-code");
-
-        when(context.getUserInputData()).thenReturn(userInputData);
-        when(context.getFlowType()).thenReturn(Flow.Name.INVITED_USER_REGISTRATION.name());
-        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
-        when(context.getFlowUser()).thenReturn(flowUser);
-        when(context.getProperty(CONFIRMATION_CODE_INPUT)).thenReturn("valid-code");
-
-        User user = new User();
-        user.setUserName(USERNAME);
-        user.setTenantDomain(TENANT_DOMAIN);
-        user.setUserStoreDomain("PRIMARY");
-        when(context.getProperty(USER)).thenReturn(user);
-        when(context.getProperty(RECOVERY_SCENARIO)).thenReturn("SCENARIO");
-
-        // Mock IdentityTenantUtil
-        mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN))
-                .thenReturn(TENANT_ID);
-
-        // Mocks for data holder and user store
-        IdentityRecoveryServiceDataHolder dataHolder = mock(IdentityRecoveryServiceDataHolder.class);
-        RealmService realmService = mock(RealmService.class);
-        UserRealm userRealm = mock(UserRealm.class);
-        AbstractUserStoreManager storeManager = mock(AbstractUserStoreManager.class);
-
-        mockedDataHolderStatic.when(IdentityRecoveryServiceDataHolder::getInstance).thenReturn(dataHolder);
-        when(dataHolder.getRealmService()).thenReturn(realmService);
-        when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
-        when(userRealm.getUserStoreManager()).thenReturn(storeManager);
-
-        IdentityEventService eventServiceMock = mock(IdentityEventService.class);
-        when(dataHolder.getIdentityEventService()).thenReturn(eventServiceMock);
-
-        // Throw UserStoreException to trigger the catch block
-        doThrow(new UserStoreException("Error while updating credential"))
-                .when(storeManager).updateCredentialByAdmin(anyString(), any(char[].class));
-
-        ExecutorResponse response = executor.execute(context);
-
-        assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_ERROR);
     }
 
     @DataProvider(name = "flowTypes")
@@ -272,7 +143,8 @@ public class PasswordProvisioningExecutorTest {
 
         return new Object[][]{
                 {Flow.Name.INVITED_USER_REGISTRATION.name()},
-                { PASSWORD_RECOVERY }
+                {PASSWORD_RECOVERY},
+                {"REGISTRATION"}
         };
     }
 }

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutorTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/executor/UserProvisioningExecutorTest.java
@@ -36,18 +36,24 @@ import org.wso2.carbon.identity.application.common.model.ApplicationBasicInfo;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.core.context.IdentityContext;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.flow.execution.engine.Constants;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineException;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowUser;
 import org.wso2.carbon.identity.flow.execution.engine.util.FlowExecutionEngineUtils;
 import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
+import org.wso2.carbon.identity.recovery.util.Utils;
+import org.wso2.carbon.identity.user.action.api.constant.UserActionError;
 import org.wso2.carbon.identity.user.action.api.exception.UserActionExecutionClientException;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.FederatedAssociationManager;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.UserStoreClientException;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -64,6 +70,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -82,6 +89,8 @@ import static org.wso2.carbon.identity.flow.execution.engine.Constants.PASSWORD_
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.USERNAME_CLAIM_URI;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.PASSWORD_RECOVERY;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.REGISTRATION;
+import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.CONFIRMATION_CODE_INPUT;
+import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.RECOVERY_SCENARIO;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.DISPLAY_CLAIM_AVAILABILITY_CONFIG;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_INVALID_USERNAME;
 import static org.wso2.carbon.identity.recovery.executor.ExecutorConstants.ExecutorErrorMessages.ERROR_CODE_USERNAME_ALREADY_EXISTS;
@@ -213,7 +222,7 @@ public class UserProvisioningExecutorTest {
         flowUser.getClaims().put(givenNameClaim, "John");
         when(flowUser.getUpdatedClaimUris()).thenReturn(Collections.singleton(givenNameClaim));
 
-        when(context.getFlowType()).thenReturn("INVITED_USER_REGISTRATION");
+        when(context.getFlowType()).thenReturn(PASSWORD_RECOVERY.getType());
         when(context.getFlowUser()).thenReturn(flowUser);
         when(context.getUserInputData()).thenReturn(userInputData);
         when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
@@ -226,6 +235,8 @@ public class UserProvisioningExecutorTest {
         ExecutorResponse response = executor.execute(context);
 
         assertEquals(response.getResult(), STATUS_COMPLETE);
+        // The password write now happens in this executor for non-registration flows.
+        verify(userStoreManager).updateCredentialByAdmin(eq(USERNAME), any(char[].class));
         verify(userStoreManager).setUserClaimValues(eq(PRIMARY_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + USERNAME),
                 eq(Collections.singletonMap(givenNameClaim, "John")), isNull());
     }
@@ -1132,6 +1143,109 @@ public class UserProvisioningExecutorTest {
         verify(consentManager, never()).getPIICategoryByUuid(anyString());
     }
 
+    @Test
+    public void testExecutePasswordRecoveryUsesFlowUserCredential() throws Exception {
+
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        FlowUser flowUser = createTestFlowUser(USERNAME);
+        // A flow extension configured after the password step may override the credential on the flow user.
+        Map<String, char[]> overridden = new HashMap<>();
+        overridden.put(PASSWORD_KEY, "OverriddenByExtension1!".toCharArray());
+        when(flowUser.getUserCredentials()).thenReturn(overridden);
+
+        when(context.getFlowType()).thenReturn(PASSWORD_RECOVERY.getType());
+        when(context.getFlowUser()).thenReturn(flowUser);
+        when(context.getUserInputData()).thenReturn(new HashMap<>());
+        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+        when(context.getContextIdentifier()).thenReturn(CONTEXT_ID);
+        when(context.getProperty("isUsernamePatternValidationSkipped")).thenReturn(null);
+
+        AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+
+        // Capture the credential value at call time, since the executor zeroes the array afterwards.
+        StringBuilder capturedPassword = new StringBuilder();
+        doAnswer(invocation -> {
+            capturedPassword.append(new String((char[]) invocation.getArgument(1)));
+            return null;
+        }).when(userStoreManager).updateCredentialByAdmin(eq(USERNAME), any(char[].class));
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_COMPLETE);
+        assertEquals(capturedPassword.toString(), "OverriddenByExtension1!");
+    }
+
+    @Test
+    public void testExecutePasswordRecoveryPreUpdatePasswordActionFailureReturnsFlowEngineErrorCode()
+            throws Exception {
+
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        FlowUser flowUser = createTestFlowUser(USERNAME);
+
+        when(context.getFlowType()).thenReturn(PASSWORD_RECOVERY.getType());
+        when(context.getFlowUser()).thenReturn(flowUser);
+        when(context.getUserInputData()).thenReturn(new HashMap<>());
+        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+        when(context.getContextIdentifier()).thenReturn(CONTEXT_ID);
+        when(context.getProperty("isUsernamePatternValidationSkipped")).thenReturn(null);
+
+        AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+        UserActionExecutionClientException actionException = new UserActionExecutionClientException(
+                "action-error-code", "Password policy violated", "The password does not meet the policy.");
+        UserStoreClientException storeException = new UserStoreClientException(
+                "Pre update password action failed",
+                UserActionError.PRE_UPDATE_PASSWORD_ACTION_EXECUTION_FAILED, actionException);
+        doThrow(storeException).when(userStoreManager).updateCredentialByAdmin(eq(USERNAME), any(char[].class));
+
+        ExecutorResponse response = executor.execute(context);
+
+        assertEquals(response.getResult(), STATUS_USER_ERROR);
+        // Recovery and ask-password flows retain the flow-engine error code, not the recovery executor code.
+        assertEquals(response.getErrorCode(),
+                Constants.ErrorMessages.ERROR_CODE_PRE_UPDATE_PASSWORD_ACTION_VALIDATION_FAILURE.getCode());
+        assertNotNull(response.getErrorMessage());
+    }
+
+    @Test
+    public void testExecuteAskPasswordUpdatesCredentialAndSetsUserId() throws Exception {
+
+        FlowExecutionContext context = mock(FlowExecutionContext.class);
+        FlowUser flowUser = createTestFlowUser(USERNAME);
+
+        when(context.getFlowType()).thenReturn("INVITED_USER_REGISTRATION");
+        when(context.getFlowUser()).thenReturn(flowUser);
+        when(context.getUserInputData()).thenReturn(new HashMap<>());
+        when(context.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+        when(context.getContextIdentifier()).thenReturn(CONTEXT_ID);
+        when(context.getProperty("isUsernamePatternValidationSkipped")).thenReturn(null);
+        when(context.getProperty(CONFIRMATION_CODE_INPUT)).thenReturn("valid-code");
+        when(context.getProperty(RECOVERY_SCENARIO)).thenReturn("ASK_PASSWORD");
+
+        User resolvedUser = new User();
+        resolvedUser.setUserName(USERNAME);
+        resolvedUser.setTenantDomain(TENANT_DOMAIN);
+        resolvedUser.setUserStoreDomain(PRIMARY_DOMAIN);
+
+        AbstractUserStoreManager userStoreManager = setupUserStoreManagerMocks();
+
+        IdentityContext identityContext = mock(IdentityContext.class);
+        when(identityContext.getCurrentFlow()).thenReturn(null);
+
+        try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class);
+             MockedStatic<IdentityContext> mockedIdentityContext = mockStatic(IdentityContext.class)) {
+
+            mockedUtils.when(() -> Utils.resolveUserFromContext(context)).thenReturn(resolvedUser);
+            mockedIdentityContext.when(IdentityContext::getThreadLocalIdentityContext).thenReturn(identityContext);
+
+            ExecutorResponse response = executor.execute(context);
+
+            assertEquals(response.getResult(), STATUS_COMPLETE);
+            verify(userStoreManager).updateCredentialByAdmin(eq(USERNAME), any(char[].class));
+            verify(flowUser).setUserId(USER_ID);
+            verify(flowUser).setUserStoreDomain(PRIMARY_DOMAIN);
+        }
+    }
+
     private FlowUser createTestFlowUser(String username) {
 
         FlowUser flowUser = mock(FlowUser.class);
@@ -1348,6 +1462,7 @@ public class UserProvisioningExecutorTest {
         mockedIdentityUtil.when(() -> IdentityUtil.addDomainToName(anyString(), anyString()))
                 .thenReturn(PRIMARY_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + USERNAME);
         mockedUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName(anyString())).thenReturn(USERNAME);
+        when(dataHolder.getIdentityEventService()).thenReturn(mock(IdentityEventService.class));
 
         return userStoreManager;
     }


### PR DESCRIPTION
## Purpose
In the password recovery and ask password (invited user registration) flows, the provisioned credential should reflect the value present on the flow user at the time of provisioning, so that a flow extension configured after the password provisioning step can override it. Previously the provisioning step re-read the retained raw user input, discarding any credential set on the flow user by a later extension.

## Related Issue
- https://github.com/wso2/product-is/issues/28177
- https://github.com/wso2/product-is/issues/28330

## Manual Testing

ID | Flow | Scenario / Setup | Expected Result | Verified
-- | -- | -- | -- | --
1 | PASSWORD_RECOVERY | Reset via Email OTP, primary store | Password updated; login works with new password | Yes
2 | PASSWORD_RECOVERY | Reset via SMS OTP, primary store | Password updated; login works with new password | Yes
3 | PASSWORD_RECOVERY | Reset via Magic Link, primary store | Password updated; login works with new password | Yes
4 | INVITED_USER_REGISTRATION | Ask-password via SMS OTP, primary store | Password set; login works | Yes
5 | REGISTRATION | Self-signup with password, primary store | User created; login works | Yes
6 | INVITED_USER_REGISTRATION | Set password + fill profile claims | Password set AND claims persisted | Yes
7 | PASSWORD_RECOVERY | Flow that also updates a claim | Password reset AND claim written | Yes
8 | INVITED_USER_REGISTRATION | Passkey registration | Passkey | Yes
9 | INVITED_USER_REGISTRATION | Consent V2 enabled, purpose declared | Exactly one consent receipt created | Yes
10 | PASSWORD_RECOVERY | Pre-update password action rejects the password | Raw API code = FE-60012 | Yes
11 | INVITED_USER_REGISTRATION | Pre-update password action rejects the password | Raw API code = FE-60012 | Yes
12 | REGISTRATION | Pre-update password action rejects the password | Raw API code = FEE-60003 | Yes
14 | INVITED_USER_REGISTRATION | Missing or invalid confirmation code | Error: Required properties are missing in the context | Yes



## Implementation
- `PasswordProvisioningExecutor` now only captures the submitted password onto the flow user (`FlowUser.setUserCredentials`) and returns; it no longer updates the credential itself.
- The credential update, together with the pre-update handling for the ask password flow, is moved into the terminal `UserProvisioningExecutor`. It reads the credential from the flow user (`getUserCredentials`), so a value overridden by a flow extension between the two steps is the value that gets persisted.
- Claim update and consent processing are consolidated in `UserProvisioningExecutor`.
- The existing error code returned when the pre-update password action rejects the credential is retained for these flows.

This covers the server-side credential provisioning behavior; the Console flow builder changes for exposing the flow extension step are handled separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Streamlined password provisioning to reliably capture provided passwords and complete the flow using existing credentials when no input is provided.
  - Improved non-registration user updates by handling password and claim persistence in a more consistent flow.
  - Enhanced password pre-update validation error reporting to better reflect flow-engine error codes/messages.
  - Improved invited-user password event handling and ensured password buffers are cleared after processing.

- **Tests**
  - Updated and expanded executor test coverage for password recovery and credential preservation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->