### PR TITLE
Return HTTP 500 instead of silent 200 on failed resident-IdP governance update

### DIFF
--- a/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceServiceImpl.java
+++ b/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/IdentityGovernanceServiceImpl.java
@@ -134,7 +134,8 @@ public class IdentityGovernanceServiceImpl implements IdentityGovernanceService 
             log.debug("Client error while updating identityManagement properties of Resident IdP.", e);
             throw new IdentityGovernanceClientException(e.getMessage(), e);
         } catch (IdentityProviderManagementException e) {
-            log.error("Error while updating identityManagement Properties of Resident Idp.", e);
+            throw new IdentityGovernanceException(
+                    "Error while updating identityManagement Properties of Resident IdP.", e);
         } catch (OrganizationManagementException e) {
             throw new IdentityGovernanceException(String.format("Error while checking if tenant %s is an organization.",
                     tenantDomain), e);


### PR DESCRIPTION
## Purpose

Fixes wso2/product-is#28203

`PATCH /api/server/v1/identity-governance/{category-id}/connectors/{connector-id}` returned **HTTP 200** even when the underlying resident-IdP update **failed and was rolled back**. The change was silently discarded and the only evidence was an `ERROR` line in `wso2carbon.log`, so an API caller could not distinguish a successful update from a failed one.

`IdentityGovernanceServiceImpl.updateConfiguration` caught `IdentityProviderManagementException`, logged it, and did **not** rethrow — unlike its sibling `catch` blocks for `IdentityProviderManagementClientException` (rethrown → HTTP 400) and `OrganizationManagementException` (rethrown → HTTP 500). Because no exception reached the REST layer, `ServerIdentityGovernanceService.updateGovernanceConnectorProperty` completed with HTTP 200.

## Changes

Rethrow the caught `IdentityProviderManagementException` wrapped as `IdentityGovernanceException`, matching the sibling `catch` blocks, so the REST layer maps it to `INTERNAL_SERVER_ERROR` (500) instead of returning 200. The client-error branch (400) and the organization branch (500) are unchanged, so genuine client errors still return 400 — only true server-side failures now surface as 500 instead of a misleading 200.

## Related Issues

- wso2/product-is#28203