### PR TITLE
Add breached credential detection with a pluggable breach source SPI

### DIFF
--- a/components/org.wso2.carbon.identity.breach.detection.api/pom.xml
+++ b/components/org.wso2.carbon.identity.breach.detection.api/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.governance</groupId>
+        <artifactId>identity-governance</artifactId>
+        <version>1.16.36-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.breach.detection.api</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Breach Source SPI</name>
+    <description>The published contract a breach intelligence source implements.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <!--
+                          The exported package carries the CONTRACT version rather than
+                          ${identity.governance.exp.pkg.version}, deliberately. Connectors are built outside
+                          this repository and compile against this package; versioning it on the repository's
+                          release number would invalidate every one of them on a release that never touched
+                          the contract.
+                        -->
+                        <Export-Package>
+                            org.wso2.carbon.identity.breach.source;version="${breach.spi.package.version}"
+                        </Export-Package>
+                        <Import-Package>
+                            !org.wso2.carbon.identity.breach.source,
+                            *
+                        </Import-Package>
+                        <_noimportjava>true</_noimportjava>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/BreachContext.java
+++ b/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/BreachContext.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.source;
+
+import java.util.Optional;
+
+/**
+ * Everything a source is given to reach a verdict: the candidate password, who it is for, where, and for what
+ * kind of operation.
+ * <p>
+ * It carries more than a password-only source needs, on purpose. A validator context carrying only the value
+ * and the tenant is structurally incapable of supporting credential-pair intelligence, and that limitation is
+ * not recoverable once connectors exist in the field.
+ */
+public final class BreachContext {
+
+    private final Credential credential;
+    private final Subject subject;
+    private final String tenantDomain;
+    private final String organizationId;
+    private final Operation operation;
+
+    private BreachContext(Builder builder) {
+
+        this.credential = builder.credential;
+        this.subject = builder.subject;
+        this.tenantDomain = builder.tenantDomain;
+        this.organizationId = builder.organizationId;
+        this.operation = builder.operation == null ? Operation.UNKNOWN : builder.operation;
+    }
+
+    public Credential getCredential() {
+
+        return credential;
+    }
+
+    public Subject getSubject() {
+
+        return subject;
+    }
+
+    public String getTenantDomain() {
+
+        return tenantDomain;
+    }
+
+    /**
+     * @return the organization id where the operation ran inside one; empty otherwise.
+     */
+    public Optional<String> getOrganizationId() {
+
+        return Optional.ofNullable(organizationId);
+    }
+
+    public Operation getOperation() {
+
+        return operation;
+    }
+
+    public static Builder builder() {
+
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link BreachContext}.
+     */
+    public static final class Builder {
+
+        private Credential credential;
+        private Subject subject;
+        private String tenantDomain;
+        private String organizationId;
+        private Operation operation;
+
+        private Builder() {
+
+        }
+
+        public Builder credential(Credential credential) {
+
+            this.credential = credential;
+            return this;
+        }
+
+        public Builder subject(Subject subject) {
+
+            this.subject = subject;
+            return this;
+        }
+
+        public Builder tenantDomain(String tenantDomain) {
+
+            this.tenantDomain = tenantDomain;
+            return this;
+        }
+
+        public Builder organizationId(String organizationId) {
+
+            this.organizationId = organizationId;
+            return this;
+        }
+
+        public Builder operation(Operation operation) {
+
+            this.operation = operation;
+            return this;
+        }
+
+        public BreachContext build() {
+
+            if (credential == null) {
+                throw new IllegalStateException("A breach context requires a credential.");
+            }
+            if (tenantDomain == null) {
+                throw new IllegalStateException("A breach context requires a tenant domain.");
+            }
+            return new BreachContext(this);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/BreachSource.java
+++ b/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/BreachSource.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.source;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+
+/**
+ * A breach-intelligence source, published as an OSGi service.
+ * <p>
+ * The engine <em>discovers</em> sources rather than knowing them, so a source has to describe itself well
+ * enough that the engine can order it, the configuration layer can resolve its settings, and the Console can
+ * render it - none of which can be hard-coded against a source that did not exist when the core was built.
+ * <p>
+ * Register from a connector's activator:
+ * <pre>{@code
+ * bundleContext.registerService(BreachSource.class, new HibpBreachSource(), null);
+ * }</pre>
+ * <p>
+ * Everything but {@link #getId()}, {@link #getDescriptor()} and {@link #evaluate(BreachContext)} has a default,
+ * and the contract gains default methods rather than abstract ones, so an existing connector keeps compiling
+ * across additive revisions.
+ */
+public interface BreachSource {
+
+    /**
+     * A stable id. Tenant policy names sources by it, deployment configuration is namespaced on it
+     * ({@code [breach_detection.sources.<id>]}), and telemetry is labelled with it. Lowercase, no spaces.
+     *
+     * @return the source id.
+     */
+    String getId();
+
+    /**
+     * @return how this source presents itself to an administrator.
+     */
+    Descriptor getDescriptor();
+
+    /**
+     * The deployment settings this source needs. The core resolves them and hands them back through
+     * {@link #configure(SourceConfiguration)}.
+     *
+     * @return declared settings; empty if the source needs none.
+     */
+    default List<PropertyDescriptor> getProperties() {
+
+        return Collections.emptyList();
+    }
+
+    /**
+     * A cost hint. The engine sorts ascending, so an in-process source declaring a low number is consulted
+     * before a network round trip without the engine knowing what either one is.
+     *
+     * @return the priority; lower runs first.
+     */
+    default int getPriority() {
+
+        return 1000;
+    }
+
+    /**
+     * @return what this source is and what it needs.
+     */
+    default EnumSet<Capability> getCapabilities() {
+
+        return EnumSet.of(Capability.PASSWORD_ONLY);
+    }
+
+    /**
+     * Hand the source its resolved deployment settings. Called on bind and again whenever configuration is
+     * reloaded. A source must tolerate being reconfigured while evaluations are in flight.
+     *
+     * @param configuration resolved settings for this source.
+     */
+    default void configure(SourceConfiguration configuration) {
+
+    }
+
+    /**
+     * Whether this source is set up well enough to be called. Separates "not set up" from "set up and
+     * failing" - the distinction that keeps a non-operational source from reporting itself as enforcing.
+     *
+     * @param tenantDomain the tenant asking.
+     * @return {@code true} if the source can be called.
+     */
+    default boolean isConfigured(String tenantDomain) {
+
+        return true;
+    }
+
+    /**
+     * What this source reports about itself, for the administrator surface.
+     *
+     * @param tenantDomain the tenant asking.
+     * @return the status.
+     */
+    default SourceStatus getStatus(String tenantDomain) {
+
+        return SourceStatus.builder(isConfigured(tenantDomain)
+                ? SourceStatus.State.READY : SourceStatus.State.NOT_CONFIGURED).build();
+    }
+
+    /**
+     * Reach a verdict on the candidate password.
+     * <p>
+     * Return {@link Outcome#UNAVAILABLE} - or throw {@link BreachSourceException} - for anything that is not a
+     * positive determination. Never return {@link Outcome#NOT_FOUND} because a call failed. Never log, cache,
+     * or transmit the credential in a recoverable form, and never retain it past this call.
+     *
+     * @param context the candidate password and its surrounding operation.
+     * @return the verdict.
+     * @throws BreachSourceException if no verdict could be produced.
+     */
+    BreachVerdict evaluate(BreachContext context) throws BreachSourceException;
+}

--- a/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/BreachSourceException.java
+++ b/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/BreachSourceException.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.source;
+
+/**
+ * Thrown by a source that could not reach a verdict.
+ * <p>
+ * The engine treats this identically to a returned {@link Outcome#UNAVAILABLE}: contained to the source that
+ * raised it, resolved by that source's failure policy, and never allowed to fail the other sources. The
+ * message must carry no part of the candidate password and no source credential, including in the cause
+ * chain.
+ */
+public class BreachSourceException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    private final UnavailableCause cause;
+
+    public BreachSourceException(UnavailableCause cause, String message) {
+
+        super(message);
+        this.cause = cause == null ? UnavailableCause.INTERNAL : cause;
+    }
+
+    public BreachSourceException(UnavailableCause cause, String message, Throwable throwable) {
+
+        super(message, throwable);
+        this.cause = cause == null ? UnavailableCause.INTERNAL : cause;
+    }
+
+    public UnavailableCause getUnavailableCause() {
+
+        return cause;
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/BreachVerdict.java
+++ b/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/BreachVerdict.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.source;
+
+import java.util.Optional;
+import java.util.OptionalLong;
+
+/**
+ * What one source concluded, and - when it could not conclude anything - why.
+ * <p>
+ * Occurrence counts are operator- and telemetry-facing only. They are deliberately never shown to an end user:
+ * a count invites treating a smaller number as safer and offers nothing actionable.
+ */
+public final class BreachVerdict {
+
+    private final Outcome outcome;
+    private final String sourceId;
+    private final Long occurrences;
+    private final UnavailableCause cause;
+    private final String detail;
+
+    private BreachVerdict(Outcome outcome, String sourceId, Long occurrences, UnavailableCause cause,
+                          String detail) {
+
+        this.outcome = outcome;
+        this.sourceId = sourceId;
+        this.occurrences = occurrences;
+        this.cause = cause;
+        this.detail = detail;
+    }
+
+    /**
+     * The password is in this source's corpus.
+     *
+     * @param sourceId    reporting source.
+     * @param occurrences how many records, or a negative value when the source does not count.
+     * @return the verdict.
+     */
+    public static BreachVerdict found(String sourceId, long occurrences) {
+
+        return new BreachVerdict(Outcome.FOUND, sourceId, occurrences < 0 ? null : occurrences, null, null);
+    }
+
+    /**
+     * The password is in this source's corpus, with no count available.
+     *
+     * @param sourceId reporting source.
+     * @return the verdict.
+     */
+    public static BreachVerdict found(String sourceId) {
+
+        return new BreachVerdict(Outcome.FOUND, sourceId, null, null, null);
+    }
+
+    /**
+     * The source positively determined the password is absent. Never returned for "could not check".
+     *
+     * @param sourceId reporting source.
+     * @return the verdict.
+     */
+    public static BreachVerdict notFound(String sourceId) {
+
+        return new BreachVerdict(Outcome.NOT_FOUND, sourceId, null, null, null);
+    }
+
+    /**
+     * The source could not produce a verdict.
+     *
+     * @param sourceId reporting source.
+     * @param cause    why, so telemetry can distinguish a quota from an outage.
+     * @param detail   operator-facing detail. Must never contain the credential or a source credential.
+     * @return the verdict.
+     */
+    public static BreachVerdict unavailable(String sourceId, UnavailableCause cause, String detail) {
+
+        return new BreachVerdict(Outcome.UNAVAILABLE, sourceId, null,
+                cause == null ? UnavailableCause.INTERNAL : cause, detail);
+    }
+
+    public Outcome getOutcome() {
+
+        return outcome;
+    }
+
+    public String getSourceId() {
+
+        return sourceId;
+    }
+
+    public OptionalLong getOccurrences() {
+
+        return occurrences == null ? OptionalLong.empty() : OptionalLong.of(occurrences);
+    }
+
+    public Optional<UnavailableCause> getCause() {
+
+        return Optional.ofNullable(cause);
+    }
+
+    /**
+     * @return operator-facing detail; never contains any part of the candidate password.
+     */
+    public Optional<String> getDetail() {
+
+        return Optional.ofNullable(detail);
+    }
+
+    @Override
+    public String toString() {
+
+        return "BreachVerdict{sourceId=" + sourceId + ", outcome=" + outcome
+                + (cause == null ? "" : ", cause=" + cause) + '}';
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/Capability.java
+++ b/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/Capability.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.source;
+
+/**
+ * What a source needs and what it is, declared so the engine and the administrator surface can treat it
+ * correctly without knowing what it is.
+ */
+public enum Capability {
+
+    /** Answers without crossing the deployment boundary. No timeout or circuit breaker applies. */
+    OFFLINE,
+
+    /** Calls a service outside the deployment. The engine bounds the call and breaks the circuit on failure. */
+    REMOTE,
+
+    /** Keyed on the password alone. The subject on the context is ignored. */
+    PASSWORD_ONLY,
+
+    /**
+     * Keyed on the credential pair, so the subject identity is transmitted to the source. Drives the privacy
+     * disclosure the administrator sees before the source can be enabled.
+     */
+    NEEDS_SUBJECT
+}

--- a/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/Credential.java
+++ b/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/Credential.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.source;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.text.Normalizer;
+import java.util.Arrays;
+
+/**
+ * The candidate password, held as a {@code char[]} rather than a {@code String} so it can be cleared and so it
+ * never lands in the string pool or a heap dump for longer than the evaluation takes.
+ * <p>
+ * It has no meaningful {@code toString}, and must never enter a log statement, an exception message, a metric
+ * label, or a cache key. The engine clears it after the last source returns; a source must not retain it.
+ */
+public final class Credential {
+
+    private static final String MASK = "Credential{****}";
+
+    private final char[] chars;
+    private volatile boolean cleared;
+
+    /**
+     * @param chars the candidate password. Taken by reference: the caller must not mutate or reuse it.
+     */
+    public Credential(char[] chars) {
+
+        if (chars == null) {
+            throw new IllegalArgumentException("Credential characters cannot be null.");
+        }
+        this.chars = chars;
+    }
+
+    /**
+     * The raw characters. Never copy these into a {@code String}.
+     *
+     * @return the backing array, by reference.
+     */
+    public char[] getChars() {
+
+        assertUsable();
+        return chars;
+    }
+
+    /**
+     * @return the number of characters, safe to log.
+     */
+    public int length() {
+
+        return chars.length;
+    }
+
+    /**
+     * The canonical byte form: Unicode NFC, encoded UTF-8. No case folding and no trimming - passwords are
+     * case- and whitespace-significant, and folding them would refuse credentials nobody listed.
+     * <p>
+     * The caller owns the returned array and should wipe it once done.
+     *
+     * @return canonical UTF-8 bytes.
+     */
+    public byte[] canonicalBytes() {
+
+        assertUsable();
+        CharBuffer canonical = canonicalChars();
+        ByteBuffer encoded = StandardCharsets.UTF_8.encode(canonical);
+        byte[] bytes = new byte[encoded.remaining()];
+        encoded.get(bytes);
+        if (encoded.hasArray()) {
+            Arrays.fill(encoded.array(), (byte) 0);
+        }
+        if (canonical.hasArray() && canonical.array() != chars) {
+            Arrays.fill(canonical.array(), '\0');
+        }
+        return bytes;
+    }
+
+    /**
+     * Digest of the canonical byte form, uppercase hex. This is what a source matches on; the credential
+     * itself never leaves the process.
+     *
+     * @param algorithm a {@link MessageDigest} algorithm name, for example {@code SHA-1} or {@code SHA-256}.
+     * @return uppercase hex digest.
+     * @throws IllegalArgumentException if the algorithm is not available.
+     */
+    public String digestHex(String algorithm) {
+
+        byte[] bytes = canonicalBytes();
+        try {
+            MessageDigest digest = MessageDigest.getInstance(algorithm);
+            byte[] out = digest.digest(bytes);
+            char[] hex = new char[out.length * 2];
+            for (int i = 0; i < out.length; i++) {
+                int v = out[i] & 0xFF;
+                hex[i * 2] = Character.forDigit(v >>> 4, 16);
+                hex[i * 2 + 1] = Character.forDigit(v & 0x0F, 16);
+            }
+            return new String(hex).toUpperCase(java.util.Locale.ROOT);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalArgumentException("Unsupported digest algorithm: " + algorithm, e);
+        } finally {
+            Arrays.fill(bytes, (byte) 0);
+        }
+    }
+
+    /**
+     * Zero the backing array. Called by the engine once every source has returned.
+     */
+    public void clear() {
+
+        Arrays.fill(chars, '\0');
+        cleared = true;
+    }
+
+    /**
+     * @return {@code true} once {@link #clear()} has run.
+     */
+    public boolean isCleared() {
+
+        return cleared;
+    }
+
+    private CharBuffer canonicalChars() {
+
+        CharBuffer raw = CharBuffer.wrap(chars);
+        if (Normalizer.isNormalized(raw, Normalizer.Form.NFC)) {
+            return raw;
+        }
+        return CharBuffer.wrap(Normalizer.normalize(raw, Normalizer.Form.NFC).toCharArray());
+    }
+
+    private void assertUsable() {
+
+        if (cleared) {
+            throw new IllegalStateException("The credential has already been cleared.");
+        }
+    }
+
+    @Override
+    public String toString() {
+
+        return MASK;
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/Descriptor.java
+++ b/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/Descriptor.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.source;
+
+import java.util.Optional;
+
+/**
+ * How a source describes itself to an administrator.
+ * <p>
+ * The Console cannot hard-code a label for a source it has never seen, so the copy travels with the source.
+ * Write it in an administrator's language, not the mechanism's - "sends only a partial, irreversible
+ * fingerprint of the password", not "k-anonymity".
+ */
+public final class Descriptor {
+
+    private final String displayName;
+    private final String description;
+    private final String vendor;
+    private final String documentationUrl;
+    private final String privacyNotice;
+
+    private Descriptor(Builder builder) {
+
+        this.displayName = builder.displayName;
+        this.description = builder.description;
+        this.vendor = builder.vendor;
+        this.documentationUrl = builder.documentationUrl;
+        this.privacyNotice = builder.privacyNotice;
+    }
+
+    public String getDisplayName() {
+
+        return displayName;
+    }
+
+    public String getDescription() {
+
+        return description;
+    }
+
+    public Optional<String> getVendor() {
+
+        return Optional.ofNullable(vendor);
+    }
+
+    public Optional<String> getDocumentationUrl() {
+
+        return Optional.ofNullable(documentationUrl);
+    }
+
+    /**
+     * What this source is told about the user, in the administrator's language. Rendered before a source
+     * declaring {@link Capability#NEEDS_SUBJECT} can be enabled.
+     *
+     * @return the disclosure, if the source supplies one.
+     */
+    public Optional<String> getPrivacyNotice() {
+
+        return Optional.ofNullable(privacyNotice);
+    }
+
+    public static Builder builder(String displayName) {
+
+        return new Builder(displayName);
+    }
+
+    /**
+     * Builder for {@link Descriptor}.
+     */
+    public static final class Builder {
+
+        private final String displayName;
+        private String description;
+        private String vendor;
+        private String documentationUrl;
+        private String privacyNotice;
+
+        private Builder(String displayName) {
+
+            this.displayName = displayName;
+        }
+
+        public Builder description(String description) {
+
+            this.description = description;
+            return this;
+        }
+
+        public Builder vendor(String vendor) {
+
+            this.vendor = vendor;
+            return this;
+        }
+
+        public Builder documentationUrl(String documentationUrl) {
+
+            this.documentationUrl = documentationUrl;
+            return this;
+        }
+
+        public Builder privacyNotice(String privacyNotice) {
+
+            this.privacyNotice = privacyNotice;
+            return this;
+        }
+
+        public Descriptor build() {
+
+            return new Descriptor(this);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/Operation.java
+++ b/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/Operation.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.source;
+
+/**
+ * The credential-write operation a candidate password was submitted for.
+ * <p>
+ * Carried on {@link BreachContext} so a source can vary its answer by operation - refusing on registration
+ * but only reporting on an administrative reset, for example. A source that does not care ignores it.
+ */
+public enum Operation {
+
+    /** Self-registration, and administrative user creation. */
+    REGISTER,
+
+    /** Self-service password change, with the current password supplied. */
+    SELF_UPDATE,
+
+    /** Administrative password reset. */
+    ADMIN_RESET,
+
+    /** Password set while accepting an invitation. */
+    INVITE,
+
+    /** Password set through the recovery flow. */
+    RECOVERY,
+
+    /** A credential write that could not be attributed to one of the above. */
+    UNKNOWN
+}

--- a/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/Outcome.java
+++ b/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/Outcome.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.source;
+
+/**
+ * What a source concluded about a candidate password.
+ * <p>
+ * {@link #UNAVAILABLE} is not {@link #NOT_FOUND}. A source that cannot reach its corpus, times out, exhausts a
+ * quota, or fails to parse a response returns {@code UNAVAILABLE}. No source is permitted to invent
+ * {@code NOT_FOUND}: collapsing the two is what makes a breach check silently stop enforcing while still
+ * reporting itself as enabled.
+ */
+public enum Outcome {
+
+    /** The source reports the password as present in its corpus. */
+    FOUND,
+
+    /** The source positively reports the password as absent from its corpus. */
+    NOT_FOUND,
+
+    /** The source could not produce a verdict. Resolved by the failure policy configured for it. */
+    UNAVAILABLE
+}

--- a/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/PropertyDescriptor.java
+++ b/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/PropertyDescriptor.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.source;
+
+import java.util.Optional;
+
+/**
+ * One deployment setting a source needs.
+ * <p>
+ * The core does not know a connector's settings, so the connector declares them and the core resolves the
+ * values - the connector reads no file and holds no vault handle of its own. The {@code secret} flag is what
+ * makes that enforceable: a secret is resolved through the platform secret store, is never written to the
+ * tenant governance store, and is never returned by any management API.
+ */
+public final class PropertyDescriptor {
+
+    private final String name;
+    private final PropertyType type;
+    private final boolean required;
+    private final boolean secret;
+    private final String defaultValue;
+    private final String displayName;
+    private final String description;
+
+    private PropertyDescriptor(Builder builder) {
+
+        this.name = builder.name;
+        this.type = builder.type;
+        this.required = builder.required;
+        this.secret = builder.secret;
+        this.defaultValue = builder.defaultValue;
+        this.displayName = builder.displayName == null ? builder.name : builder.displayName;
+        this.description = builder.description;
+    }
+
+    /**
+     * @return the setting name, as it appears under {@code [breach_detection.sources.&lt;id&gt;]}.
+     */
+    public String getName() {
+
+        return name;
+    }
+
+    public PropertyType getType() {
+
+        return type;
+    }
+
+    public boolean isRequired() {
+
+        return required;
+    }
+
+    /**
+     * @return {@code true} if the value is a credential: vault-resolved, never returned, never logged.
+     */
+    public boolean isSecret() {
+
+        return secret;
+    }
+
+    public Optional<String> getDefaultValue() {
+
+        return Optional.ofNullable(defaultValue);
+    }
+
+    public String getDisplayName() {
+
+        return displayName;
+    }
+
+    public Optional<String> getDescription() {
+
+        return Optional.ofNullable(description);
+    }
+
+    public static Builder builder(String name, PropertyType type) {
+
+        return new Builder(name, type);
+    }
+
+    /**
+     * Builder for {@link PropertyDescriptor}.
+     */
+    public static final class Builder {
+
+        private final String name;
+        private final PropertyType type;
+        private boolean required;
+        private boolean secret;
+        private String defaultValue;
+        private String displayName;
+        private String description;
+
+        private Builder(String name, PropertyType type) {
+
+            this.name = name;
+            this.type = type;
+        }
+
+        public Builder required(boolean required) {
+
+            this.required = required;
+            return this;
+        }
+
+        public Builder secret(boolean secret) {
+
+            this.secret = secret;
+            return this;
+        }
+
+        public Builder defaultValue(String defaultValue) {
+
+            this.defaultValue = defaultValue;
+            return this;
+        }
+
+        public Builder displayName(String displayName) {
+
+            this.displayName = displayName;
+            return this;
+        }
+
+        public Builder description(String description) {
+
+            this.description = description;
+            return this;
+        }
+
+        public PropertyDescriptor build() {
+
+            return new PropertyDescriptor(this);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/PropertyType.java
+++ b/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/PropertyType.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.source;
+
+/**
+ * The shape of a source setting, so a Console that has never seen the source can still render a field for it.
+ */
+public enum PropertyType {
+
+    STRING,
+    INTEGER,
+    BOOLEAN,
+    /** An integer number of milliseconds. Rendered as a duration. */
+    DURATION_MS,
+    /** A filesystem path, resolved by the core against the permitted locations. */
+    PATH
+}

--- a/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/SourceConfiguration.java
+++ b/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/SourceConfiguration.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.source;
+
+import java.util.Optional;
+
+/**
+ * The resolved deployment settings for one source, handed to it by the core.
+ * <p>
+ * A source never reads {@code deployment.toml} and never touches the vault: it declares what it needs through
+ * {@link BreachSource#getProperties()} and receives the values here. That is what keeps the {@code secret}
+ * flag on a {@link PropertyDescriptor} enforceable rather than advisory.
+ */
+public interface SourceConfiguration {
+
+    /**
+     * @param name declared property name.
+     * @return the configured value, or the declared default, or empty.
+     */
+    Optional<String> getString(String name);
+
+    /**
+     * @param name         declared property name.
+     * @param defaultValue value to use when unset or unparseable.
+     * @return the resolved integer.
+     */
+    int getInt(String name, int defaultValue);
+
+    /**
+     * @param name         declared property name.
+     * @param defaultValue value to use when unset or unparseable.
+     * @return the resolved long.
+     */
+    long getLong(String name, long defaultValue);
+
+    /**
+     * @param name         declared property name.
+     * @param defaultValue value to use when unset.
+     * @return the resolved flag.
+     */
+    boolean getBoolean(String name, boolean defaultValue);
+
+    /**
+     * Resolve a property declared as {@code secret} through the platform secret store.
+     * <p>
+     * The caller owns the returned array and must wipe it after use. Never render it, log it, or return it
+     * from an API.
+     *
+     * @param name declared property name.
+     * @return the secret, or empty when unset.
+     */
+    Optional<char[]> getSecret(String name);
+
+    /**
+     * Resolve a property declared as a {@link PropertyType#PATH}, confined to the permitted locations. A value
+     * that escapes them resolves to empty and is reported at load.
+     *
+     * @param name declared property name.
+     * @return the resolved absolute path, or empty.
+     */
+    Optional<String> getPath(String name);
+}

--- a/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/SourceStatus.java
+++ b/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/SourceStatus.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.source;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * What a source reports about itself to an administrator.
+ * <p>
+ * A source proves it is working rather than asserting it: the facts map carries the entry count, the format,
+ * the load time, the skipped-line count, the last success. An administrator who supplied a blocklist file can
+ * confirm it was actually read, which is the state that separates enforcing from a silent no-op.
+ */
+public final class SourceStatus {
+
+    /**
+     * The state a source can report about itself. Whether a source is <em>installed</em> at all is the
+     * engine's determination, not the source's.
+     */
+    public enum State {
+
+        /** Set up and answering. */
+        READY,
+
+        /** Installed but not set up - no file, no required credential. */
+        NOT_CONFIGURED,
+
+        /** Set up but currently unable to answer. */
+        UNAVAILABLE
+    }
+
+    private final State state;
+    private final String summary;
+    private final Map<String, String> facts;
+    private final Long lastSuccessEpochMillis;
+
+    private SourceStatus(Builder builder) {
+
+        this.state = builder.state;
+        this.summary = builder.summary;
+        this.facts = Collections.unmodifiableMap(new LinkedHashMap<>(builder.facts));
+        this.lastSuccessEpochMillis = builder.lastSuccessEpochMillis;
+    }
+
+    public State getState() {
+
+        return state;
+    }
+
+    /**
+     * @return a one-line operator-facing summary. Never contains a credential.
+     */
+    public Optional<String> getSummary() {
+
+        return Optional.ofNullable(summary);
+    }
+
+    /**
+     * @return ordered display facts, rendered as a label/value list in the administrator surface.
+     */
+    public Map<String, String> getFacts() {
+
+        return facts;
+    }
+
+    public Optional<Long> getLastSuccessEpochMillis() {
+
+        return Optional.ofNullable(lastSuccessEpochMillis);
+    }
+
+    public static Builder builder(State state) {
+
+        return new Builder(state);
+    }
+
+    /**
+     * Builder for {@link SourceStatus}.
+     */
+    public static final class Builder {
+
+        private final State state;
+        private final Map<String, String> facts = new LinkedHashMap<>();
+        private String summary;
+        private Long lastSuccessEpochMillis;
+
+        private Builder(State state) {
+
+            this.state = state;
+        }
+
+        public Builder summary(String summary) {
+
+            this.summary = summary;
+            return this;
+        }
+
+        public Builder fact(String label, String value) {
+
+            if (label != null && value != null) {
+                facts.put(label, value);
+            }
+            return this;
+        }
+
+        public Builder lastSuccess(Long epochMillis) {
+
+            this.lastSuccessEpochMillis = epochMillis;
+            return this;
+        }
+
+        public SourceStatus build() {
+
+            return new SourceStatus(this);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/Subject.java
+++ b/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/Subject.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.source;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Who the password is being set for.
+ * <p>
+ * Present on every context so that a source keyed on credential pairs rather than passwords alone can be added
+ * without redesigning anything. A source declaring {@link Capability#PASSWORD_ONLY} ignores this entirely, and
+ * the administrator surface uses {@link Capability#NEEDS_SUBJECT} to disclose that identity is transmitted
+ * before such a source can be enabled.
+ */
+public final class Subject {
+
+    private final String username;
+    private final String userId;
+    private final String userStoreDomain;
+    private final Function<String, String> claimResolver;
+
+    private Subject(Builder builder) {
+
+        this.username = builder.username;
+        this.userId = builder.userId;
+        this.userStoreDomain = builder.userStoreDomain;
+        this.claimResolver = builder.claimResolver;
+    }
+
+    public String getUsername() {
+
+        return username;
+    }
+
+    /**
+     * @return the user id where the operation carried one; empty on create, where no id exists yet.
+     */
+    public Optional<String> getUserId() {
+
+        return Optional.ofNullable(userId);
+    }
+
+    public String getUserStoreDomain() {
+
+        return userStoreDomain;
+    }
+
+    /**
+     * Resolve a claim for this subject. Lazily evaluated - a source that never asks costs no store round trip.
+     *
+     * @param claimUri claim URI.
+     * @return the claim value, or empty if unset or unresolvable.
+     */
+    public Optional<String> getClaim(String claimUri) {
+
+        if (claimResolver == null || claimUri == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(claimResolver.apply(claimUri));
+    }
+
+    public static Builder builder(String username) {
+
+        return new Builder(username);
+    }
+
+    /**
+     * Builder for {@link Subject}.
+     */
+    public static final class Builder {
+
+        private final String username;
+        private String userId;
+        private String userStoreDomain;
+        private Function<String, String> claimResolver;
+
+        private Builder(String username) {
+
+            this.username = username;
+        }
+
+        public Builder userId(String userId) {
+
+            this.userId = userId;
+            return this;
+        }
+
+        public Builder userStoreDomain(String userStoreDomain) {
+
+            this.userStoreDomain = userStoreDomain;
+            return this;
+        }
+
+        public Builder claimResolver(Function<String, String> claimResolver) {
+
+            this.claimResolver = claimResolver;
+            return this;
+        }
+
+        public Subject build() {
+
+            return new Subject(this);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/UnavailableCause.java
+++ b/components/org.wso2.carbon.identity.breach.detection.api/src/main/java/org/wso2/carbon/identity/breach/source/UnavailableCause.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.source;
+
+/**
+ * Why a source returned {@link Outcome#UNAVAILABLE}.
+ * <p>
+ * These are distinguished rather than collapsed because the operator response differs entirely: an exhausted
+ * quota is a billing action, a transport failure is a network one, and a source named in policy with no bundle
+ * behind it is a deployment one.
+ */
+public enum UnavailableCause {
+
+    /** The call did not complete inside the configured timeout. */
+    TIMEOUT,
+
+    /** The call failed to reach the service, or the service returned a transport-level failure. */
+    TRANSPORT,
+
+    /** A rate limit or quota was exhausted. */
+    QUOTA,
+
+    /** A response was received but could not be understood. */
+    PARSE,
+
+    /** The source is installed but not usable with the configuration it was given. */
+    MISCONFIGURED,
+
+    /** Repeated failure opened the circuit breaker; the source is not being called. */
+    CIRCUIT_OPEN,
+
+    /** Tenant policy names a source id with no bound service - usually a missing connector JAR. */
+    SOURCE_NOT_REGISTERED,
+
+    /** An unexpected error inside the source. Contained to that source. */
+    INTERNAL
+}

--- a/components/org.wso2.carbon.identity.breach.detection.api/src/test/java/org/wso2/carbon/identity/breach/source/BreachVerdictTest.java
+++ b/components/org.wso2.carbon.identity.breach.detection.api/src/test/java/org/wso2/carbon/identity/breach/source/BreachVerdictTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.source;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unavailable is not not-found. Collapsing the two is the defect the whole design is organised against, so it
+ * gets a test rather than a comment.
+ */
+public class BreachVerdictTest {
+
+    @Test
+    public void unavailableIsItsOwnOutcomeAndCarriesACause() {
+
+        BreachVerdict verdict = BreachVerdict.unavailable("hibp", UnavailableCause.TIMEOUT, "no answer");
+        assertEquals(verdict.getOutcome(), Outcome.UNAVAILABLE);
+        assertEquals(verdict.getCause().orElse(null), UnavailableCause.TIMEOUT);
+        assertFalse(verdict.getOccurrences().isPresent());
+    }
+
+    @Test
+    public void anUnavailableVerdictWithNoCauseStillHasOne() {
+
+        assertEquals(BreachVerdict.unavailable("x", null, null).getCause().orElse(null),
+                UnavailableCause.INTERNAL);
+    }
+
+    @Test
+    public void foundCarriesOccurrencesOnlyWhenTheSourceCounts() {
+
+        assertEquals(BreachVerdict.found("hibp", 612953).getOccurrences().getAsLong(), 612953L);
+        assertFalse(BreachVerdict.found("localList").getOccurrences().isPresent());
+        assertFalse(BreachVerdict.found("localList", -1).getOccurrences().isPresent());
+    }
+
+    @Test
+    public void notFoundIsPositiveAndCarriesNoCause() {
+
+        BreachVerdict verdict = BreachVerdict.notFound("localList");
+        assertEquals(verdict.getOutcome(), Outcome.NOT_FOUND);
+        assertFalse(verdict.getCause().isPresent());
+    }
+
+    @Test
+    public void theStringFormCarriesNoCredentialAndNoCount() {
+
+        String text = BreachVerdict.found("hibp", 612953).toString();
+        assertTrue(text.contains("hibp"));
+        assertFalse(text.contains("612953"));
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection.api/src/test/java/org/wso2/carbon/identity/breach/source/CredentialTest.java
+++ b/components/org.wso2.carbon.identity.breach.detection.api/src/test/java/org/wso2/carbon/identity/breach/source/CredentialTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.source;
+
+import org.testng.annotations.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Locale;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+/**
+ * The credential is the one object in this design that must not leak, so its handling is pinned down here
+ * rather than left to review.
+ */
+public class CredentialTest {
+
+    @Test
+    public void digestMatchesAPlainSha1OfTheUtf8Bytes() {
+
+        Credential credential = new Credential("Password@1".toCharArray());
+        assertEquals(credential.digestHex("SHA-1"), sha("SHA-1", "Password@1"));
+    }
+
+    @Test
+    public void digestSupportsSha256() {
+
+        Credential credential = new Credential("correct horse battery staple".toCharArray());
+        assertEquals(credential.digestHex("SHA-256"), sha("SHA-256", "correct horse battery staple"));
+    }
+
+    @Test
+    public void composedAndDecomposedFormsAgree() {
+
+        // The same password typed on two platforms must not hash differently.
+        Credential composed = new Credential("cafépass".toCharArray());
+        Credential decomposed = new Credential("cafépass".toCharArray());
+        assertEquals(composed.digestHex("SHA-1"), decomposed.digestHex("SHA-1"));
+    }
+
+    @Test
+    public void caseAndWhitespaceAreSignificant() {
+
+        // Folding either would refuse credentials nobody listed.
+        assertNotEquals(new Credential("Secret".toCharArray()).digestHex("SHA-1"),
+                new Credential("secret".toCharArray()).digestHex("SHA-1"));
+        assertNotEquals(new Credential(" Secret".toCharArray()).digestHex("SHA-1"),
+                new Credential("Secret".toCharArray()).digestHex("SHA-1"));
+        assertNotEquals(new Credential("Secret ".toCharArray()).digestHex("SHA-1"),
+                new Credential("Secret".toCharArray()).digestHex("SHA-1"));
+    }
+
+    @Test
+    public void toStringNeverRevealsTheCredential() {
+
+        Credential credential = new Credential("Password@1".toCharArray());
+        assertFalse(credential.toString().contains("Password"));
+        assertFalse(credential.toString().contains("@1"));
+    }
+
+    @Test
+    public void clearZeroesTheBackingArray() {
+
+        char[] chars = "Password@1".toCharArray();
+        Credential credential = new Credential(chars);
+        credential.clear();
+        assertTrue(credential.isCleared());
+        for (char c : chars) {
+            assertEquals(c, '\0');
+        }
+    }
+
+    @Test
+    public void aClearedCredentialCannotBeReadAgain() {
+
+        Credential credential = new Credential("Password@1".toCharArray());
+        credential.clear();
+        try {
+            credential.digestHex("SHA-1");
+            fail("A cleared credential must not still answer.");
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage().contains("cleared"));
+        }
+    }
+
+    @Test
+    public void canonicalBytesDoNotAliasTheBackingArray() {
+
+        char[] chars = "Password@1".toCharArray();
+        Credential credential = new Credential(chars);
+        byte[] first = credential.canonicalBytes();
+        java.util.Arrays.fill(first, (byte) 0);
+        // Wiping what the caller was handed must not damage the credential itself.
+        assertEquals(credential.digestHex("SHA-1"), sha("SHA-1", "Password@1"));
+    }
+
+    @Test
+    public void lengthIsSafeToExpose() {
+
+        assertEquals(new Credential("Password@1".toCharArray()).length(), 10);
+    }
+
+    private static String sha(String algorithm, String value) {
+
+        try {
+            byte[] out = MessageDigest.getInstance(algorithm).digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder();
+            for (byte b : out) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString().toUpperCase(Locale.ROOT);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection.api/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.breach.detection.api/src/test/resources/testng.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="breach-source-spi">
+    <test name="breach-source-spi-tests">
+        <packages>
+            <package name="org.wso2.carbon.identity.breach.source"/>
+        </packages>
+    </test>
+</suite>

--- a/components/org.wso2.carbon.identity.breach.detection/pom.xml
+++ b/components/org.wso2.carbon.identity.breach.detection/pom.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.governance</groupId>
+        <artifactId>identity-governance</artifactId>
+        <version>1.16.36-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.breach.detection</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Breached Credential Detection</name>
+    <description>
+        Refuses passwords that appear in credential breach corpora. Holds no reference to any remote source:
+        those register themselves against the breach source SPI.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.breach.detection.api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.governance</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.user.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.user.api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-Package>
+                            org.wso2.carbon.identity.breach.detection.internal,
+                            org.wso2.carbon.identity.breach.detection.listener,
+                            org.wso2.carbon.identity.breach.detection.engine,
+                            org.wso2.carbon.identity.breach.detection.policy,
+                            org.wso2.carbon.identity.breach.detection.connector,
+                            org.wso2.carbon.identity.breach.detection.source,
+                            org.wso2.carbon.identity.breach.detection.config,
+                            org.wso2.carbon.identity.breach.detection.metrics,
+                            org.wso2.carbon.identity.breach.detection.util
+                        </Private-Package>
+                        <!--
+                          Only the management contract is exported. A connector that reaches past the SPI is
+                          exactly the coupling the core/connector split exists to prevent.
+                        -->
+                        <Export-Package>
+                            org.wso2.carbon.identity.breach.detection.mgt;version="${identity.governance.exp.pkg.version}",
+                            org.wso2.carbon.identity.breach.detection.constants;version="${identity.governance.exp.pkg.version}"
+                        </Export-Package>
+                        <Import-Package>
+                            org.wso2.carbon.identity.breach.source;version="${breach.spi.imp.pkg.version.range}",
+                            org.osgi.framework;version="${osgi.framework.imp.pkg.version.range}",
+                            org.osgi.service.component;version="${osgi.service.component.imp.pkg.version.range}",
+                            org.apache.commons.logging;version="${commons-logging.osgi.version.range}",
+                            org.wso2.carbon.user.core.*;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.api;version="${carbon.user.api.imp.pkg.version.range}",
+                            org.wso2.carbon.utils.*;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.identity.core.*;version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.mgt.policy;version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.common.model;version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.governance;version="${identity.governance.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.governance.common;version="${identity.governance.imp.pkg.version.range}",
+                            org.apache.axiom.om;version="${axiom.osgi.version.range}",
+                            org.wso2.securevault;version="${securevault.version.range}";resolution:=optional,
+                            *
+                        </Import-Package>
+                        <!--
+                          java.* is delegated by the boot classloader. Importing it makes the bundle
+                          unresolvable on Equinox.
+                        -->
+                        <_noimportjava>true</_noimportjava>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/config/BreachDetectionConfig.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/config/BreachDetectionConfig.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.config;
+
+import org.apache.axiom.om.OMAttribute;
+import org.apache.axiom.om.OMContainer;
+import org.apache.axiom.om.OMElement;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.breach.detection.constants.BreachDetectionConstants;
+import org.wso2.carbon.identity.breach.detection.util.BreachDetectionUtils;
+import org.wso2.carbon.identity.core.model.IdentityEventListenerConfig;
+import org.wso2.carbon.identity.core.util.IdentityConfigParser;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Operator configuration: the deployment kill switch, the evaluation bounds, and the per-source namespaces.
+ * <p>
+ * Read from identity.xml, which the config parser renders from {@code [breach_detection]} in deployment.toml.
+ * Deliberately separate from tenant policy: incident control must not depend on a tenant configuration store
+ * being reachable, and filesystem and memory are deployment properties rather than tenant ones.
+ */
+public class BreachDetectionConfig {
+
+    private static final Log LOG = LogFactory.getLog(BreachDetectionConfig.class);
+
+    private static volatile BreachDetectionConfig instance;
+
+    private final boolean enabledAtDeployment;
+    private final int listenerOrder;
+    private final Map<String, String> globalProperties;
+    private final Map<String, SourceNamespace> sourceNamespaces;
+
+    private BreachDetectionConfig() {
+
+        IdentityEventListenerConfig listenerConfig = IdentityUtil.readEventListenerProperty(
+                BreachDetectionConstants.LISTENER_TYPE, BreachDetectionConstants.LISTENER_CLASS);
+
+        // Absent declaration means the capability was never wired in, which is off, not on.
+        this.enabledAtDeployment = listenerConfig != null && Boolean.parseBoolean(listenerConfig.getEnable());
+        this.listenerOrder = listenerConfig == null
+                ? BreachDetectionConstants.DEFAULT_LISTENER_ORDER : listenerConfig.getOrder();
+
+        Map<String, String> globals = new LinkedHashMap<>();
+        Map<String, SourceNamespace> namespaces = new LinkedHashMap<>();
+        parse(globals, namespaces);
+        this.globalProperties = Collections.unmodifiableMap(globals);
+        this.sourceNamespaces = Collections.unmodifiableMap(namespaces);
+    }
+
+    public static BreachDetectionConfig getInstance() {
+
+        BreachDetectionConfig local = instance;
+        if (local == null) {
+            synchronized (BreachDetectionConfig.class) {
+                local = instance;
+                if (local == null) {
+                    local = new BreachDetectionConfig();
+                    instance = local;
+                }
+            }
+        }
+        return local;
+    }
+
+    /**
+     * Re-read identity.xml. Used by the management service after an operator edits configuration.
+     *
+     * @return the reloaded configuration.
+     */
+    public static BreachDetectionConfig reload() {
+
+        synchronized (BreachDetectionConfig.class) {
+            instance = new BreachDetectionConfig();
+            return instance;
+        }
+    }
+
+    /**
+     * The deployment kill switch. False disables the capability for every tenant without removing software,
+     * and leaves stored tenant policy untouched for when it is switched back on.
+     *
+     * @return whether the capability is switched on at deployment level.
+     */
+    public boolean isEnabledAtDeployment() {
+
+        return enabledAtDeployment;
+    }
+
+    public int getListenerOrder() {
+
+        return listenerOrder;
+    }
+
+    /**
+     * @return per-source configuration, keyed by normalized source id.
+     */
+    public Map<String, SourceNamespace> getSourceNamespaces() {
+
+        return sourceNamespaces;
+    }
+
+    /**
+     * @param normalizedSourceId key from {@link BreachDetectionUtils#normalizeSourceId(String)}.
+     * @return the namespace, or {@code null} if the operator configured none.
+     */
+    public SourceNamespace getSourceNamespace(String normalizedSourceId) {
+
+        return sourceNamespaces.get(normalizedSourceId);
+    }
+
+    public int getEvaluationTimeoutMs() {
+
+        return BreachDetectionUtils.parseInt(globalProperties.get(BreachDetectionConstants.CONFIG_SOURCE_TIMEOUT_MS),
+                BreachDetectionConstants.DEFAULT_SOURCE_TIMEOUT_MS);
+    }
+
+    /**
+     * Bulk imports and migration-time writes can be exempted so a migration does not pay a network round trip
+     * per row, or burn third-party quota on data that is already in the store.
+     *
+     * @return whether bulk operations skip evaluation.
+     */
+    public boolean isBulkExempt() {
+
+        return BreachDetectionUtils.parseBoolean(globalProperties.get(BreachDetectionConstants.CONFIG_EXEMPT_BULK),
+                false);
+    }
+
+    public int getWorkerThreads() {
+
+        return BreachDetectionUtils.parseInt(globalProperties.get(BreachDetectionConstants.CONFIG_WORKER_THREADS),
+                BreachDetectionConstants.DEFAULT_WORKER_THREADS);
+    }
+
+    private void parse(Map<String, String> globals, Map<String, SourceNamespace> namespaces) {
+
+        OMElement root;
+        try {
+            root = IdentityConfigParser.getInstance()
+                    .getConfigElement(BreachDetectionConstants.CONFIG_ELEMENT);
+        } catch (Throwable t) {
+            LOG.error("Could not read the " + BreachDetectionConstants.CONFIG_ELEMENT
+                    + " configuration element. Breach detection will run with defaults.", t);
+            return;
+        }
+        if (root == null) {
+            return;
+        }
+
+        SecretResolutionSupport secrets = createSecretSupport(root);
+
+        Iterator<?> children = root.getChildElements();
+        while (children.hasNext()) {
+            Object child = children.next();
+            if (!(child instanceof OMElement)) {
+                continue;
+            }
+            OMElement element = (OMElement) child;
+            String localName = element.getLocalName();
+            if (BreachDetectionConstants.CONFIG_PROPERTY_ELEMENT.equals(localName)) {
+                String name = attribute(element, BreachDetectionConstants.CONFIG_ATTRIBUTE_NAME);
+                if (name != null) {
+                    globals.put(name, text(element));
+                }
+            } else if (BreachDetectionConstants.CONFIG_SOURCES_ELEMENT.equals(localName)) {
+                parseSources(element, namespaces, secrets);
+            } else if (BreachDetectionConstants.CONFIG_SOURCE_ELEMENT.equals(localName)) {
+                parseSource(element, namespaces, secrets);
+            }
+        }
+    }
+
+    private void parseSources(OMElement sourcesElement, Map<String, SourceNamespace> namespaces,
+                              SecretResolutionSupport secrets) {
+
+        Iterator<?> children = sourcesElement.getChildElements();
+        while (children.hasNext()) {
+            Object child = children.next();
+            if (child instanceof OMElement
+                    && BreachDetectionConstants.CONFIG_SOURCE_ELEMENT.equals(((OMElement) child).getLocalName())) {
+                parseSource((OMElement) child, namespaces, secrets);
+            }
+        }
+    }
+
+    private void parseSource(OMElement sourceElement, Map<String, SourceNamespace> namespaces,
+                             SecretResolutionSupport secrets) {
+
+        String id = attribute(sourceElement, BreachDetectionConstants.CONFIG_ATTRIBUTE_ID);
+        if (id == null || id.trim().isEmpty()) {
+            LOG.warn("Ignoring a breach detection source configuration block with no id attribute.");
+            return;
+        }
+        Map<String, String> properties = new LinkedHashMap<>();
+        Map<String, String> aliases = new LinkedHashMap<>();
+        Iterator<?> children = sourceElement.getChildElements();
+        while (children.hasNext()) {
+            Object child = children.next();
+            if (!(child instanceof OMElement)) {
+                continue;
+            }
+            OMElement property = (OMElement) child;
+            if (!BreachDetectionConstants.CONFIG_PROPERTY_ELEMENT.equals(property.getLocalName())) {
+                continue;
+            }
+            String name = attribute(property, BreachDetectionConstants.CONFIG_ATTRIBUTE_NAME);
+            if (name == null) {
+                continue;
+            }
+            String value = text(property);
+            String alias = attribute(property, BreachDetectionConstants.CONFIG_ATTRIBUTE_SECRET_ALIAS);
+            if (alias == null) {
+                alias = secretAliasFromValue(value);
+            }
+            if (alias != null) {
+                aliases.put(name, alias);
+                String resolved = secrets == null ? null : secrets.resolve(alias);
+                // A value that could not be resolved stays absent rather than being stored as its own alias.
+                properties.put(name, resolved);
+            } else {
+                properties.put(name, value);
+            }
+        }
+        namespaces.put(BreachDetectionUtils.normalizeSourceId(id.trim()),
+                new SourceNamespace(id.trim(), properties, aliases));
+    }
+
+    private SecretResolutionSupport createSecretSupport(OMElement element) {
+
+        try {
+            OMContainer parent = element.getParent();
+            OMElement documentRoot = element;
+            while (parent instanceof OMElement) {
+                documentRoot = (OMElement) parent;
+                parent = documentRoot.getParent();
+            }
+            return new SecretResolutionSupport(documentRoot);
+        } catch (Throwable t) {
+            LOG.debug("Secure vault support is unavailable for breach detection configuration.", t);
+            return null;
+        }
+    }
+
+    private static String secretAliasFromValue(String value) {
+
+        if (value != null && value.startsWith("$secret{") && value.endsWith("}")) {
+            return value.substring("$secret{".length(), value.length() - 1);
+        }
+        return null;
+    }
+
+    private static String attribute(OMElement element, String name) {
+
+        for (Iterator<?> it = element.getAllAttributes(); it.hasNext(); ) {
+            Object next = it.next();
+            if (next instanceof OMAttribute && name.equals(((OMAttribute) next).getLocalName())) {
+                return ((OMAttribute) next).getAttributeValue();
+            }
+        }
+        return null;
+    }
+
+    private static String text(OMElement element) {
+
+        String value = element.getText();
+        return value == null ? null : value.trim();
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/config/ResolvedSourceConfiguration.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/config/ResolvedSourceConfiguration.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.config;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.breach.source.PropertyDescriptor;
+import org.wso2.carbon.identity.breach.source.PropertyType;
+import org.wso2.carbon.identity.breach.source.SourceConfiguration;
+import org.wso2.carbon.identity.breach.detection.util.BreachDetectionUtils;
+import org.wso2.carbon.utils.CarbonUtils;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * The settings one source declared, resolved against what the operator configured.
+ * <p>
+ * The source itself reads nothing: it declares what it needs and the core hands the values over. That is what
+ * makes the {@code secret} flag enforceable rather than advisory, and it is why a connector holds no
+ * filesystem or vault access of its own.
+ */
+public class ResolvedSourceConfiguration implements SourceConfiguration {
+
+    private static final Log LOG = LogFactory.getLog(ResolvedSourceConfiguration.class);
+
+    private final String sourceId;
+    private final Map<String, String> values;
+    private final Map<String, PropertyDescriptor> declared;
+
+    public ResolvedSourceConfiguration(String sourceId, List<PropertyDescriptor> descriptors,
+                                       SourceNamespace namespace) {
+
+        this.sourceId = sourceId;
+        this.declared = new LinkedHashMap<>();
+        for (PropertyDescriptor descriptor : descriptors) {
+            declared.put(descriptor.getName(), descriptor);
+        }
+        this.values = new HashMap<>();
+        if (namespace != null) {
+            values.putAll(namespace.getProperties());
+            reportUnrecognisedKeys(namespace);
+        }
+        reportMissingRequired();
+    }
+
+    @Override
+    public Optional<String> getString(String name) {
+
+        String value = values.get(name);
+        if (value != null && !value.trim().isEmpty()) {
+            return Optional.of(value.trim());
+        }
+        PropertyDescriptor descriptor = declared.get(name);
+        return descriptor == null ? Optional.empty() : descriptor.getDefaultValue();
+    }
+
+    @Override
+    public int getInt(String name, int defaultValue) {
+
+        return BreachDetectionUtils.parseInt(getString(name).orElse(null), defaultValue);
+    }
+
+    @Override
+    public long getLong(String name, long defaultValue) {
+
+        return BreachDetectionUtils.parseLong(getString(name).orElse(null), defaultValue);
+    }
+
+    @Override
+    public boolean getBoolean(String name, boolean defaultValue) {
+
+        return BreachDetectionUtils.parseBoolean(getString(name).orElse(null), defaultValue);
+    }
+
+    @Override
+    public Optional<char[]> getSecret(String name) {
+
+        PropertyDescriptor descriptor = declared.get(name);
+        if (descriptor == null || !descriptor.isSecret()) {
+            // Refusing here is the point: a value not declared secret must not be reachable as one.
+            LOG.warn("Source '" + sourceId + "' asked for '" + name + "' as a secret, but it is not declared "
+                    + "as one. Returning nothing.");
+            return Optional.empty();
+        }
+        String value = values.get(name);
+        if (value == null || value.trim().isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(value.trim().toCharArray());
+    }
+
+    @Override
+    public Optional<String> getPath(String name) {
+
+        Optional<String> configured = getString(name);
+        if (!configured.isPresent()) {
+            return Optional.empty();
+        }
+        String raw = expand(configured.get());
+        Path candidate;
+        try {
+            candidate = Paths.get(raw).toAbsolutePath().normalize();
+        } catch (Exception e) {
+            LOG.error("Source '" + sourceId + "' was configured with an unusable path for '" + name + "'.");
+            return Optional.empty();
+        }
+        if (!isWithinPermittedRoots(candidate)) {
+            // Blocklist data is evaluation data, never a path reference the file itself can redirect.
+            LOG.error("Source '" + sourceId + "' was configured with a path for '" + name
+                    + "' outside the permitted locations. Ignoring it.");
+            return Optional.empty();
+        }
+        return Optional.of(candidate.toString());
+    }
+
+    /**
+     * @return the declared settings, for the administrator surface.
+     */
+    public Map<String, PropertyDescriptor> getDeclaredProperties() {
+
+        return declared;
+    }
+
+    private boolean isWithinPermittedRoots(Path candidate) {
+
+        Set<Path> roots = new HashSet<>();
+        addRoot(roots, safeCarbonHome());
+        addRoot(roots, System.getProperty("carbon.config.dir.path"));
+        if (roots.isEmpty()) {
+            // With no resolvable deployment root there is nothing to confine against; fail closed.
+            return false;
+        }
+        for (Path root : roots) {
+            if (candidate.startsWith(root)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void addRoot(Set<Path> roots, String raw) {
+
+        if (raw == null || raw.trim().isEmpty()) {
+            return;
+        }
+        try {
+            roots.add(Paths.get(raw).toAbsolutePath().normalize());
+        } catch (Exception ignored) {
+            // An unusable root simply does not widen the permitted set.
+        }
+    }
+
+    private static String safeCarbonHome() {
+
+        try {
+            return CarbonUtils.getCarbonHome();
+        } catch (Throwable t) {
+            return System.getProperty("carbon.home");
+        }
+    }
+
+    private static String expand(String value) {
+
+        String carbonHome = safeCarbonHome();
+        String expanded = value;
+        if (carbonHome != null) {
+            expanded = expanded.replace("${carbon.home}", carbonHome);
+        }
+        return expanded.replace('/', File.separatorChar);
+    }
+
+    private void reportUnrecognisedKeys(SourceNamespace namespace) {
+
+        for (String key : namespace.getProperties().keySet()) {
+            if (!declared.containsKey(key)) {
+                // Reported rather than ignored: a typo must not silently leave a connector on its default.
+                LOG.warn("Breach detection source '" + sourceId + "' has no setting named '" + key
+                        + "'. Check the [breach_detection.sources." + namespace.getId() + "] configuration.");
+            }
+        }
+    }
+
+    private void reportMissingRequired() {
+
+        for (PropertyDescriptor descriptor : declared.values()) {
+            if (descriptor.isRequired() && !getString(descriptor.getName()).isPresent()) {
+                LOG.warn("Breach detection source '" + sourceId + "' requires '" + descriptor.getName()
+                        + "', which is not configured. The source will report itself as not configured.");
+            }
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/config/SecretResolutionSupport.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/config/SecretResolutionSupport.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.config;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.securevault.SecretResolver;
+import org.wso2.securevault.SecretResolverFactory;
+
+/**
+ * Resolves a secure-vault alias to its value.
+ * <p>
+ * Isolated in its own class and loaded reflectively by {@link BreachDetectionConfig} so that a deployment
+ * without the secure vault bundle degrades to literal values rather than failing to load the configuration
+ * layer outright.
+ */
+final class SecretResolutionSupport {
+
+    private static final Log LOG = LogFactory.getLog(SecretResolutionSupport.class);
+
+    private final SecretResolver resolver;
+
+    SecretResolutionSupport(OMElement documentRoot) {
+
+        SecretResolver created = null;
+        try {
+            created = SecretResolverFactory.create(documentRoot, false);
+        } catch (Throwable t) {
+            LOG.debug("Secure vault is not available for breach detection configuration. " +
+                    "Secret properties will be read literally.", t);
+        }
+        this.resolver = created;
+    }
+
+    /**
+     * @param alias secure vault alias.
+     * @return the resolved value, or {@code null} when no resolver is initialised or the alias is unknown.
+     */
+    String resolve(String alias) {
+
+        if (resolver == null || alias == null || !resolver.isInitialized()) {
+            return null;
+        }
+        try {
+            if (resolver.isTokenProtected(alias)) {
+                return resolver.resolve(alias);
+            }
+        } catch (Throwable t) {
+            // Never let a vault failure surface the alias or the value.
+            LOG.error("Failed to resolve a secure vault alias for a breach detection source property.");
+        }
+        return null;
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/config/SourceNamespace.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/config/SourceNamespace.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.config;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The operator configuration written under one source's namespace, before any source has claimed it.
+ * <p>
+ * A namespace whose id matches no registered source is reported at load rather than ignored - it usually means
+ * a connector JAR is missing.
+ */
+public final class SourceNamespace {
+
+    private final String id;
+    private final Map<String, String> properties;
+    private final Map<String, String> secretAliases;
+
+    SourceNamespace(String id, Map<String, String> properties, Map<String, String> secretAliases) {
+
+        this.id = id;
+        this.properties = Collections.unmodifiableMap(new LinkedHashMap<>(properties));
+        this.secretAliases = Collections.unmodifiableMap(new LinkedHashMap<>(secretAliases));
+    }
+
+    /**
+     * @return the id exactly as written in configuration.
+     */
+    public String getId() {
+
+        return id;
+    }
+
+    public Map<String, String> getProperties() {
+
+        return properties;
+    }
+
+    /**
+     * @return property name to secure-vault alias, for values written as {@code $secret{alias}}.
+     */
+    public Map<String, String> getSecretAliases() {
+
+        return secretAliases;
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/connector/BreachDetectionConnectorConfig.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/connector/BreachDetectionConnectorConfig.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.connector;
+
+import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.breach.detection.constants.BreachDetectionConstants;
+import org.wso2.carbon.identity.breach.detection.engine.SourceRegistry;
+import org.wso2.carbon.identity.breach.detection.policy.BreachPolicyResolver;
+import org.wso2.carbon.identity.breach.source.BreachSource;
+import org.wso2.carbon.identity.breach.source.Capability;
+import org.wso2.carbon.identity.governance.IdentityGovernanceException;
+import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Per-organization policy, carried on the existing governance connector mechanism.
+ * <p>
+ * Reusing it brings a per-tenant store, tenant isolation, and a working management API without inventing any of
+ * them. Source credentials stay out of it entirely: connector properties are readable over REST, and that is
+ * exactly how a credential ends up in a response body.
+ * <p>
+ * The property list is built from what is bound right now, so installing a connector JAR adds its failure-policy
+ * setting with no core change.
+ */
+public class BreachDetectionConnectorConfig implements IdentityConnectorConfig {
+
+    private final SourceRegistry registry;
+
+    public BreachDetectionConnectorConfig(SourceRegistry registry) {
+
+        this.registry = registry;
+    }
+
+    @Override
+    public String getName() {
+
+        return BreachDetectionConstants.CONNECTOR_NAME;
+    }
+
+    @Override
+    public String getFriendlyName() {
+
+        return BreachDetectionConstants.CONNECTOR_FRIENDLY_NAME;
+    }
+
+    @Override
+    public String getCategory() {
+
+        return BreachDetectionConstants.CONNECTOR_CATEGORY;
+    }
+
+    @Override
+    public String getSubCategory() {
+
+        return BreachDetectionConstants.CONNECTOR_SUB_CATEGORY;
+    }
+
+    @Override
+    public int getOrder() {
+
+        return BreachDetectionConstants.CONNECTOR_ORDER;
+    }
+
+    @Override
+    public Map<String, String> getPropertyNameMapping() {
+
+        Map<String, String> names = new LinkedHashMap<>();
+        names.put(BreachDetectionConstants.PROPERTY_ENABLE, "Refuse breached passwords");
+        names.put(BreachDetectionConstants.PROPERTY_SOURCES, "Sources");
+        for (BreachSource source : registry.installed()) {
+            names.put(BreachPolicyResolver.onErrorProperty(source.getId()),
+                    "If " + source.getDescriptor().getDisplayName() + " cannot be reached");
+        }
+        return names;
+    }
+
+    @Override
+    public Map<String, String> getPropertyDescriptionMapping() {
+
+        Map<String, String> descriptions = new LinkedHashMap<>();
+        descriptions.put(BreachDetectionConstants.PROPERTY_ENABLE,
+                "Refuse passwords that have appeared in known data breaches. Turning this on can refuse "
+                        + "passwords that were previously accepted.");
+        descriptions.put(BreachDetectionConstants.PROPERTY_SOURCES,
+                "Comma-separated ids of the sources to consult. Only sources installed on this server can "
+                        + "return a verdict.");
+        for (BreachSource source : registry.installed()) {
+            descriptions.put(BreachPolicyResolver.onErrorProperty(source.getId()),
+                    "Whether to allow or deny a password when " + source.getDescriptor().getDisplayName()
+                            + " cannot answer. Choose deny only if you would rather block sign-ups than risk "
+                            + "accepting a breached password.");
+        }
+        return descriptions;
+    }
+
+    @Override
+    public String[] getPropertyNames() {
+
+        List<String> names = new ArrayList<>();
+        names.add(BreachDetectionConstants.PROPERTY_ENABLE);
+        names.add(BreachDetectionConstants.PROPERTY_SOURCES);
+        for (BreachSource source : registry.installed()) {
+            names.add(BreachPolicyResolver.onErrorProperty(source.getId()));
+        }
+        return names.toArray(new String[0]);
+    }
+
+    @Override
+    public Properties getDefaultPropertyValues(String tenantDomain) throws IdentityGovernanceException {
+
+        Properties defaults = new Properties();
+        // Off by default. Upgrading with no configuration change must change nothing.
+        defaults.put(BreachDetectionConstants.PROPERTY_ENABLE, BreachDetectionConstants.DEFAULT_ENABLE);
+        defaults.put(BreachDetectionConstants.PROPERTY_SOURCES, BreachDetectionConstants.DEFAULT_SOURCES);
+        for (BreachSource source : registry.installed()) {
+            defaults.put(BreachPolicyResolver.onErrorProperty(source.getId()), defaultOnError(source));
+        }
+        return defaults;
+    }
+
+    @Override
+    public Map<String, String> getDefaultPropertyValues(String[] propertyNames, String tenantDomain)
+            throws IdentityGovernanceException {
+
+        Map<String, String> defaults = new HashMap<>();
+        Properties all = getDefaultPropertyValues(tenantDomain);
+        for (String name : propertyNames) {
+            Object value = all.get(name);
+            if (value != null) {
+                defaults.put(name, String.valueOf(value));
+            }
+        }
+        return defaults;
+    }
+
+    @Override
+    public Map<String, Property> getMetaData() {
+
+        Map<String, Property> metadata = new LinkedHashMap<>();
+        metadata.put(BreachDetectionConstants.PROPERTY_ENABLE, booleanProperty());
+        return metadata;
+    }
+
+    private static String defaultOnError(BreachSource source) {
+
+        return source.getCapabilities().contains(Capability.OFFLINE)
+                ? BreachDetectionConstants.ON_ERROR_DENY : BreachDetectionConstants.ON_ERROR_ALLOW;
+    }
+
+    private static Property booleanProperty() {
+
+        Property property = new Property();
+        property.setType("boolean");
+        return property;
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/constants/BreachDetectionConstants.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/constants/BreachDetectionConstants.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.constants;
+
+/**
+ * Names shared across the capability: configuration keys, governance property names, and the error codes a
+ * caller sees. Exported so an administrator API can name the same things without duplicating literals.
+ */
+public class BreachDetectionConstants {
+
+    private BreachDetectionConstants() {
+
+    }
+
+    /** Listener registration, mirroring the declaration in identity.xml. */
+    public static final String LISTENER_TYPE = "org.wso2.carbon.user.core.listener.UserOperationEventListener";
+
+    public static final String LISTENER_CLASS =
+            "org.wso2.carbon.identity.breach.detection.listener.BreachDetectionListener";
+
+    /**
+     * After input validation at 3, so a password failing composition never reaches a breach source, and before
+     * the service extension at 10000, so in-product policy resolves before any customer extension runs.
+     */
+    public static final int DEFAULT_LISTENER_ORDER = 420;
+
+    /** The identity.xml element carrying operator configuration, rendered from [breach_detection]. */
+    public static final String CONFIG_ELEMENT = "BreachDetection";
+    public static final String CONFIG_SOURCES_ELEMENT = "Sources";
+    public static final String CONFIG_SOURCE_ELEMENT = "Source";
+    public static final String CONFIG_PROPERTY_ELEMENT = "Property";
+    public static final String CONFIG_ATTRIBUTE_ID = "id";
+    public static final String CONFIG_ATTRIBUTE_NAME = "name";
+    public static final String CONFIG_ATTRIBUTE_SECRET_ALIAS = "secretAlias";
+
+    /** The one source that ships in the core. */
+    public static final String LOCAL_LIST_SOURCE_ID = "localList";
+
+    /** Governance connector - per-organization policy. */
+    public static final String CONNECTOR_NAME = "breachDetection";
+    public static final String CONNECTOR_FRIENDLY_NAME = "Breached Password Detection";
+    public static final String CONNECTOR_CATEGORY = "Password Policies";
+    public static final String CONNECTOR_SUB_CATEGORY = "DEFAULT";
+    public static final int CONNECTOR_ORDER = 0;
+
+    public static final String PROPERTY_ENABLE = "breachDetection.enable";
+    public static final String PROPERTY_SOURCES = "breachDetection.sources";
+    public static final String PROPERTY_ON_ERROR_PREFIX = "breachDetection.";
+    public static final String PROPERTY_ON_ERROR_SUFFIX = ".onError";
+
+    public static final String ON_ERROR_ALLOW = "allow";
+    public static final String ON_ERROR_DENY = "deny";
+
+    /**
+     * Deployment default is disabled. Upgrading with no configuration change must produce password-setting
+     * behaviour identical to before the upgrade.
+     */
+    public static final String DEFAULT_ENABLE = "false";
+    public static final String DEFAULT_SOURCES = "";
+
+    /** Operator settings, read from identity.xml. */
+    public static final String CONFIG_SOURCE_TIMEOUT_MS = "evaluation_timeout_ms";
+    public static final int DEFAULT_SOURCE_TIMEOUT_MS = 1500;
+    public static final String CONFIG_EXEMPT_BULK = "exempt_bulk_operations";
+    public static final String CONFIG_WORKER_THREADS = "worker_threads";
+    public static final int DEFAULT_WORKER_THREADS = 20;
+
+    /**
+     * Error codes. A policy rejection is a client error carrying the reason - never a server fault, which is
+     * indistinguishable from an outage and stops portals rendering the cause.
+     */
+    public static final String ERROR_CODE_BREACHED_PASSWORD = "BRD-60001";
+    public static final String ERROR_CODE_CANNOT_VERIFY = "BRD-60002";
+
+    /** Message keys, resolved through the bundled resource bundle so they localize with everything else. */
+    public static final String MESSAGE_KEY_BREACHED = "breach.detection.password.breached";
+    public static final String MESSAGE_KEY_CANNOT_VERIFY = "breach.detection.password.unverifiable";
+    public static final String MESSAGE_KEY_RECOVERY_STILL_VALID = "breach.detection.recovery.still.valid";
+
+    public static final String RESOURCE_BUNDLE = "org.wso2.carbon.identity.breach.detection.i18n.Resources";
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/engine/BreachEvaluationEngine.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/engine/BreachEvaluationEngine.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.engine;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.breach.detection.mgt.EnforcementStatus;
+import org.wso2.carbon.identity.breach.detection.metrics.BreachMetrics;
+import org.wso2.carbon.identity.breach.detection.policy.BreachPolicy;
+import org.wso2.carbon.identity.breach.detection.policy.FailurePolicy;
+import org.wso2.carbon.identity.breach.source.BreachContext;
+import org.wso2.carbon.identity.breach.source.BreachSource;
+import org.wso2.carbon.identity.breach.source.BreachSourceException;
+import org.wso2.carbon.identity.breach.source.BreachVerdict;
+import org.wso2.carbon.identity.breach.source.Capability;
+import org.wso2.carbon.identity.breach.source.Outcome;
+import org.wso2.carbon.identity.breach.source.UnavailableCause;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Orders the sources a tenant enabled, bounds each call, short-circuits on the first match, contains failures
+ * to the source that caused them, and resolves the whole thing into one decision.
+ * <p>
+ * It knows nothing about any concrete source. Ordering comes from the priority each source declares, so an
+ * in-process offline list is consulted before a network round trip - which means the passwords an operator most
+ * wants blocked never leave the deployment and never consume third-party quota.
+ */
+public class BreachEvaluationEngine {
+
+    private static final Log LOG = LogFactory.getLog(BreachEvaluationEngine.class);
+
+    private final SourceRegistry registry;
+    private final BreachMetrics metrics;
+    private final ThreadPoolExecutor executor;
+    private final int timeoutMs;
+
+    public BreachEvaluationEngine(SourceRegistry registry, BreachMetrics metrics, int workerThreads,
+                                  int timeoutMs) {
+
+        this.registry = registry;
+        this.metrics = metrics;
+        this.timeoutMs = timeoutMs;
+        AtomicInteger counter = new AtomicInteger();
+        this.executor = new ThreadPoolExecutor(1, Math.max(1, workerThreads), 60L, TimeUnit.SECONDS,
+                new ArrayBlockingQueue<>(Math.max(1, workerThreads) * 10),
+                runnable -> {
+                    Thread thread = new Thread(runnable, "breach-source-" + counter.incrementAndGet());
+                    thread.setDaemon(true);
+                    return thread;
+                },
+                new ThreadPoolExecutor.AbortPolicy());
+    }
+
+    /**
+     * Evaluate a candidate against the sources this organization's policy names.
+     *
+     * @param context the candidate and its surrounding operation.
+     * @param policy  the organization's effective policy.
+     * @return the decision, the reported status, and every contributing verdict.
+     */
+    public EvaluationResult evaluate(BreachContext context, BreachPolicy policy) {
+
+        if (policy == null || !policy.isEnabled()) {
+            return EvaluationResult.accept(EnforcementStatus.OFF);
+        }
+        List<PlannedSource> plan = plan(policy);
+        if (plan.isEmpty()) {
+            // Enabled but naming nothing is not enforcing, and must never be reported as if it were.
+            LOG.warn("Breached password detection is enabled for tenant '" + context.getTenantDomain()
+                    + "' but names no source. No password is being checked.");
+            return EvaluationResult.accept(EnforcementStatus.NOT_ENFORCING);
+        }
+
+        List<BreachVerdict> verdicts = new ArrayList<>(plan.size());
+        List<AtomicBoolean> outstanding = new ArrayList<>(plan.size());
+        String breachedBy = null;
+
+        for (PlannedSource planned : plan) {
+            BreachVerdict verdict = verdictFor(planned, context, outstanding);
+            verdicts.add(verdict);
+            if (verdict.getOutcome() == Outcome.FOUND) {
+                breachedBy = verdict.getSourceId();
+                // A match ends it. Nothing after this needs asking, and no network call is worth making.
+                break;
+            }
+        }
+
+        clearWhenSafe(context, outstanding);
+        return resolve(context, policy, verdicts, breachedBy);
+    }
+
+    /**
+     * Stop accepting work. Called when the component deactivates.
+     */
+    public void shutdown() {
+
+        executor.shutdownNow();
+    }
+
+    private List<PlannedSource> plan(BreachPolicy policy) {
+
+        List<PlannedSource> installed = new ArrayList<>();
+        List<PlannedSource> missing = new ArrayList<>();
+        for (String sourceId : policy.getSourceIds()) {
+            Optional<BreachSource> bound = registry.get(sourceId);
+            if (bound.isPresent()) {
+                installed.add(new PlannedSource(bound.get().getId(), bound.get()));
+            } else {
+                missing.add(new PlannedSource(sourceId, null));
+            }
+        }
+        installed.sort(Comparator.comparingInt((PlannedSource p) -> p.source.getPriority())
+                .thenComparing(p -> p.sourceId));
+        installed.addAll(missing);
+        return installed;
+    }
+
+    private BreachVerdict verdictFor(PlannedSource planned, BreachContext context,
+                                     List<AtomicBoolean> outstanding) {
+
+        long started = System.nanoTime();
+        BreachVerdict verdict = call(planned, context, outstanding);
+        metrics.record(context.getTenantDomain(), planned.sourceId, verdict.getOutcome(),
+                verdict.getCause().orElse(null), System.nanoTime() - started);
+        return verdict;
+    }
+
+    private BreachVerdict call(PlannedSource planned, BreachContext context,
+                               List<AtomicBoolean> outstanding) {
+
+        if (planned.source == null) {
+            // Policy names it; nothing is bound behind it. Treated as unavailable, never silently skipped.
+            return BreachVerdict.unavailable(planned.sourceId, UnavailableCause.SOURCE_NOT_REGISTERED,
+                    "No connector is installed for source '" + planned.sourceId + "'.");
+        }
+        try {
+            if (!planned.source.isConfigured(context.getTenantDomain())) {
+                return BreachVerdict.unavailable(planned.sourceId, UnavailableCause.MISCONFIGURED,
+                        "The source is installed but not configured.");
+            }
+        } catch (Throwable t) {
+            return contain(planned.sourceId, t);
+        }
+
+        boolean offline = planned.source.getCapabilities().contains(Capability.OFFLINE);
+        if (offline) {
+            // In-process and answering in microseconds. A thread hand-off would cost more than the lookup.
+            return invoke(planned, context);
+        }
+        // Tracked by a flag the task itself sets, not by the future's state: cancelling a future marks it
+        // done while the worker may still be reading the characters.
+        AtomicBoolean finished = new AtomicBoolean();
+        Future<BreachVerdict> future;
+        try {
+            future = executor.submit(() -> {
+                try {
+                    return invoke(planned, context);
+                } finally {
+                    finished.set(true);
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            return BreachVerdict.unavailable(planned.sourceId, UnavailableCause.INTERNAL,
+                    "Evaluation capacity is exhausted.");
+        }
+        outstanding.add(finished);
+        try {
+            BreachVerdict verdict = future.get(timeoutMs, TimeUnit.MILLISECONDS);
+            outstanding.remove(finished);
+            return verdict;
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            return BreachVerdict.unavailable(planned.sourceId, UnavailableCause.TIMEOUT,
+                    "The source did not answer within " + timeoutMs + " ms.");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            future.cancel(true);
+            return BreachVerdict.unavailable(planned.sourceId, UnavailableCause.INTERNAL,
+                    "The evaluation was interrupted.");
+        } catch (Exception e) {
+            outstanding.remove(finished);
+            return contain(planned.sourceId, e.getCause() == null ? e : e.getCause());
+        }
+    }
+
+    private BreachVerdict invoke(PlannedSource planned, BreachContext context) {
+
+        try {
+            BreachVerdict verdict = planned.source.evaluate(context);
+            if (verdict == null) {
+                return BreachVerdict.unavailable(planned.sourceId, UnavailableCause.INTERNAL,
+                        "The source returned no verdict.");
+            }
+            return verdict;
+        } catch (BreachSourceException e) {
+            return BreachVerdict.unavailable(planned.sourceId, e.getUnavailableCause(), e.getMessage());
+        } catch (Throwable t) {
+            return contain(planned.sourceId, t);
+        }
+    }
+
+    private BreachVerdict contain(String sourceId, Throwable t) {
+
+        // Contained to this source: one connector's defect must not take the others down with it.
+        LOG.error("Breach source '" + sourceId + "' failed while evaluating a password. The source is treated "
+                + "as unavailable and the remaining sources are unaffected.", t);
+        return BreachVerdict.unavailable(sourceId, UnavailableCause.INTERNAL,
+                "The source raised an unexpected error.");
+    }
+
+    private void clearWhenSafe(BreachContext context, List<AtomicBoolean> outstanding) {
+
+        for (AtomicBoolean finished : outstanding) {
+            if (!finished.get()) {
+                // A timed-out source may still be reading the characters. Leave them to the collector rather
+                // than corrupting a call in flight.
+                LOG.debug("A breach source call is still outstanding; leaving the credential to be collected.");
+                return;
+            }
+        }
+        context.getCredential().clear();
+    }
+
+    private EvaluationResult resolve(BreachContext context, BreachPolicy policy, List<BreachVerdict> verdicts,
+                                     String breachedBy) {
+
+        if (breachedBy != null) {
+            return EvaluationResult.of(Decision.REFUSE_BREACHED, EnforcementStatus.ENFORCING, verdicts,
+                    breachedBy);
+        }
+
+        int answered = 0;
+        String denyingSource = null;
+        for (BreachVerdict verdict : verdicts) {
+            if (verdict.getOutcome() == Outcome.NOT_FOUND) {
+                answered++;
+            } else if (verdict.getOutcome() == Outcome.UNAVAILABLE
+                    && policy.getFailurePolicy(verdict.getSourceId()) == FailurePolicy.DENY
+                    && denyingSource == null) {
+                denyingSource = verdict.getSourceId();
+            }
+        }
+        int unavailable = verdicts.size() - answered;
+
+        EnforcementStatus status;
+        if (unavailable == 0) {
+            status = EnforcementStatus.ENFORCING;
+        } else if (answered > 0) {
+            status = EnforcementStatus.DEGRADED;
+        } else {
+            status = EnforcementStatus.NOT_ENFORCING;
+        }
+
+        if (status == EnforcementStatus.NOT_ENFORCING) {
+            // The signal that matters most: everything looks healthy from outside while nothing is checked.
+            LOG.error("Breached password detection is not enforcing for tenant '" + context.getTenantDomain()
+                    + "': no enabled source could return a verdict. Verdicts: " + verdicts);
+        } else if (status == EnforcementStatus.DEGRADED && LOG.isWarnEnabled()) {
+            LOG.warn("Breached password detection is degraded for tenant '" + context.getTenantDomain()
+                    + "': " + unavailable + " of " + verdicts.size() + " sources could not answer.");
+        }
+
+        if (denyingSource != null) {
+            return EvaluationResult.of(Decision.REFUSE_UNVERIFIED, status, verdicts, denyingSource);
+        }
+        return EvaluationResult.of(Decision.ACCEPT, status, verdicts, null);
+    }
+
+    /**
+     * One entry in the ordered evaluation plan. A null source means policy names an id nothing has registered.
+     */
+    private static final class PlannedSource {
+
+        private final String sourceId;
+        private final BreachSource source;
+
+        private PlannedSource(String sourceId, BreachSource source) {
+
+            this.sourceId = sourceId;
+            this.source = source;
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/engine/Decision.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/engine/Decision.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.engine;
+
+/**
+ * What the engine concluded the caller should do.
+ * <p>
+ * A refusal because the password is breached and a refusal because it could not be checked are separate
+ * decisions, because the user-facing message and the operator response differ.
+ */
+public enum Decision {
+
+    /** No enabled source reported the password, or the ones that could not answer are set to allow. */
+    ACCEPT,
+
+    /** A source reported the password as breached. */
+    REFUSE_BREACHED,
+
+    /** A source could not answer and is set to refuse. */
+    REFUSE_UNVERIFIED
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/engine/EvaluationResult.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/engine/EvaluationResult.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.engine;
+
+import org.wso2.carbon.identity.breach.detection.mgt.EnforcementStatus;
+import org.wso2.carbon.identity.breach.source.BreachVerdict;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The outcome of one evaluation: what to do, what the capability was actually doing at the time, and every
+ * verdict that contributed.
+ */
+public final class EvaluationResult {
+
+    private final Decision decision;
+    private final EnforcementStatus status;
+    private final List<BreachVerdict> verdicts;
+    private final String decidingSourceId;
+
+    private EvaluationResult(Decision decision, EnforcementStatus status, List<BreachVerdict> verdicts,
+                             String decidingSourceId) {
+
+        this.decision = decision;
+        this.status = status;
+        this.verdicts = Collections.unmodifiableList(verdicts);
+        this.decidingSourceId = decidingSourceId;
+    }
+
+    static EvaluationResult of(Decision decision, EnforcementStatus status, List<BreachVerdict> verdicts,
+                               String decidingSourceId) {
+
+        return new EvaluationResult(decision, status, verdicts, decidingSourceId);
+    }
+
+    static EvaluationResult accept(EnforcementStatus status) {
+
+        return new EvaluationResult(Decision.ACCEPT, status, Collections.emptyList(), null);
+    }
+
+    public Decision getDecision() {
+
+        return decision;
+    }
+
+    public EnforcementStatus getStatus() {
+
+        return status;
+    }
+
+    public List<BreachVerdict> getVerdicts() {
+
+        return verdicts;
+    }
+
+    /**
+     * @return the source that caused a refusal, or {@code null} when the password was accepted.
+     */
+    public String getDecidingSourceId() {
+
+        return decidingSourceId;
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/engine/SourceRegistry.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/engine/SourceRegistry.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.engine;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.breach.detection.util.BreachDetectionUtils;
+import org.wso2.carbon.identity.breach.source.BreachSource;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * What is bound right now.
+ * <p>
+ * The engine holds no reference to any concrete source: it tracks whatever registers itself. Removing a
+ * connector JAR unbinds one service and changes nothing else.
+ * <p>
+ * Because the set is dynamic, the registry is worth observing in its own right - the bound ids and their
+ * declared priorities are logged on startup and on every bind and unbind, so an operator can answer "is the
+ * connector actually loaded" without inspecting a directory.
+ */
+public class SourceRegistry {
+
+    private static final Log LOG = LogFactory.getLog(SourceRegistry.class);
+
+    private final ConcurrentHashMap<String, BreachSource> sources = new ConcurrentHashMap<>();
+
+    public void bind(BreachSource source) {
+
+        if (source == null || source.getId() == null || source.getId().trim().isEmpty()) {
+            LOG.warn("Ignoring a breach source that did not declare an id.");
+            return;
+        }
+        String key = BreachDetectionUtils.normalizeSourceId(source.getId());
+        BreachSource previous = sources.put(key, source);
+        if (previous != null) {
+            LOG.warn("Breach source id '" + source.getId() + "' was already registered. The newly bound "
+                    + "service replaces it.");
+        }
+        LOG.info("Breach source bound: id=" + source.getId() + ", priority=" + source.getPriority()
+                + ", capabilities=" + source.getCapabilities() + ". Bound sources are now " + describe() + ".");
+    }
+
+    public void unbind(BreachSource source) {
+
+        if (source == null || source.getId() == null) {
+            return;
+        }
+        sources.remove(BreachDetectionUtils.normalizeSourceId(source.getId()), source);
+        LOG.info("Breach source unbound: id=" + source.getId() + ". Bound sources are now " + describe() + ".");
+    }
+
+    /**
+     * @param sourceId an id as written in policy or configuration.
+     * @return the bound source, or empty when policy names something that is not installed.
+     */
+    public Optional<BreachSource> get(String sourceId) {
+
+        return Optional.ofNullable(sources.get(BreachDetectionUtils.normalizeSourceId(sourceId)));
+    }
+
+    /**
+     * @return every bound source, ordered by declared priority ascending. Ordering is data, not code: a local
+     * in-process source declares a low number and therefore runs first without the engine knowing what it is.
+     */
+    public List<BreachSource> installed() {
+
+        List<BreachSource> ordered = new ArrayList<>(sources.values());
+        ordered.sort(Comparator.comparingInt(BreachSource::getPriority)
+                .thenComparing(BreachSource::getId));
+        return ordered;
+    }
+
+    /**
+     * @return a compact operator-facing description of the bound set.
+     */
+    public String describe() {
+
+        StringBuilder builder = new StringBuilder("[");
+        boolean first = true;
+        for (BreachSource source : installed()) {
+            if (!first) {
+                builder.append(", ");
+            }
+            builder.append(source.getId()).append('@').append(source.getPriority());
+            first = false;
+        }
+        return builder.append(']').toString();
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/internal/BreachDetectionDataHolder.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/internal/BreachDetectionDataHolder.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.internal;
+
+import org.wso2.carbon.identity.breach.detection.engine.BreachEvaluationEngine;
+import org.wso2.carbon.identity.breach.detection.engine.SourceRegistry;
+import org.wso2.carbon.identity.breach.detection.metrics.BreachMetrics;
+import org.wso2.carbon.identity.breach.detection.policy.BreachPolicyResolver;
+import org.wso2.carbon.identity.breach.detection.source.LocalBlocklistSource;
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ * Wiring, held in one place so the listener and the management service reach the same instances.
+ */
+public class BreachDetectionDataHolder {
+
+    private static final BreachDetectionDataHolder INSTANCE = new BreachDetectionDataHolder();
+
+    private final SourceRegistry sourceRegistry = new SourceRegistry();
+    private final BreachMetrics metrics = new BreachMetrics();
+
+    private IdentityGovernanceService identityGovernanceService;
+    private RealmService realmService;
+    private BreachEvaluationEngine evaluationEngine;
+    private BreachPolicyResolver policyResolver;
+    private LocalBlocklistSource localBlocklistSource;
+
+    private BreachDetectionDataHolder() {
+
+    }
+
+    public static BreachDetectionDataHolder getInstance() {
+
+        return INSTANCE;
+    }
+
+    public SourceRegistry getSourceRegistry() {
+
+        return sourceRegistry;
+    }
+
+    public BreachMetrics getMetrics() {
+
+        return metrics;
+    }
+
+    public IdentityGovernanceService getIdentityGovernanceService() {
+
+        return identityGovernanceService;
+    }
+
+    public void setIdentityGovernanceService(IdentityGovernanceService identityGovernanceService) {
+
+        this.identityGovernanceService = identityGovernanceService;
+    }
+
+    public RealmService getRealmService() {
+
+        return realmService;
+    }
+
+    public void setRealmService(RealmService realmService) {
+
+        this.realmService = realmService;
+    }
+
+    public BreachEvaluationEngine getEvaluationEngine() {
+
+        return evaluationEngine;
+    }
+
+    public void setEvaluationEngine(BreachEvaluationEngine evaluationEngine) {
+
+        this.evaluationEngine = evaluationEngine;
+    }
+
+    public BreachPolicyResolver getPolicyResolver() {
+
+        return policyResolver;
+    }
+
+    public void setPolicyResolver(BreachPolicyResolver policyResolver) {
+
+        this.policyResolver = policyResolver;
+    }
+
+    public LocalBlocklistSource getLocalBlocklistSource() {
+
+        return localBlocklistSource;
+    }
+
+    public void setLocalBlocklistSource(LocalBlocklistSource localBlocklistSource) {
+
+        this.localBlocklistSource = localBlocklistSource;
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/internal/BreachDetectionServiceComponent.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/internal/BreachDetectionServiceComponent.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.breach.detection.config.BreachDetectionConfig;
+import org.wso2.carbon.identity.breach.detection.connector.BreachDetectionConnectorConfig;
+import org.wso2.carbon.identity.breach.detection.engine.BreachEvaluationEngine;
+import org.wso2.carbon.identity.breach.detection.engine.SourceRegistry;
+import org.wso2.carbon.identity.breach.detection.listener.BreachDetectionListener;
+import org.wso2.carbon.identity.breach.detection.mgt.BreachDetectionService;
+import org.wso2.carbon.identity.breach.detection.policy.BreachPolicyResolver;
+import org.wso2.carbon.identity.breach.detection.source.LocalBlocklistSource;
+import org.wso2.carbon.identity.breach.source.BreachSource;
+import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
+import org.wso2.carbon.user.core.listener.UserOperationEventListener;
+import org.wso2.carbon.user.core.service.RealmService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Starts the capability and publishes its services.
+ * <p>
+ * The reference to {@link BreachSource} is dynamic and multiple-cardinality, which is the whole point of the
+ * core/connector split: a connector JAR dropped into {@code dropins} registers itself and is picked up with no
+ * configuration edit and no restart, and removing it unbinds one service and changes nothing else.
+ */
+@Component(
+        name = "identity.breach.detection.component",
+        immediate = true
+)
+public class BreachDetectionServiceComponent {
+
+    private static final Log LOG = LogFactory.getLog(BreachDetectionServiceComponent.class);
+
+    private final List<ServiceRegistration<?>> registrations = new ArrayList<>();
+
+    @Activate
+    protected void activate(ComponentContext context) {
+
+        BundleContext bundleContext = context.getBundleContext();
+        BreachDetectionDataHolder holder = BreachDetectionDataHolder.getInstance();
+        SourceRegistry registry = holder.getSourceRegistry();
+
+        BreachDetectionConfig config = BreachDetectionConfig.reload();
+
+        holder.setEvaluationEngine(new BreachEvaluationEngine(registry, holder.getMetrics(),
+                config.getWorkerThreads(), config.getEvaluationTimeoutMs()));
+        holder.setPolicyResolver(new BreachPolicyResolver(registry));
+
+        LocalBlocklistSource localBlocklistSource = new LocalBlocklistSource();
+        holder.setLocalBlocklistSource(localBlocklistSource);
+        SourceConfigurator.configure(localBlocklistSource);
+
+        // The in-tree offline list registers exactly like a connector. The engine has no special path for it.
+        registrations.add(bundleContext.registerService(BreachSource.class, localBlocklistSource, null));
+        registrations.add(bundleContext.registerService(IdentityConnectorConfig.class,
+                new BreachDetectionConnectorConfig(registry), null));
+        registrations.add(bundleContext.registerService(UserOperationEventListener.class,
+                new BreachDetectionListener(), null));
+        registrations.add(bundleContext.registerService(BreachDetectionService.class,
+                new BreachDetectionServiceImpl(), null));
+
+        SourceConfigurator.configureAll(registry);
+
+        LOG.info("Breached password detection started. Deployment switch: "
+                + (config.isEnabledAtDeployment() ? "on" : "off")
+                + ", listener order: " + config.getListenerOrder()
+                + ", per-source timeout: " + config.getEvaluationTimeoutMs() + " ms"
+                + ", bound sources: " + registry.describe() + ".");
+
+        List<String> orphaned = SourceConfigurator.orphanedNamespaces(registry);
+        if (!orphaned.isEmpty()) {
+            LOG.warn("Breach detection configuration names sources that are not installed: " + orphaned
+                    + ". Add the connector JARs to repository/components/dropins, or remove the configuration.");
+        }
+    }
+
+    @Deactivate
+    protected void deactivate(ComponentContext context) {
+
+        for (ServiceRegistration<?> registration : registrations) {
+            try {
+                registration.unregister();
+            } catch (Exception e) {
+                LOG.debug("Failed to unregister a breach detection service.", e);
+            }
+        }
+        registrations.clear();
+
+        BreachDetectionDataHolder holder = BreachDetectionDataHolder.getInstance();
+        if (holder.getEvaluationEngine() != null) {
+            holder.getEvaluationEngine().shutdown();
+        }
+        if (holder.getLocalBlocklistSource() != null) {
+            holder.getLocalBlocklistSource().shutdown();
+        }
+        LOG.info("Breached password detection stopped.");
+    }
+
+    @Reference(
+            name = "breach.source",
+            service = BreachSource.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetBreachSource"
+    )
+    protected void setBreachSource(BreachSource source) {
+
+        BreachDetectionDataHolder.getInstance().getSourceRegistry().bind(source);
+        SourceConfigurator.configure(source);
+    }
+
+    protected void unsetBreachSource(BreachSource source) {
+
+        BreachDetectionDataHolder.getInstance().getSourceRegistry().unbind(source);
+    }
+
+    @Reference(
+            name = "identity.governance.service",
+            service = IdentityGovernanceService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdentityGovernanceService"
+    )
+    protected void setIdentityGovernanceService(IdentityGovernanceService service) {
+
+        BreachDetectionDataHolder.getInstance().setIdentityGovernanceService(service);
+    }
+
+    protected void unsetIdentityGovernanceService(IdentityGovernanceService service) {
+
+        BreachDetectionDataHolder.getInstance().setIdentityGovernanceService(null);
+    }
+
+    @Reference(
+            name = "user.realm.service",
+            service = RealmService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRealmService"
+    )
+    protected void setRealmService(RealmService realmService) {
+
+        BreachDetectionDataHolder.getInstance().setRealmService(realmService);
+    }
+
+    protected void unsetRealmService(RealmService realmService) {
+
+        BreachDetectionDataHolder.getInstance().setRealmService(null);
+    }
+
+    /**
+     * Held so that identity.xml has been parsed before this component reads it.
+     */
+    @Reference(
+            name = "identity.core.init.event.service",
+            service = IdentityCoreInitializedEvent.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdentityCoreInitializedEventService"
+    )
+    protected void setIdentityCoreInitializedEventService(IdentityCoreInitializedEvent event) {
+
+        // Nothing to hold; the reference exists purely for start-up ordering.
+    }
+
+    protected void unsetIdentityCoreInitializedEventService(IdentityCoreInitializedEvent event) {
+
+        // Nothing to release.
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/internal/BreachDetectionServiceImpl.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/internal/BreachDetectionServiceImpl.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.internal;
+
+import org.wso2.carbon.identity.breach.detection.config.BreachDetectionConfig;
+import org.wso2.carbon.identity.breach.detection.engine.SourceRegistry;
+import org.wso2.carbon.identity.breach.detection.mgt.BreachDetectionService;
+import org.wso2.carbon.identity.breach.detection.mgt.BreachDetectionStatus;
+import org.wso2.carbon.identity.breach.detection.mgt.EnforcementStatus;
+import org.wso2.carbon.identity.breach.detection.mgt.SourceState;
+import org.wso2.carbon.identity.breach.detection.mgt.SourceView;
+import org.wso2.carbon.identity.breach.detection.policy.BreachPolicy;
+import org.wso2.carbon.identity.breach.detection.source.LocalBlocklistSource;
+import org.wso2.carbon.identity.breach.source.BreachSource;
+import org.wso2.carbon.identity.breach.source.SourceStatus;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Assembles what an administrator sees.
+ * <p>
+ * Installed and enabled are reported as separate sets, because their difference is the actionable state: a
+ * source enabled in policy with nothing bound behind it needs a deployment action, not a configuration change.
+ * Nothing here accepts a candidate password.
+ */
+public class BreachDetectionServiceImpl implements BreachDetectionService {
+
+    @Override
+    public BreachDetectionStatus getStatus(String tenantDomain) {
+
+        BreachDetectionDataHolder holder = BreachDetectionDataHolder.getInstance();
+        SourceRegistry registry = holder.getSourceRegistry();
+        BreachDetectionConfig config = BreachDetectionConfig.getInstance();
+        BreachPolicy policy = holder.getPolicyResolver() == null
+                ? BreachPolicy.disabled() : holder.getPolicyResolver().resolve(tenantDomain);
+
+        Set<String> ids = new LinkedHashSet<>();
+        for (BreachSource source : registry.installed()) {
+            ids.add(source.getId());
+        }
+        ids.addAll(policy.getSourceIds());
+
+        List<SourceView> views = new ArrayList<>(ids.size());
+        int enabledCount = 0;
+        int readyCount = 0;
+        for (String id : ids) {
+            boolean enabled = policy.getSourceIds().stream().anyMatch(id::equalsIgnoreCase);
+            SourceView view = toView(id, enabled, tenantDomain, policy);
+            views.add(view);
+            if (enabled) {
+                enabledCount++;
+                if (view.getState() == SourceState.READY) {
+                    readyCount++;
+                }
+            }
+        }
+
+        EnforcementStatus status = resolveStatus(config, policy, enabledCount, readyCount);
+        return new BreachDetectionStatus(tenantDomain, config.isEnabledAtDeployment(), policy.isEnabled(),
+                status, views, SourceConfigurator.orphanedNamespaces(registry));
+    }
+
+    @Override
+    public String reloadSources() {
+
+        BreachDetectionConfig.reload();
+        SourceRegistry registry = BreachDetectionDataHolder.getInstance().getSourceRegistry();
+        SourceConfigurator.configureAll(registry);
+        LocalBlocklistSource localList = BreachDetectionDataHolder.getInstance().getLocalBlocklistSource();
+        String listOutcome = localList == null ? "No local blocklist source is present." : localList.reload();
+        return "Reconfigured " + registry.installed().size() + " bound sources. " + listOutcome;
+    }
+
+    private EnforcementStatus resolveStatus(BreachDetectionConfig config, BreachPolicy policy, int enabledCount,
+                                            int readyCount) {
+
+        if (!config.isEnabledAtDeployment()) {
+            return EnforcementStatus.DISABLED;
+        }
+        if (!policy.isEnabled()) {
+            return EnforcementStatus.OFF;
+        }
+        if (enabledCount == 0 || readyCount == 0) {
+            // Enabled with nothing that can answer is not enforcing, and is never reported as if it were.
+            return EnforcementStatus.NOT_ENFORCING;
+        }
+        return readyCount == enabledCount ? EnforcementStatus.ENFORCING : EnforcementStatus.DEGRADED;
+    }
+
+    private SourceView toView(String id, boolean enabled, String tenantDomain, BreachPolicy policy) {
+
+        BreachDetectionDataHolder holder = BreachDetectionDataHolder.getInstance();
+        Optional<BreachSource> bound = holder.getSourceRegistry().get(id);
+        SourceView.Builder builder = SourceView.builder(id)
+                .enabled(enabled)
+                .failurePolicy(policy.getFailurePolicy(id).toConfigValue())
+                .stats(holder.getMetrics().snapshot(tenantDomain, id));
+
+        if (!bound.isPresent()) {
+            // Distinct from unreachable, because the fix is adding a connector rather than changing a setting.
+            return builder.installed(false)
+                    .state(SourceState.NOT_INSTALLED)
+                    .displayName(id)
+                    .description("Switched on in this organization's policy, but no connector with this id is "
+                            + "present on this server.")
+                    .fact("NEEDED", "connector in repository/components/dropins")
+                    .build();
+        }
+
+        BreachSource source = bound.get();
+        builder.installed(true)
+                .displayName(source.getDescriptor().getDisplayName())
+                .description(source.getDescriptor().getDescription())
+                .vendor(source.getDescriptor().getVendor().orElse(null))
+                .documentationUrl(source.getDescriptor().getDocumentationUrl().orElse(null))
+                .privacyNotice(source.getDescriptor().getPrivacyNotice().orElse(null))
+                .priority(source.getPriority())
+                .capabilities(source.getCapabilities())
+                .properties(source.getProperties());
+
+        SourceStatus status;
+        try {
+            status = source.getStatus(tenantDomain);
+        } catch (Throwable t) {
+            status = SourceStatus.builder(SourceStatus.State.UNAVAILABLE)
+                    .summary("The source failed to report its status.")
+                    .build();
+        }
+        builder.facts(status.getFacts()).summary(status.getSummary().orElse(null));
+
+        if (!enabled) {
+            return builder.state(SourceState.OFF).build();
+        }
+        switch (status.getState()) {
+            case READY:
+                return builder.state(SourceState.READY).build();
+            case NOT_CONFIGURED:
+                return builder.state(SourceState.NOT_CONFIGURED).build();
+            default:
+                return builder.state(SourceState.UNAVAILABLE).build();
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/internal/SourceConfigurator.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/internal/SourceConfigurator.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.breach.detection.config.BreachDetectionConfig;
+import org.wso2.carbon.identity.breach.detection.config.ResolvedSourceConfiguration;
+import org.wso2.carbon.identity.breach.detection.config.SourceNamespace;
+import org.wso2.carbon.identity.breach.detection.engine.SourceRegistry;
+import org.wso2.carbon.identity.breach.detection.util.BreachDetectionUtils;
+import org.wso2.carbon.identity.breach.source.BreachSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Hands each source the settings it declared, resolved from operator configuration.
+ * <p>
+ * This is the only place a source's configuration is assembled. A connector reads nothing itself and receives
+ * no filesystem or vault access of its own, which is what makes the {@code secret} flag on a property
+ * descriptor enforceable.
+ */
+public final class SourceConfigurator {
+
+    private static final Log LOG = LogFactory.getLog(SourceConfigurator.class);
+
+    private SourceConfigurator() {
+
+    }
+
+    /**
+     * @param source the source to configure.
+     */
+    public static void configure(BreachSource source) {
+
+        if (source == null) {
+            return;
+        }
+        try {
+            SourceNamespace namespace = BreachDetectionConfig.getInstance()
+                    .getSourceNamespace(BreachDetectionUtils.normalizeSourceId(source.getId()));
+            source.configure(new ResolvedSourceConfiguration(source.getId(), source.getProperties(), namespace));
+        } catch (Throwable t) {
+            // Contained: a connector that cannot be configured must not stop the others from starting.
+            LOG.error("Failed to configure breach source '" + source.getId()
+                    + "'. It will report itself as not configured.", t);
+        }
+    }
+
+    /**
+     * @param registry the registry to walk.
+     */
+    public static void configureAll(SourceRegistry registry) {
+
+        for (BreachSource source : registry.installed()) {
+            configure(source);
+        }
+    }
+
+    /**
+     * Configuration namespaces naming a source id that nothing has registered.
+     * <p>
+     * Reported rather than ignored: it usually means a connector JAR is missing, and that is a deployment
+     * action rather than a configuration one.
+     *
+     * @param registry the registry to check against.
+     * @return the orphaned namespace ids, as written in configuration.
+     */
+    public static List<String> orphanedNamespaces(SourceRegistry registry) {
+
+        List<String> orphaned = new ArrayList<>();
+        for (Map.Entry<String, SourceNamespace> entry
+                : BreachDetectionConfig.getInstance().getSourceNamespaces().entrySet()) {
+            if (!registry.get(entry.getKey()).isPresent()) {
+                orphaned.add(entry.getValue().getId());
+            }
+        }
+        return orphaned;
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/listener/BreachDetectionListener.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/listener/BreachDetectionListener.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.listener;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.breach.detection.config.BreachDetectionConfig;
+import org.wso2.carbon.identity.breach.detection.constants.BreachDetectionConstants;
+import org.wso2.carbon.identity.breach.detection.engine.BreachEvaluationEngine;
+import org.wso2.carbon.identity.breach.detection.engine.Decision;
+import org.wso2.carbon.identity.breach.detection.engine.EvaluationResult;
+import org.wso2.carbon.identity.breach.detection.internal.BreachDetectionDataHolder;
+import org.wso2.carbon.identity.breach.detection.policy.BreachPolicy;
+import org.wso2.carbon.identity.breach.detection.policy.BreachPolicyResolver;
+import org.wso2.carbon.identity.breach.detection.util.BreachDetectionUtils;
+import org.wso2.carbon.identity.breach.source.BreachContext;
+import org.wso2.carbon.identity.breach.source.Credential;
+import org.wso2.carbon.identity.breach.source.Operation;
+import org.wso2.carbon.identity.breach.source.Subject;
+import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Flow;
+import org.wso2.carbon.identity.core.context.model.Organization;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.mgt.policy.PolicyViolationException;
+import org.wso2.carbon.user.core.UserStoreClientException;
+import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.utils.Secret;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * The single interception point.
+ * <p>
+ * Every path that sets a password converges on {@code AbstractUserStoreManager}, which drives an ordered
+ * listener chain before writing to the store. Sitting in that chain gives uniform coverage for free: portals,
+ * management APIs, recovery and invitation acceptance all pass through it, and so does any path added later,
+ * including one against a secondary user store.
+ * <p>
+ * Order 420 places this after composition rules at 3 - so a password failing length or character class never
+ * reaches a breach source - and before the service extension at 10000, so in-product policy resolves before any
+ * customer extension runs.
+ */
+public class BreachDetectionListener extends AbstractIdentityUserOperationEventListener {
+
+    private static final Log LOG = LogFactory.getLog(BreachDetectionListener.class);
+
+    @Override
+    public int getExecutionOrderId() {
+
+        int order = getOrderId();
+        return order == IdentityCoreConstantsOrderPlaceholder.UNDEFINED
+                ? BreachDetectionConstants.DEFAULT_LISTENER_ORDER : order;
+    }
+
+    @Override
+    public boolean doPreAddUser(String userName, Object credential, String[] roleList,
+                                Map<String, String> claims, String profile, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        // Self-registration, administrative user creation, and invitation completion all arrive here.
+        return check(userName, null, credential, userStoreManager, Operation.REGISTER);
+    }
+
+    @Override
+    public boolean doPreUpdateCredential(String userName, Object newCredential, Object oldCredential,
+                                         UserStoreManager userStoreManager) throws UserStoreException {
+
+        return check(userName, null, newCredential, userStoreManager, Operation.SELF_UPDATE);
+    }
+
+    @Override
+    public boolean doPreUpdateCredentialWithID(String userID, Object newCredential, Object oldCredential,
+                                               UserStoreManager userStoreManager) throws UserStoreException {
+
+        return check(null, userID, newCredential, userStoreManager, Operation.SELF_UPDATE);
+    }
+
+    @Override
+    public boolean doPreUpdateCredentialByAdmin(String userName, Object newCredential,
+                                                UserStoreManager userStoreManager) throws UserStoreException {
+
+        // Administrative reset, and the reset that completes a recovery flow.
+        return check(userName, null, newCredential, userStoreManager, Operation.ADMIN_RESET);
+    }
+
+    @Override
+    public boolean doPreUpdateCredentialByAdminWithID(String userID, Object newCredential,
+                                                      UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        return check(null, userID, newCredential, userStoreManager, Operation.ADMIN_RESET);
+    }
+
+    private boolean check(String userName, String userId, Object credential, UserStoreManager userStoreManager,
+                          Operation fallbackOperation) throws UserStoreException {
+
+        if (!isEnable()) {
+            return true;
+        }
+        BreachEvaluationEngine engine = BreachDetectionDataHolder.getInstance().getEvaluationEngine();
+        BreachPolicyResolver resolver = BreachDetectionDataHolder.getInstance().getPolicyResolver();
+        if (engine == null || resolver == null) {
+            LOG.debug("Breach detection is not fully started yet. The credential write proceeds unchanged.");
+            return true;
+        }
+
+        char[] chars = extract(credential);
+        if (chars == null || chars.length == 0) {
+            // Nothing to check. Composition rules own empty and malformed input.
+            return true;
+        }
+
+        Operation operation = resolveOperation(fallbackOperation);
+        if (operation == null) {
+            // Exempted by configuration - a bulk import or migration-time write.
+            return true;
+        }
+
+        String tenantDomain = resolveTenantDomain(userStoreManager);
+        BreachPolicy policy = resolver.resolve(tenantDomain);
+        if (!policy.isEnabled()) {
+            return true;
+        }
+
+        // A copy, so clearing it after evaluation cannot corrupt the write that follows.
+        Credential candidate = new Credential(Arrays.copyOf(chars, chars.length));
+        BreachContext context = BreachContext.builder()
+                .credential(candidate)
+                .subject(Subject.builder(userName)
+                        .userId(userId)
+                        .userStoreDomain(resolveUserStoreDomain(userStoreManager))
+                        .build())
+                .tenantDomain(tenantDomain)
+                .organizationId(resolveOrganizationId())
+                .operation(operation)
+                .build();
+
+        EvaluationResult result;
+        try {
+            result = engine.evaluate(context, policy);
+        } catch (Throwable t) {
+            // A defect in our own engine is a server fault, and must not masquerade as a policy decision.
+            LOG.error("Breached password detection failed unexpectedly. The credential write is refused.", t);
+            throw new UserStoreException("An internal error occurred while checking the password.");
+        } finally {
+            if (!candidate.isCleared()) {
+                try {
+                    candidate.clear();
+                } catch (RuntimeException ignored) {
+                    // Already cleared by the engine.
+                }
+            }
+        }
+
+        if (result.getDecision() == Decision.REFUSE_BREACHED) {
+            throw policyRejection(BreachDetectionConstants.ERROR_CODE_BREACHED_PASSWORD,
+                    BreachDetectionUtils.getMessage(BreachDetectionConstants.MESSAGE_KEY_BREACHED,
+                            "This password has appeared in a known data breach. Choose a different one - even "
+                                    + "a small change to it is likely to be found too."));
+        }
+        if (result.getDecision() == Decision.REFUSE_UNVERIFIED) {
+            throw policyRejection(BreachDetectionConstants.ERROR_CODE_CANNOT_VERIFY,
+                    BreachDetectionUtils.getMessage(BreachDetectionConstants.MESSAGE_KEY_CANNOT_VERIFY,
+                            "This password could not be checked against the breached password sources right "
+                                    + "now. Try again shortly."));
+        }
+        return true;
+    }
+
+    /**
+     * A policy decision is a client error carrying its reason - never a server fault, which is
+     * indistinguishable from an outage and stops portals rendering the cause. The policy violation in the cause
+     * chain is what the recovery and self-registration paths recognise.
+     */
+    private UserStoreClientException policyRejection(String errorCode, String message) {
+
+        return new UserStoreClientException(message, errorCode, new PolicyViolationException(message));
+    }
+
+    private Operation resolveOperation(Operation fallback) {
+
+        Flow flow = currentFlow();
+        if (flow == null || flow.getName() == null) {
+            return fallback;
+        }
+        if (flow.getName() == Flow.Name.BULK_RESOURCE_UPDATE
+                && BreachDetectionConfig.getInstance().isBulkExempt()) {
+            return null;
+        }
+        boolean administrative = flow.getInitiatingPersona() == Flow.InitiatingPersona.ADMIN;
+        switch (flow.getName()) {
+            case REGISTER:
+            case JUST_IN_TIME_PROVISION:
+                return Operation.REGISTER;
+            case INVITE:
+            case INVITED_USER_REGISTRATION:
+                return Operation.INVITE;
+            case PASSWORD_RESET:
+            case CREDENTIAL_RESET:
+                return administrative ? Operation.ADMIN_RESET : Operation.RECOVERY;
+            case CREDENTIAL_UPDATE:
+            case CREDENTIAL_ENROLL:
+                return administrative ? Operation.ADMIN_RESET : Operation.SELF_UPDATE;
+            default:
+                return fallback;
+        }
+    }
+
+    private Flow currentFlow() {
+
+        try {
+            IdentityContext context = IdentityContext.getThreadLocalIdentityContext();
+            return context == null ? null : context.getFlow();
+        } catch (Throwable t) {
+            LOG.debug("No identity context is available; falling back to the listener hook for the operation.");
+            return null;
+        }
+    }
+
+    private String resolveOrganizationId() {
+
+        try {
+            IdentityContext context = IdentityContext.getThreadLocalIdentityContext();
+            Organization organization = context == null ? null : context.getOrganization();
+            return organization == null ? null : organization.getId();
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+
+    private String resolveTenantDomain(UserStoreManager userStoreManager) {
+
+        try {
+            int tenantId = userStoreManager.getTenantId();
+            String domain = IdentityTenantUtil.getTenantDomain(tenantId);
+            if (domain != null) {
+                return domain;
+            }
+        } catch (Throwable t) {
+            LOG.debug("Could not resolve the tenant from the user store manager.", t);
+        }
+        return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+    }
+
+    private String resolveUserStoreDomain(UserStoreManager userStoreManager) {
+
+        try {
+            return userStoreManager.getRealmConfiguration()
+                    .getUserStoreProperty("DomainName");
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+
+    /**
+     * The credential arrives as a {@link Secret} for listeners that handle secrets and as a character sequence
+     * otherwise. Neither is turned into a {@code String} here.
+     */
+    private char[] extract(Object credential) {
+
+        if (credential == null) {
+            return null;
+        }
+        if (credential instanceof Secret) {
+            return ((Secret) credential).getChars();
+        }
+        if (credential instanceof char[]) {
+            return (char[]) credential;
+        }
+        if (credential instanceof CharSequence) {
+            CharSequence sequence = (CharSequence) credential;
+            char[] chars = new char[sequence.length()];
+            for (int i = 0; i < sequence.length(); i++) {
+                chars[i] = sequence.charAt(i);
+            }
+            return chars;
+        }
+        LOG.debug("The credential arrived in an unrecognised form and was not evaluated.");
+        return null;
+    }
+
+    /**
+     * The sentinel {@code getOrderId} returns when identity.xml carries no declaration for this listener.
+     */
+    private static final class IdentityCoreConstantsOrderPlaceholder {
+
+        private static final int UNDEFINED = -1;
+
+        private IdentityCoreConstantsOrderPlaceholder() {
+
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/metrics/BreachMetrics.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/metrics/BreachMetrics.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.metrics;
+
+import org.wso2.carbon.identity.breach.detection.mgt.SourceStats;
+import org.wso2.carbon.identity.breach.source.Outcome;
+import org.wso2.carbon.identity.breach.source.UnavailableCause;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Counters per source and per organization: evaluations, verdicts, unavailable broken out by cause, and
+ * latency.
+ * <p>
+ * Nothing here takes a candidate password, any part of one, or its digest. Occurrence counts stay on the
+ * verdict and never reach a metric label either - a label cardinality of "every breached password" would be a
+ * password store with extra steps.
+ */
+public class BreachMetrics {
+
+    private final ConcurrentHashMap<String, Counters> counters = new ConcurrentHashMap<>();
+
+    /**
+     * Record one source's verdict.
+     *
+     * @param tenantDomain organization the evaluation ran in.
+     * @param sourceId     the reporting source.
+     * @param outcome      what it concluded.
+     * @param cause        why it could not conclude, when applicable.
+     * @param latencyNanos how long the call took.
+     */
+    public void record(String tenantDomain, String sourceId, Outcome outcome, UnavailableCause cause,
+                       long latencyNanos) {
+
+        Counters c = counters.computeIfAbsent(key(tenantDomain, sourceId), k -> new Counters());
+        c.record(outcome, cause, latencyNanos);
+    }
+
+    /**
+     * @param tenantDomain organization.
+     * @param sourceId     source.
+     * @return a snapshot, never null.
+     */
+    public SourceStats snapshot(String tenantDomain, String sourceId) {
+
+        Counters c = counters.get(key(tenantDomain, sourceId));
+        return c == null ? Counters.EMPTY.toStats() : c.toStats();
+    }
+
+    private static String key(String tenantDomain, String sourceId) {
+
+        return tenantDomain + '|' + sourceId;
+    }
+
+    /**
+     * Counters for one (organization, source) pair. Today's counters roll over on the day boundary so the
+     * administrator surface can report "checks today" without keeping a time series.
+     */
+    private static final class Counters {
+
+        private static final Counters EMPTY = new Counters();
+
+        private final AtomicLong evaluations = new AtomicLong();
+        private final AtomicLong found = new AtomicLong();
+        private final AtomicLong notFound = new AtomicLong();
+        private final AtomicLong unavailable = new AtomicLong();
+        private final AtomicLong latencyTotalNanos = new AtomicLong();
+        private final AtomicLong latencyMaxNanos = new AtomicLong();
+        private final ConcurrentHashMap<UnavailableCause, AtomicLong> byCause = new ConcurrentHashMap<>();
+
+        private final AtomicLong dayStamp = new AtomicLong(currentDay());
+        private final AtomicLong todayEvaluations = new AtomicLong();
+        private final AtomicLong todayFound = new AtomicLong();
+        private final AtomicLong todayUnavailable = new AtomicLong();
+
+        void record(Outcome outcome, UnavailableCause cause, long latencyNanos) {
+
+            rollOverIfNeeded();
+            evaluations.incrementAndGet();
+            todayEvaluations.incrementAndGet();
+            latencyTotalNanos.addAndGet(latencyNanos);
+            latencyMaxNanos.accumulateAndGet(latencyNanos, Math::max);
+            if (outcome == Outcome.FOUND) {
+                found.incrementAndGet();
+                todayFound.incrementAndGet();
+            } else if (outcome == Outcome.NOT_FOUND) {
+                notFound.incrementAndGet();
+            } else {
+                unavailable.incrementAndGet();
+                todayUnavailable.incrementAndGet();
+                byCause.computeIfAbsent(cause == null ? UnavailableCause.INTERNAL : cause,
+                        k -> new AtomicLong()).incrementAndGet();
+            }
+        }
+
+        private void rollOverIfNeeded() {
+
+            long today = currentDay();
+            long stamped = dayStamp.get();
+            if (stamped != today && dayStamp.compareAndSet(stamped, today)) {
+                todayEvaluations.set(0);
+                todayFound.set(0);
+                todayUnavailable.set(0);
+            }
+        }
+
+        SourceStats toStats() {
+
+            Map<String, Long> causes = new LinkedHashMap<>();
+            byCause.forEach((cause, count) -> causes.put(cause.name(), count.get()));
+            long total = evaluations.get();
+            long averageMs = total == 0 ? 0
+                    : TimeUnit.NANOSECONDS.toMillis(latencyTotalNanos.get() / total);
+            return new SourceStats(total, found.get(), notFound.get(), unavailable.get(), causes,
+                    todayEvaluations.get(), todayFound.get(), todayUnavailable.get(),
+                    TimeUnit.NANOSECONDS.toMillis(latencyMaxNanos.get()), averageMs);
+        }
+
+        private static long currentDay() {
+
+            return System.currentTimeMillis() / TimeUnit.DAYS.toMillis(1);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/mgt/BreachDetectionService.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/mgt/BreachDetectionService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.mgt;
+
+/**
+ * The management contract, published as an OSGi service.
+ * <p>
+ * This is what an administrator API renders from. It is the only part of the core exported to anything outside
+ * it apart from the SPI, and it deliberately exposes no way to submit a candidate password: no interface
+ * introduced by this capability accepts a password from a caller.
+ */
+public interface BreachDetectionService {
+
+    /**
+     * @param tenantDomain the organization asking.
+     * @return what the capability is doing for that organization, including installed and enabled sources.
+     */
+    BreachDetectionStatus getStatus(String tenantDomain);
+
+    /**
+     * Re-read operator configuration from identity.xml and re-hand it to every bound source. A source backed by
+     * a file rebuilds its index; a failure leaves the previously loaded data in effect.
+     *
+     * @return a human-readable summary of what was reloaded.
+     */
+    String reloadSources();
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/mgt/BreachDetectionStatus.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/mgt/BreachDetectionStatus.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.mgt;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * What the capability is doing for one organization, right now.
+ * <p>
+ * This is the object the administrator surface renders. It reports installed and enabled sources as separate
+ * facts and never claims to be enforcing when nothing can answer.
+ */
+public final class BreachDetectionStatus {
+
+    private final String tenantDomain;
+    private final boolean enabledAtDeployment;
+    private final boolean enabledForOrganization;
+    private final EnforcementStatus status;
+    private final List<SourceView> sources;
+    private final List<String> orphanedConfigurationNamespaces;
+
+    public BreachDetectionStatus(String tenantDomain, boolean enabledAtDeployment,
+                                 boolean enabledForOrganization, EnforcementStatus status,
+                                 List<SourceView> sources, List<String> orphanedConfigurationNamespaces) {
+
+        this.tenantDomain = tenantDomain;
+        this.enabledAtDeployment = enabledAtDeployment;
+        this.enabledForOrganization = enabledForOrganization;
+        this.status = status;
+        this.sources = Collections.unmodifiableList(sources);
+        this.orphanedConfigurationNamespaces = Collections.unmodifiableList(orphanedConfigurationNamespaces);
+    }
+
+    public String getTenantDomain() {
+
+        return tenantDomain;
+    }
+
+    public boolean isEnabledAtDeployment() {
+
+        return enabledAtDeployment;
+    }
+
+    public boolean isEnabledForOrganization() {
+
+        return enabledForOrganization;
+    }
+
+    public EnforcementStatus getStatus() {
+
+        return status;
+    }
+
+    /**
+     * @return every source that is either installed or named in policy, so the difference is visible.
+     */
+    public List<SourceView> getSources() {
+
+        return sources;
+    }
+
+    /**
+     * @return deployment configuration namespaces naming a source id nothing has registered. Usually a missing
+     * connector JAR.
+     */
+    public List<String> getOrphanedConfigurationNamespaces() {
+
+        return orphanedConfigurationNamespaces;
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/mgt/EnforcementStatus.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/mgt/EnforcementStatus.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.mgt;
+
+/**
+ * What an administrator is told the capability is actually doing.
+ * <p>
+ * The distinction between {@link #ENFORCING} and everything below it is the point of the whole design: an
+ * administrator must never see <em>Enforcing</em> when nothing can produce a verdict.
+ */
+public enum EnforcementStatus {
+
+    /** Switched off at deployment level. Tenant policy is retained and unchanged. */
+    DISABLED,
+
+    /** Switched off for this organization. */
+    OFF,
+
+    /** Every enabled source is answering. */
+    ENFORCING,
+
+    /** At least one enabled source cannot answer, and at least one still can. */
+    DEGRADED,
+
+    /** No enabled source can currently produce a verdict. Raised at a severity that supports alerting. */
+    NOT_ENFORCING
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/mgt/SourceState.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/mgt/SourceState.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.mgt;
+
+/**
+ * The state of one source as an administrator sees it.
+ * <p>
+ * {@link #NOT_INSTALLED} is distinct from {@link #UNAVAILABLE} because the fix is a deployment action - a
+ * missing connector JAR - rather than a configuration one.
+ */
+public enum SourceState {
+
+    /** Bound, configured, and answering. */
+    READY,
+
+    /** Bound but not set up: no file, or a required credential missing. */
+    NOT_CONFIGURED,
+
+    /** Bound and set up, but currently unable to answer. */
+    UNAVAILABLE,
+
+    /** Named in this organization's policy with no bound service behind it. */
+    NOT_INSTALLED,
+
+    /** Bound and installed, but not named in this organization's policy. */
+    OFF
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/mgt/SourceStats.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/mgt/SourceStats.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.mgt;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Counters for one source in one organization. Carries no password, no digest, and no fragment of either.
+ */
+public final class SourceStats {
+
+    private final long evaluations;
+    private final long found;
+    private final long notFound;
+    private final long unavailable;
+    private final Map<String, Long> unavailableByCause;
+    private final long todayEvaluations;
+    private final long todayFound;
+    private final long todayUnavailable;
+    private final long maxLatencyMs;
+    private final long averageLatencyMs;
+
+    public SourceStats(long evaluations, long found, long notFound, long unavailable,
+                       Map<String, Long> unavailableByCause, long todayEvaluations, long todayFound,
+                       long todayUnavailable, long maxLatencyMs, long averageLatencyMs) {
+
+        this.evaluations = evaluations;
+        this.found = found;
+        this.notFound = notFound;
+        this.unavailable = unavailable;
+        this.unavailableByCause = Collections.unmodifiableMap(new LinkedHashMap<>(unavailableByCause));
+        this.todayEvaluations = todayEvaluations;
+        this.todayFound = todayFound;
+        this.todayUnavailable = todayUnavailable;
+        this.maxLatencyMs = maxLatencyMs;
+        this.averageLatencyMs = averageLatencyMs;
+    }
+
+    public long getEvaluations() {
+
+        return evaluations;
+    }
+
+    public long getFound() {
+
+        return found;
+    }
+
+    public long getNotFound() {
+
+        return notFound;
+    }
+
+    public long getUnavailable() {
+
+        return unavailable;
+    }
+
+    /**
+     * @return unavailable counts broken out by cause, so a quota is distinguishable from a transport failure.
+     */
+    public Map<String, Long> getUnavailableByCause() {
+
+        return unavailableByCause;
+    }
+
+    public long getTodayEvaluations() {
+
+        return todayEvaluations;
+    }
+
+    public long getTodayFound() {
+
+        return todayFound;
+    }
+
+    public long getTodayUnavailable() {
+
+        return todayUnavailable;
+    }
+
+    public long getMaxLatencyMs() {
+
+        return maxLatencyMs;
+    }
+
+    public long getAverageLatencyMs() {
+
+        return averageLatencyMs;
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/mgt/SourceView.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/mgt/SourceView.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.mgt;
+
+import org.wso2.carbon.identity.breach.source.Capability;
+import org.wso2.carbon.identity.breach.source.PropertyDescriptor;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * One source as the administrator surface renders it.
+ * <p>
+ * <em>Installed</em> and <em>enabled</em> are reported separately on purpose. Their difference is the
+ * actionable state: a source enabled in policy but not installed is a deployment problem, and one installed but
+ * not enabled is simply available.
+ */
+public final class SourceView {
+
+    private final String id;
+    private final String displayName;
+    private final String description;
+    private final String vendor;
+    private final String documentationUrl;
+    private final String privacyNotice;
+    private final boolean installed;
+    private final boolean enabled;
+    private final int priority;
+    private final Set<Capability> capabilities;
+    private final SourceState state;
+    private final String summary;
+    private final Map<String, String> facts;
+    private final List<PropertyDescriptor> properties;
+    private final SourceStats stats;
+    private final String failurePolicy;
+
+    private SourceView(Builder builder) {
+
+        this.id = builder.id;
+        this.displayName = builder.displayName;
+        this.description = builder.description;
+        this.vendor = builder.vendor;
+        this.documentationUrl = builder.documentationUrl;
+        this.privacyNotice = builder.privacyNotice;
+        this.installed = builder.installed;
+        this.enabled = builder.enabled;
+        this.priority = builder.priority;
+        this.capabilities = builder.capabilities;
+        this.state = builder.state;
+        this.summary = builder.summary;
+        this.facts = Collections.unmodifiableMap(new LinkedHashMap<>(builder.facts));
+        this.properties = Collections.unmodifiableList(builder.properties);
+        this.stats = builder.stats;
+        this.failurePolicy = builder.failurePolicy;
+    }
+
+    public String getId() {
+
+        return id;
+    }
+
+    public String getDisplayName() {
+
+        return displayName;
+    }
+
+    public String getDescription() {
+
+        return description;
+    }
+
+    public Optional<String> getVendor() {
+
+        return Optional.ofNullable(vendor);
+    }
+
+    public Optional<String> getDocumentationUrl() {
+
+        return Optional.ofNullable(documentationUrl);
+    }
+
+    /**
+     * @return what this source is told about the user, rendered before it can be enabled.
+     */
+    public Optional<String> getPrivacyNotice() {
+
+        return Optional.ofNullable(privacyNotice);
+    }
+
+    /**
+     * @return whether a service is bound right now.
+     */
+    public boolean isInstalled() {
+
+        return installed;
+    }
+
+    /**
+     * @return whether this organization's policy names it.
+     */
+    public boolean isEnabled() {
+
+        return enabled;
+    }
+
+    public int getPriority() {
+
+        return priority;
+    }
+
+    public Set<Capability> getCapabilities() {
+
+        return capabilities;
+    }
+
+    public SourceState getState() {
+
+        return state;
+    }
+
+    public Optional<String> getSummary() {
+
+        return Optional.ofNullable(summary);
+    }
+
+    /**
+     * @return what the source proves about itself: entry count, format, load time, skipped lines, last success.
+     */
+    public Map<String, String> getFacts() {
+
+        return facts;
+    }
+
+    /**
+     * @return the settings the source declares. A secret renders write-only and is never returned as a value.
+     */
+    public List<PropertyDescriptor> getProperties() {
+
+        return properties;
+    }
+
+    public SourceStats getStats() {
+
+        return stats;
+    }
+
+    /**
+     * @return {@code allow} or {@code deny}: what happens when this source cannot be reached.
+     */
+    public String getFailurePolicy() {
+
+        return failurePolicy;
+    }
+
+    public static Builder builder(String id) {
+
+        return new Builder(id);
+    }
+
+    /**
+     * Builder for {@link SourceView}.
+     */
+    public static final class Builder {
+
+        private final String id;
+        private final Map<String, String> facts = new LinkedHashMap<>();
+        private String displayName;
+        private String description;
+        private String vendor;
+        private String documentationUrl;
+        private String privacyNotice;
+        private boolean installed;
+        private boolean enabled;
+        private int priority;
+        private Set<Capability> capabilities = Collections.emptySet();
+        private SourceState state = SourceState.OFF;
+        private String summary;
+        private List<PropertyDescriptor> properties = Collections.emptyList();
+        private SourceStats stats;
+        private String failurePolicy;
+
+        private Builder(String id) {
+
+            this.id = id;
+            this.displayName = id;
+        }
+
+        public Builder displayName(String displayName) {
+
+            this.displayName = displayName;
+            return this;
+        }
+
+        public Builder description(String description) {
+
+            this.description = description;
+            return this;
+        }
+
+        public Builder vendor(String vendor) {
+
+            this.vendor = vendor;
+            return this;
+        }
+
+        public Builder documentationUrl(String documentationUrl) {
+
+            this.documentationUrl = documentationUrl;
+            return this;
+        }
+
+        public Builder privacyNotice(String privacyNotice) {
+
+            this.privacyNotice = privacyNotice;
+            return this;
+        }
+
+        public Builder installed(boolean installed) {
+
+            this.installed = installed;
+            return this;
+        }
+
+        public Builder enabled(boolean enabled) {
+
+            this.enabled = enabled;
+            return this;
+        }
+
+        public Builder priority(int priority) {
+
+            this.priority = priority;
+            return this;
+        }
+
+        public Builder capabilities(Set<Capability> capabilities) {
+
+            this.capabilities = Collections.unmodifiableSet(capabilities);
+            return this;
+        }
+
+        public Builder state(SourceState state) {
+
+            this.state = state;
+            return this;
+        }
+
+        public Builder summary(String summary) {
+
+            this.summary = summary;
+            return this;
+        }
+
+        public Builder fact(String label, String value) {
+
+            if (label != null && value != null) {
+                facts.put(label, value);
+            }
+            return this;
+        }
+
+        public Builder facts(Map<String, String> values) {
+
+            if (values != null) {
+                facts.putAll(values);
+            }
+            return this;
+        }
+
+        public Builder properties(List<PropertyDescriptor> properties) {
+
+            this.properties = properties;
+            return this;
+        }
+
+        public Builder stats(SourceStats stats) {
+
+            this.stats = stats;
+            return this;
+        }
+
+        public Builder failurePolicy(String failurePolicy) {
+
+            this.failurePolicy = failurePolicy;
+            return this;
+        }
+
+        public SourceView build() {
+
+            return new SourceView(this);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/policy/BreachPolicy.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/policy/BreachPolicy.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.policy;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * One organization's effective policy: whether the capability is on, which sources it names, and what to do
+ * when one of them cannot answer.
+ */
+public final class BreachPolicy {
+
+    private static final BreachPolicy DISABLED =
+            new BreachPolicy(false, Collections.emptyList(), Collections.emptyMap());
+
+    private final boolean enabled;
+    private final List<String> sourceIds;
+    private final Map<String, FailurePolicy> failurePolicies;
+
+    public BreachPolicy(boolean enabled, List<String> sourceIds, Map<String, FailurePolicy> failurePolicies) {
+
+        this.enabled = enabled;
+        this.sourceIds = Collections.unmodifiableList(sourceIds);
+        this.failurePolicies = Collections.unmodifiableMap(new LinkedHashMap<>(failurePolicies));
+    }
+
+    /**
+     * @return the policy a tenant with no explicit configuration inherits.
+     */
+    public static BreachPolicy disabled() {
+
+        return DISABLED;
+    }
+
+    public boolean isEnabled() {
+
+        return enabled;
+    }
+
+    /**
+     * @return source ids as named in policy, in configuration order. The engine re-orders by declared priority.
+     */
+    public List<String> getSourceIds() {
+
+        return sourceIds;
+    }
+
+    /**
+     * @param sourceId source id as named in policy.
+     * @return the failure policy for that source, defaulting to allow.
+     */
+    public FailurePolicy getFailurePolicy(String sourceId) {
+
+        return failurePolicies.getOrDefault(sourceId, FailurePolicy.ALLOW);
+    }
+
+    public Map<String, FailurePolicy> getFailurePolicies() {
+
+        return failurePolicies;
+    }
+
+    @Override
+    public String toString() {
+
+        return "BreachPolicy{enabled=" + enabled + ", sources=" + sourceIds + '}';
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/policy/BreachPolicyResolver.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/policy/BreachPolicyResolver.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.policy;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.breach.detection.constants.BreachDetectionConstants;
+import org.wso2.carbon.identity.breach.detection.engine.SourceRegistry;
+import org.wso2.carbon.identity.breach.detection.internal.BreachDetectionDataHolder;
+import org.wso2.carbon.identity.breach.source.BreachSource;
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Resolves one organization's effective policy from the governance store.
+ * <p>
+ * Enabling the capability in one organization leaves every other one unchanged, an organization with no
+ * explicit configuration inherits the deployment default of disabled, and sub-organizations resolve through the
+ * governance service's existing inheritance rules rather than anything invented here.
+ */
+public class BreachPolicyResolver {
+
+    private static final Log LOG = LogFactory.getLog(BreachPolicyResolver.class);
+
+    private final SourceRegistry registry;
+
+    public BreachPolicyResolver(SourceRegistry registry) {
+
+        this.registry = registry;
+    }
+
+    /**
+     * @param tenantDomain the organization asking.
+     * @return the effective policy. Never null: an unreadable store resolves to disabled rather than to an
+     * assumption that it was on.
+     */
+    public BreachPolicy resolve(String tenantDomain) {
+
+        IdentityGovernanceService governanceService =
+                BreachDetectionDataHolder.getInstance().getIdentityGovernanceService();
+        if (governanceService == null) {
+            LOG.debug("The identity governance service is not available yet. Treating breach detection as "
+                    + "disabled for tenant " + tenantDomain + ".");
+            return BreachPolicy.disabled();
+        }
+
+        try {
+            Map<String, String> values = read(governanceService, tenantDomain, baseProperties());
+            boolean enabled = Boolean.parseBoolean(values.get(BreachDetectionConstants.PROPERTY_ENABLE));
+            List<String> sourceIds = splitSources(values.get(BreachDetectionConstants.PROPERTY_SOURCES));
+            if (!enabled) {
+                return new BreachPolicy(false, sourceIds, new LinkedHashMap<>());
+            }
+
+            List<String> missing = new ArrayList<>();
+            for (String sourceId : sourceIds) {
+                if (!values.containsKey(onErrorProperty(sourceId))) {
+                    missing.add(onErrorProperty(sourceId));
+                }
+            }
+            if (!missing.isEmpty()) {
+                // Policy can name a source that is not installed, so its failure policy is not in the first read.
+                values.putAll(read(governanceService, tenantDomain, missing));
+            }
+
+            Map<String, FailurePolicy> failurePolicies = new LinkedHashMap<>();
+            for (String sourceId : sourceIds) {
+                String configured = values.get(onErrorProperty(sourceId));
+                failurePolicies.put(sourceId, configured == null
+                        ? defaultFailurePolicy(sourceId) : FailurePolicy.from(configured));
+            }
+            return new BreachPolicy(true, sourceIds, failurePolicies);
+        } catch (Exception e) {
+            LOG.error("Could not read breached password detection policy for tenant '" + tenantDomain
+                    + "'. Treating it as disabled.", e);
+            return BreachPolicy.disabled();
+        }
+    }
+
+    /**
+     * An offline source that cannot answer means its file is broken, which an operator can fix and which
+     * carries no third-party outage risk - so it defaults to refusing. A remote source defaults to allowing,
+     * because fail-closed on a third party turns their outage into an outage of every password write here.
+     *
+     * @param sourceId the source.
+     * @return the default failure policy.
+     */
+    private FailurePolicy defaultFailurePolicy(String sourceId) {
+
+        return registry.get(sourceId)
+                .filter(source -> source.getCapabilities()
+                        .contains(org.wso2.carbon.identity.breach.source.Capability.OFFLINE))
+                .map(source -> FailurePolicy.DENY)
+                .orElse(FailurePolicy.ALLOW);
+    }
+
+    private List<String> baseProperties() {
+
+        List<String> names = new ArrayList<>();
+        names.add(BreachDetectionConstants.PROPERTY_ENABLE);
+        names.add(BreachDetectionConstants.PROPERTY_SOURCES);
+        for (BreachSource source : registry.installed()) {
+            names.add(onErrorProperty(source.getId()));
+        }
+        return names;
+    }
+
+    private Map<String, String> read(IdentityGovernanceService governanceService, String tenantDomain,
+                                     List<String> names) throws Exception {
+
+        Map<String, String> values = new LinkedHashMap<>();
+        Property[] properties = governanceService.getConfiguration(names.toArray(new String[0]), tenantDomain);
+        if (properties == null) {
+            return values;
+        }
+        for (Property property : properties) {
+            if (property != null && property.getName() != null) {
+                values.put(property.getName(), property.getValue());
+            }
+        }
+        return values;
+    }
+
+    /**
+     * @param sourceId source id.
+     * @return the governance property naming that source's failure policy.
+     */
+    public static String onErrorProperty(String sourceId) {
+
+        return BreachDetectionConstants.PROPERTY_ON_ERROR_PREFIX + sourceId
+                + BreachDetectionConstants.PROPERTY_ON_ERROR_SUFFIX;
+    }
+
+    private static List<String> splitSources(String value) {
+
+        Set<String> ids = new LinkedHashSet<>();
+        if (value != null) {
+            for (String part : value.split(",")) {
+                String trimmed = part.trim();
+                if (!trimmed.isEmpty()) {
+                    ids.add(trimmed);
+                }
+            }
+        }
+        return new ArrayList<>(ids);
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/policy/FailurePolicy.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/policy/FailurePolicy.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.policy;
+
+import org.wso2.carbon.identity.breach.detection.constants.BreachDetectionConstants;
+
+/**
+ * What to do about a source that could not answer.
+ * <p>
+ * The default is {@link #ALLOW} for remote sources, which is defensible only because the offline list keeps
+ * enforcing when they are down. Fail-closed everywhere turns a third-party outage into an outage of every
+ * password write in the deployment.
+ */
+public enum FailurePolicy {
+
+    /** Proceed, and record the gap in telemetry. */
+    ALLOW,
+
+    /** Refuse, with a message distinguishable from a breached-password rejection. */
+    DENY;
+
+    public static FailurePolicy from(String value) {
+
+        if (BreachDetectionConstants.ON_ERROR_DENY.equalsIgnoreCase(value)) {
+            return DENY;
+        }
+        return ALLOW;
+    }
+
+    public String toConfigValue() {
+
+        return this == DENY ? BreachDetectionConstants.ON_ERROR_DENY : BreachDetectionConstants.ON_ERROR_ALLOW;
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/source/BlocklistFormat.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/source/BlocklistFormat.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.source;
+
+import java.util.Locale;
+
+/**
+ * How the operator's file is written.
+ * <p>
+ * Hashed entries are canonical. Plaintext is accepted and hashed at load, so the in-memory representation is
+ * uniform and a plaintext corpus never persists in that form inside the product.
+ */
+public enum BlocklistFormat {
+
+    SHA1("SHA-1", 40),
+    SHA256("SHA-256", 64),
+    /** Hashed at load with SHA-256, so a plaintext file and a SHA-256 file index identically. */
+    PLAINTEXT("SHA-256", -1),
+    /** Decided by looking at the first usable line. */
+    AUTO(null, -1);
+
+    private final String digestAlgorithm;
+    private final int hexLength;
+
+    BlocklistFormat(String digestAlgorithm, int hexLength) {
+
+        this.digestAlgorithm = digestAlgorithm;
+        this.hexLength = hexLength;
+    }
+
+    /**
+     * @return the algorithm a candidate password is hashed with to look it up.
+     */
+    public String getDigestAlgorithm() {
+
+        return digestAlgorithm;
+    }
+
+    /**
+     * @return the expected hex digest length, or -1 when entries are not hashed in the file.
+     */
+    public int getHexLength() {
+
+        return hexLength;
+    }
+
+    public boolean isHashed() {
+
+        return this == SHA1 || this == SHA256;
+    }
+
+    public static BlocklistFormat from(String value) {
+
+        if (value == null) {
+            return AUTO;
+        }
+        switch (value.trim().toLowerCase(Locale.ROOT)) {
+            case "sha1":
+            case "sha-1":
+                return SHA1;
+            case "sha256":
+            case "sha-256":
+                return SHA256;
+            case "plaintext":
+            case "plain":
+                return PLAINTEXT;
+            default:
+                return AUTO;
+        }
+    }
+
+    /**
+     * @return the value as it appears in configuration.
+     */
+    public String toConfigValue() {
+
+        switch (this) {
+            case SHA1:
+                return "sha1";
+            case SHA256:
+                return "sha256";
+            case PLAINTEXT:
+                return "plaintext";
+            default:
+                return "auto";
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/source/BlocklistIndex.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/source/BlocklistIndex.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.source;
+
+import java.io.Closeable;
+
+/**
+ * A loaded blocklist, whichever storage regime it landed in.
+ * <p>
+ * Both regimes answer the same question; only the resident cost differs. The source has no branch on which one
+ * it is holding.
+ */
+public interface BlocklistIndex extends Closeable {
+
+    /**
+     * @param uppercaseHexDigest the candidate's digest, uppercase hex.
+     * @return whether the digest is listed.
+     */
+    boolean contains(String uppercaseHexDigest);
+
+    /**
+     * @return how many entries were indexed.
+     */
+    long size();
+
+    /**
+     * @return which regime this index is, for the administrator surface.
+     */
+    String getRegime();
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/source/BlocklistLoader.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/source/BlocklistLoader.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.source;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.text.Normalizer;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Builds a {@link BlocklistSnapshot} from the operator's file.
+ * <p>
+ * File contents are treated strictly as literal evaluation data. A line is a password or a digest, never a
+ * directive, a path, or markup - there is nothing a line can say that changes what the loader does.
+ */
+public class BlocklistLoader {
+
+    private static final Log LOG = LogFactory.getLog(BlocklistLoader.class);
+
+    private static final int DETECTION_SAMPLE_LINES = 32;
+    private static final int ESTIMATION_SAMPLE_LINES = 1000;
+
+    private BlocklistLoader() {
+
+    }
+
+    /**
+     * Read the file and build an index.
+     *
+     * @param path             the file, already confined to a permitted location by the configuration layer.
+     * @param requestedFormat  the configured format, or {@link BlocklistFormat#AUTO} to detect it.
+     * @param mmapThresholdBytes above this size a hashed file is memory-mapped rather than read into heap.
+     * @param maxHeapEntries   the in-heap ceiling, beyond which loading stops and reports truncation.
+     * @return the snapshot.
+     * @throws IOException if the file cannot be read.
+     */
+    public static BlocklistSnapshot load(Path path, BlocklistFormat requestedFormat, long mmapThresholdBytes,
+                                         int maxHeapEntries) throws IOException {
+
+        long size = Files.size(path);
+        long modified = Files.getLastModifiedTime(path).toMillis();
+        BlocklistFormat format = requestedFormat == BlocklistFormat.AUTO ? detect(path) : requestedFormat;
+
+        if (format.isHashed() && size > mmapThresholdBytes) {
+            long estimated = estimateEntries(path, size);
+            BlocklistIndex index = new MappedBlocklistIndex(path, estimated);
+            LOG.info("Loaded the breach blocklist from a " + (size / (1024 * 1024)) + " MB " + format
+                    + " file using the memory-mapped regime. The file must be sorted by digest.");
+            return new BlocklistSnapshot(index, format, estimated, true, 0, false, System.currentTimeMillis(),
+                    path.toString(), size, modified);
+        }
+
+        Set<String> digests = new HashSet<>();
+        long skipped = 0;
+        boolean truncated = false;
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(Files.newInputStream(path), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (digests.size() >= maxHeapEntries) {
+                    truncated = true;
+                    break;
+                }
+                String content = strip(line);
+                if (content == null) {
+                    continue;
+                }
+                String digest = toDigest(content, format);
+                if (digest == null) {
+                    skipped++;
+                    continue;
+                }
+                digests.add(digest);
+            }
+        }
+
+        if (truncated) {
+            LOG.error("The breach blocklist at " + path + " exceeds the maximum of " + maxHeapEntries
+                    + " in-heap entries and was loaded only up to that point. Raise the memory-map threshold "
+                    + "and supply a digest-sorted file to index it in full.");
+        }
+        if (skipped > 0) {
+            LOG.warn("Loaded the breach blocklist from " + path + " with " + skipped
+                    + " malformed or unrecognised entries ignored.");
+        }
+        LOG.info("Loaded the breach blocklist: entries=" + digests.size() + ", skipped=" + skipped
+                + ", format=" + format.toConfigValue() + ", regime=in-heap.");
+        return new BlocklistSnapshot(new HeapBlocklistIndex(digests), format, digests.size(), false, skipped,
+                truncated, System.currentTimeMillis(), path.toString(), size, modified);
+    }
+
+    /**
+     * Blank lines and comments are not entries and are not counted as skipped. Only the line ending is
+     * stripped: passwords are whitespace-significant, so nothing else is trimmed.
+     */
+    private static String strip(String line) {
+
+        String content = line;
+        if (content.endsWith("\r")) {
+            content = content.substring(0, content.length() - 1);
+        }
+        if (content.isEmpty() || content.startsWith("#")) {
+            return null;
+        }
+        return content;
+    }
+
+    private static String toDigest(String content, BlocklistFormat format) {
+
+        if (format.isHashed()) {
+            int separator = content.indexOf(':');
+            String candidate = separator < 0 ? content : content.substring(0, separator);
+            candidate = candidate.trim();
+            if (candidate.length() != format.getHexLength() || !isHex(candidate)) {
+                return null;
+            }
+            return candidate.toUpperCase(Locale.ROOT);
+        }
+        return digestOf(content, format.getDigestAlgorithm());
+    }
+
+    private static BlocklistFormat detect(Path path) throws IOException {
+
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(Files.newInputStream(path), StandardCharsets.UTF_8))) {
+            String line;
+            int inspected = 0;
+            while ((line = reader.readLine()) != null && inspected < DETECTION_SAMPLE_LINES) {
+                String content = strip(line);
+                if (content == null) {
+                    continue;
+                }
+                inspected++;
+                int separator = content.indexOf(':');
+                String candidate = (separator < 0 ? content : content.substring(0, separator)).trim();
+                if (candidate.length() == 40 && isHex(candidate)) {
+                    return BlocklistFormat.SHA1;
+                }
+                if (candidate.length() == 64 && isHex(candidate)) {
+                    return BlocklistFormat.SHA256;
+                }
+                return BlocklistFormat.PLAINTEXT;
+            }
+        }
+        return BlocklistFormat.PLAINTEXT;
+    }
+
+    private static long estimateEntries(Path path, long size) throws IOException {
+
+        long bytes = 0;
+        long lines = 0;
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(Files.newInputStream(path), StandardCharsets.UTF_8))) {
+            String line;
+            while (lines < ESTIMATION_SAMPLE_LINES && (line = reader.readLine()) != null) {
+                bytes += line.length() + 1;
+                lines++;
+            }
+        }
+        if (lines == 0 || bytes == 0) {
+            return 0;
+        }
+        return size / Math.max(1, bytes / lines);
+    }
+
+    private static boolean isHex(String value) {
+
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            boolean hex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+            if (!hex) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Hash a file entry exactly as a candidate password is hashed: Unicode NFC, UTF-8, no case folding, no
+     * trimming. Anything else would refuse credentials the operator never listed.
+     */
+    static String digestOf(String value, String algorithm) {
+
+        try {
+            String normalized = Normalizer.isNormalized(value, Normalizer.Form.NFC)
+                    ? value : Normalizer.normalize(value, Normalizer.Form.NFC);
+            MessageDigest digest = MessageDigest.getInstance(algorithm);
+            byte[] out = digest.digest(normalized.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(out.length * 2);
+            for (byte b : out) {
+                hex.append(Character.forDigit((b & 0xFF) >>> 4, 16));
+                hex.append(Character.forDigit(b & 0x0F, 16));
+            }
+            return hex.toString().toUpperCase(Locale.ROOT);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("Unsupported digest algorithm: " + algorithm, e);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/source/BlocklistSnapshot.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/source/BlocklistSnapshot.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.source;
+
+/**
+ * One consistent view of the operator's file.
+ * <p>
+ * A refresh builds a whole new snapshot before swapping the reference, so an evaluation in flight always sees
+ * one consistent view and a half-written file can never produce partial matching.
+ */
+public final class BlocklistSnapshot {
+
+    private final BlocklistIndex index;
+    private final BlocklistFormat format;
+    private final long entries;
+    private final boolean entriesEstimated;
+    private final long skipped;
+    private final boolean truncated;
+    private final long loadedAtEpochMillis;
+    private final String path;
+    private final long fileSize;
+    private final long fileModified;
+
+    BlocklistSnapshot(BlocklistIndex index, BlocklistFormat format, long entries, boolean entriesEstimated,
+                      long skipped, boolean truncated, long loadedAtEpochMillis, String path, long fileSize,
+                      long fileModified) {
+
+        this.index = index;
+        this.format = format;
+        this.entries = entries;
+        this.entriesEstimated = entriesEstimated;
+        this.skipped = skipped;
+        this.truncated = truncated;
+        this.loadedAtEpochMillis = loadedAtEpochMillis;
+        this.path = path;
+        this.fileSize = fileSize;
+        this.fileModified = fileModified;
+    }
+
+    public BlocklistIndex getIndex() {
+
+        return index;
+    }
+
+    public BlocklistFormat getFormat() {
+
+        return format;
+    }
+
+    public long getEntries() {
+
+        return entries;
+    }
+
+    /**
+     * @return whether the entry count is an estimate, which it is for the memory-mapped regime - counting the
+     * lines of a tens-of-gigabytes file at every load would defeat the point of not reading it into heap.
+     */
+    public boolean isEntriesEstimated() {
+
+        return entriesEstimated;
+    }
+
+    /**
+     * @return how many entries were malformed, blank or unrecognised. Reported on every load: an operator has
+     * to be able to tell the difference between a file that loaded and a file that mostly did not.
+     */
+    public long getSkipped() {
+
+        return skipped;
+    }
+
+    /**
+     * @return whether the file exceeded the maximum in-heap entry count and was cut short.
+     */
+    public boolean isTruncated() {
+
+        return truncated;
+    }
+
+    public long getLoadedAtEpochMillis() {
+
+        return loadedAtEpochMillis;
+    }
+
+    public String getPath() {
+
+        return path;
+    }
+
+    public long getFileSize() {
+
+        return fileSize;
+    }
+
+    public long getFileModified() {
+
+        return fileModified;
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/source/HeapBlocklistIndex.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/source/HeapBlocklistIndex.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.source;
+
+import java.util.Set;
+
+/**
+ * A curated list, held in heap.
+ * <p>
+ * Chosen when the file is at or below the memory-map threshold. Tens of thousands of entries cost little and
+ * answer in O(1); the same structure for a full offline corpus is how a feature ends up in a customer's heap
+ * dump, which is what the other regime exists to prevent.
+ */
+public class HeapBlocklistIndex implements BlocklistIndex {
+
+    private final Set<String> digests;
+
+    HeapBlocklistIndex(Set<String> digests) {
+
+        this.digests = digests;
+    }
+
+    @Override
+    public boolean contains(String uppercaseHexDigest) {
+
+        return digests.contains(uppercaseHexDigest);
+    }
+
+    @Override
+    public long size() {
+
+        return digests.size();
+    }
+
+    @Override
+    public String getRegime() {
+
+        return "in-heap hash set";
+    }
+
+    @Override
+    public void close() {
+
+        digests.clear();
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/source/LocalBlocklistSource.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/source/LocalBlocklistSource.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.source;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.breach.detection.constants.BreachDetectionConstants;
+import org.wso2.carbon.identity.breach.source.BreachContext;
+import org.wso2.carbon.identity.breach.source.BreachSource;
+import org.wso2.carbon.identity.breach.source.BreachVerdict;
+import org.wso2.carbon.identity.breach.source.Capability;
+import org.wso2.carbon.identity.breach.source.Descriptor;
+import org.wso2.carbon.identity.breach.source.PropertyDescriptor;
+import org.wso2.carbon.identity.breach.source.PropertyType;
+import org.wso2.carbon.identity.breach.source.SourceConfiguration;
+import org.wso2.carbon.identity.breach.source.SourceStatus;
+import org.wso2.carbon.identity.breach.source.UnavailableCause;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * The operator's own list of forbidden passwords, answered without touching the network.
+ * <p>
+ * The only source that ships in the core, and the only one that is not a connector. It earns that on two
+ * grounds: it crosses no boundary, so there is no third-party API to track, and it is what makes the capability
+ * work at all in a network-isolated deployment. It is also the floor that keeps enforcing when every remote
+ * source is down - which is what makes {@code allow} a defensible default failure policy rather than a shrug.
+ * <p>
+ * It registers through the same registry as any connector and gets no privileged path from the engine.
+ */
+public class LocalBlocklistSource implements BreachSource {
+
+    private static final Log LOG = LogFactory.getLog(LocalBlocklistSource.class);
+
+    public static final String PROPERTY_PATH = "path";
+    public static final String PROPERTY_FORMAT = "format";
+    public static final String PROPERTY_MMAP_THRESHOLD_MB = "mmap_threshold_mb";
+    public static final String PROPERTY_REFRESH_SECONDS = "refresh_interval_seconds";
+    public static final String PROPERTY_MAX_HEAP_ENTRIES = "max_heap_entries";
+
+    /**
+     * Measured, not guessed. A hashed file holds roughly 41 bytes per entry, so 32 MB is about 780,000
+     * entries and about 90 MB of heap. Above that the memory-mapped regime costs about 7 microseconds a
+     * lookup instead of 0.2, and no heap at all - a trade worth making long before a corpus reaches a
+     * gigabyte.
+     */
+    private static final int DEFAULT_MMAP_THRESHOLD_MB = 32;
+    private static final int DEFAULT_REFRESH_SECONDS = 300;
+    /**
+     * The documented in-heap ceiling: about 570 MB of heap at this size. Above it a digest-sorted file
+     * should be supplied so the memory-mapped regime takes over instead.
+     */
+    private static final int DEFAULT_MAX_HEAP_ENTRIES = 5_000_000;
+
+    private final AtomicReference<BlocklistSnapshot> snapshot = new AtomicReference<>();
+    private final AtomicReference<String> lastError = new AtomicReference<>();
+    private final ScheduledExecutorService scheduler;
+
+    private volatile Path path;
+    private volatile BlocklistFormat configuredFormat = BlocklistFormat.AUTO;
+    private volatile long mmapThresholdBytes = (long) DEFAULT_MMAP_THRESHOLD_MB * 1024 * 1024;
+    private volatile int maxHeapEntries = DEFAULT_MAX_HEAP_ENTRIES;
+    private volatile ScheduledFuture<?> refreshTask;
+
+    public LocalBlocklistSource() {
+
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "breach-blocklist-refresh");
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
+
+    @Override
+    public String getId() {
+
+        return BreachDetectionConstants.LOCAL_LIST_SOURCE_ID;
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+
+        return Descriptor.builder("Password list on this server")
+                .description("Checks against a list maintained by your deployment team. "
+                        + "Works without internet access.")
+                .vendor("WSO2")
+                .build();
+    }
+
+    @Override
+    public List<PropertyDescriptor> getProperties() {
+
+        return Arrays.asList(
+                PropertyDescriptor.builder(PROPERTY_PATH, PropertyType.PATH)
+                        .required(true)
+                        .displayName("Blocklist file")
+                        .description("Absolute path to the file, inside the deployment directory.")
+                        .build(),
+                PropertyDescriptor.builder(PROPERTY_FORMAT, PropertyType.STRING)
+                        .defaultValue(BlocklistFormat.AUTO.toConfigValue())
+                        .displayName("Format")
+                        .description("sha1, sha256, plaintext, or auto. Hashed is the recommended default.")
+                        .build(),
+                PropertyDescriptor.builder(PROPERTY_MMAP_THRESHOLD_MB, PropertyType.INTEGER)
+                        .defaultValue(String.valueOf(DEFAULT_MMAP_THRESHOLD_MB))
+                        .displayName("Memory-map threshold (MB)")
+                        .description("Above this size a digest-sorted file is searched in place instead of "
+                                + "being read into heap.")
+                        .build(),
+                PropertyDescriptor.builder(PROPERTY_REFRESH_SECONDS, PropertyType.INTEGER)
+                        .defaultValue(String.valueOf(DEFAULT_REFRESH_SECONDS))
+                        .displayName("Refresh interval (seconds)")
+                        .description("How often the file is checked for replacement. No restart is needed.")
+                        .build(),
+                PropertyDescriptor.builder(PROPERTY_MAX_HEAP_ENTRIES, PropertyType.INTEGER)
+                        .defaultValue(String.valueOf(DEFAULT_MAX_HEAP_ENTRIES))
+                        .displayName("Maximum in-heap entries")
+                        .build());
+    }
+
+    @Override
+    public int getPriority() {
+
+        // In-process and certain. Consulted before any network round trip, so the passwords an operator most
+        // wants blocked never leave the deployment and never consume third-party quota.
+        return 100;
+    }
+
+    @Override
+    public EnumSet<Capability> getCapabilities() {
+
+        return EnumSet.of(Capability.OFFLINE, Capability.PASSWORD_ONLY);
+    }
+
+    @Override
+    public void configure(SourceConfiguration configuration) {
+
+        BlocklistFormat format = BlocklistFormat.from(configuration.getString(PROPERTY_FORMAT).orElse(null));
+        long threshold = configuration.getLong(PROPERTY_MMAP_THRESHOLD_MB, DEFAULT_MMAP_THRESHOLD_MB)
+                * 1024 * 1024;
+        int maxEntries = configuration.getInt(PROPERTY_MAX_HEAP_ENTRIES, DEFAULT_MAX_HEAP_ENTRIES);
+        String configuredPath = configuration.getPath(PROPERTY_PATH).orElse(null);
+
+        // Configuration is handed over on bind and again on every reconfiguration, so an unchanged
+        // configuration must not rebuild an index that is already correct.
+        boolean unchanged = snapshot.get() != null
+                && format == configuredFormat
+                && threshold == mmapThresholdBytes
+                && maxEntries == maxHeapEntries
+                && path != null && path.toString().equals(configuredPath);
+
+        this.configuredFormat = format;
+        this.mmapThresholdBytes = threshold;
+        this.maxHeapEntries = maxEntries;
+        this.path = configuredPath == null ? null : Paths.get(configuredPath);
+        if (path == null) {
+            snapshot.set(null);
+            lastError.set("No blocklist file is configured.");
+            cancelRefresh();
+            return;
+        }
+        if (!unchanged) {
+            reload();
+        }
+        scheduleRefresh(configuration.getInt(PROPERTY_REFRESH_SECONDS, DEFAULT_REFRESH_SECONDS));
+    }
+
+    @Override
+    public boolean isConfigured(String tenantDomain) {
+
+        return path != null && snapshot.get() != null;
+    }
+
+    @Override
+    public SourceStatus getStatus(String tenantDomain) {
+
+        BlocklistSnapshot current = snapshot.get();
+        if (path == null) {
+            return SourceStatus.builder(SourceStatus.State.NOT_CONFIGURED)
+                    .summary("No blocklist file is configured.")
+                    .build();
+        }
+        if (current == null) {
+            return SourceStatus.builder(SourceStatus.State.UNAVAILABLE)
+                    .summary(lastError.get() == null ? "The blocklist file could not be read." : lastError.get())
+                    .fact("FILE", path.toString())
+                    .build();
+        }
+        SourceStatus.Builder builder = SourceStatus.builder(SourceStatus.State.READY)
+                .lastSuccess(current.getLoadedAtEpochMillis())
+                .fact("ENTRIES", formatEntries(current))
+                .fact("FORMAT", describeFormat(current.getFormat()))
+                .fact("LAST LOADED", formatTimestamp(current.getLoadedAtEpochMillis()))
+                .fact("SKIPPED", current.getSkipped() + " malformed lines")
+                .fact("STORAGE", current.getIndex().getRegime());
+        if (current.isTruncated()) {
+            builder.summary("The file exceeded the maximum in-heap entry count and was loaded only in part.");
+        }
+        if (lastError.get() != null) {
+            builder.fact("LAST LOAD ERROR", lastError.get());
+        }
+        return builder.build();
+    }
+
+    @Override
+    public BreachVerdict evaluate(BreachContext context) {
+
+        BlocklistSnapshot current = snapshot.get();
+        if (current == null) {
+            // Not being able to check is not the same as finding nothing, and is never reported as if it were.
+            return BreachVerdict.unavailable(getId(), UnavailableCause.MISCONFIGURED,
+                    lastError.get() == null ? "No blocklist is loaded." : lastError.get());
+        }
+        String digest = context.getCredential().digestHex(current.getFormat().getDigestAlgorithm());
+        if (current.getIndex().contains(digest)) {
+            return BreachVerdict.found(getId());
+        }
+        return BreachVerdict.notFound(getId());
+    }
+
+    /**
+     * Rebuild the index from the configured file.
+     * <p>
+     * The new index is built in full before the reference is swapped, so an evaluation in flight always sees one
+     * consistent view. A file that cannot be parsed leaves the previously loaded list in effect and reports the
+     * failure rather than quietly emptying the list.
+     *
+     * @return a human-readable summary of what happened.
+     */
+    public String reload() {
+
+        Path current = path;
+        if (current == null) {
+            return "No blocklist file is configured.";
+        }
+        if (!Files.isReadable(current)) {
+            String message = "The blocklist file is not readable.";
+            lastError.set(message);
+            LOG.error(message + " Path: " + current);
+            return message;
+        }
+        try {
+            BlocklistSnapshot loaded =
+                    BlocklistLoader.load(current, configuredFormat, mmapThresholdBytes, maxHeapEntries);
+            BlocklistSnapshot previous = snapshot.getAndSet(loaded);
+            lastError.set(null);
+            closeQuietly(previous);
+            return "Loaded " + loaded.getEntries() + " entries with " + loaded.getSkipped() + " ignored.";
+        } catch (Exception e) {
+            String message = "The blocklist file could not be parsed. The previously loaded list stays in "
+                    + "effect.";
+            lastError.set(message);
+            LOG.error(message + " Path: " + current, e);
+            return message;
+        }
+    }
+
+    /**
+     * Release the index and stop the refresh task.
+     */
+    public void shutdown() {
+
+        cancelRefresh();
+        scheduler.shutdownNow();
+        closeQuietly(snapshot.getAndSet(null));
+    }
+
+    private void scheduleRefresh(int intervalSeconds) {
+
+        cancelRefresh();
+        if (intervalSeconds <= 0) {
+            return;
+        }
+        refreshTask = scheduler.scheduleWithFixedDelay(this::refreshIfChanged, intervalSeconds,
+                intervalSeconds, TimeUnit.SECONDS);
+    }
+
+    private void cancelRefresh() {
+
+        ScheduledFuture<?> task = refreshTask;
+        if (task != null) {
+            task.cancel(false);
+            refreshTask = null;
+        }
+    }
+
+    private void refreshIfChanged() {
+
+        try {
+            BlocklistSnapshot current = snapshot.get();
+            Path file = path;
+            if (file == null || !Files.isReadable(file)) {
+                return;
+            }
+            long size = Files.size(file);
+            long modified = Files.getLastModifiedTime(file).toMillis();
+            if (current != null && current.getFileSize() == size && current.getFileModified() == modified) {
+                return;
+            }
+            LOG.info("The breach blocklist file changed. Rebuilding the index.");
+            reload();
+        } catch (Exception e) {
+            LOG.error("Failed to check the breach blocklist file for changes.", e);
+        }
+    }
+
+    private static void closeQuietly(BlocklistSnapshot value) {
+
+        if (value == null) {
+            return;
+        }
+        try {
+            value.getIndex().close();
+        } catch (IOException e) {
+            LOG.debug("Failed to release a superseded blocklist index.", e);
+        }
+    }
+
+    private static String formatEntries(BlocklistSnapshot value) {
+
+        String count = String.format(Locale.ROOT, "%,d", value.getEntries());
+        return value.isEntriesEstimated() ? count + " (estimated)" : count;
+    }
+
+    private static String describeFormat(BlocklistFormat format) {
+
+        switch (format) {
+            case SHA1:
+                return "SHA-1 hashes";
+            case SHA256:
+                return "SHA-256 hashes";
+            default:
+                return "plaintext, hashed on load";
+        }
+    }
+
+    private static String formatTimestamp(long epochMillis) {
+
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm 'UTC'", Locale.ROOT);
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return format.format(new Date(epochMillis));
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/source/MappedBlocklistIndex.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/source/MappedBlocklistIndex.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.source;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+
+/**
+ * A full offline corpus, memory-mapped and searched in place.
+ * <p>
+ * The HIBP offline download is already ordered by hash, so this regime needs no preprocessing - which is what
+ * makes an air-gapped deployment practical rather than merely possible. Heap cost is negligible and pages are
+ * faulted on demand.
+ * <p>
+ * Mapped in chunks because a single {@link MappedByteBuffer} cannot exceed {@link Integer#MAX_VALUE} bytes and
+ * these files run to tens of gigabytes.
+ */
+public class MappedBlocklistIndex implements BlocklistIndex {
+
+    private static final long CHUNK_SIZE = 1L << 30;
+    /** Beyond this many probes the search is not converging; give up rather than spin. */
+    private static final int MAX_TAIL_SCAN_LINES = 64;
+
+    private final RandomAccessFile file;
+    private final FileChannel channel;
+    private final MappedByteBuffer[] chunks;
+    private final long length;
+    private final long entries;
+
+    MappedBlocklistIndex(Path path, long entries) throws IOException {
+
+        this.file = new RandomAccessFile(path.toFile(), "r");
+        this.channel = file.getChannel();
+        this.length = channel.size();
+        this.entries = entries;
+        int chunkCount = (int) ((length + CHUNK_SIZE - 1) / CHUNK_SIZE);
+        this.chunks = new MappedByteBuffer[Math.max(1, chunkCount)];
+        for (int i = 0; i < chunkCount; i++) {
+            long offset = (long) i * CHUNK_SIZE;
+            long size = Math.min(CHUNK_SIZE, length - offset);
+            chunks[i] = channel.map(FileChannel.MapMode.READ_ONLY, offset, size);
+        }
+    }
+
+    @Override
+    public boolean contains(String uppercaseHexDigest) {
+
+        if (length == 0 || uppercaseHexDigest == null) {
+            return false;
+        }
+        long low = 0;
+        long high = length;
+        while (low < high) {
+            long mid = (low + high) >>> 1;
+            long lineStart = mid == 0 ? 0 : nextLineStart(mid, high);
+            if (lineStart >= high) {
+                return scanRange(low, high, uppercaseHexDigest);
+            }
+            String key = readKey(lineStart);
+            int comparison = key.compareTo(uppercaseHexDigest);
+            if (comparison == 0) {
+                return true;
+            }
+            if (comparison < 0) {
+                low = endOfLine(lineStart) + 1;
+            } else {
+                high = lineStart;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public long size() {
+
+        return entries;
+    }
+
+    @Override
+    public String getRegime() {
+
+        return "memory-mapped sorted hash file";
+    }
+
+    @Override
+    public void close() throws IOException {
+
+        try {
+            channel.close();
+        } finally {
+            file.close();
+        }
+    }
+
+    private boolean scanRange(long from, long to, String target) {
+
+        long position = from == 0 ? 0 : nextLineStart(from - 1, to);
+        int lines = 0;
+        while (position < to && lines++ < MAX_TAIL_SCAN_LINES) {
+            String key = readKey(position);
+            int comparison = key.compareTo(target);
+            if (comparison == 0) {
+                return true;
+            }
+            if (comparison > 0) {
+                return false;
+            }
+            position = endOfLine(position) + 1;
+        }
+        return false;
+    }
+
+    private long nextLineStart(long from, long limit) {
+
+        long position = from;
+        while (position < limit && byteAt(position) != '\n') {
+            position++;
+        }
+        return position + 1;
+    }
+
+    private long endOfLine(long from) {
+
+        long position = from;
+        while (position < length && byteAt(position) != '\n') {
+            position++;
+        }
+        return position;
+    }
+
+    private String readKey(long lineStart) {
+
+        StringBuilder builder = new StringBuilder(64);
+        long position = lineStart;
+        while (position < length) {
+            byte b = byteAt(position);
+            if (b == '\n' || b == '\r' || b == ':') {
+                break;
+            }
+            builder.append(toUpperAscii((char) (b & 0xFF)));
+            position++;
+        }
+        return builder.toString();
+    }
+
+    private byte byteAt(long position) {
+
+        int chunk = (int) (position / CHUNK_SIZE);
+        int offset = (int) (position % CHUNK_SIZE);
+        return chunks[chunk].get(offset);
+    }
+
+    private static char toUpperAscii(char c) {
+
+        return c >= 'a' && c <= 'z' ? (char) (c - 32) : c;
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/util/BreachDetectionUtils.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/java/org/wso2/carbon/identity/breach/detection/util/BreachDetectionUtils.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.util;
+
+import org.wso2.carbon.identity.breach.detection.constants.BreachDetectionConstants;
+
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+/**
+ * Small helpers shared across the core. Nothing here ever accepts a candidate password.
+ */
+public class BreachDetectionUtils {
+
+    private BreachDetectionUtils() {
+
+    }
+
+    /**
+     * Source ids are compared leniently so that a deployment.toml namespace written as {@code local_list} and a
+     * policy entry written as {@code localList} name the same source. The canonical form is what the source
+     * itself returns from {@code getId()}.
+     *
+     * @param sourceId an id as written in configuration or policy.
+     * @return a comparison key.
+     */
+    public static String normalizeSourceId(String sourceId) {
+
+        if (sourceId == null) {
+            return null;
+        }
+        return sourceId.replace("_", "").replace("-", "").toLowerCase(Locale.ROOT).trim();
+    }
+
+    /**
+     * Resolve a user-facing message. Falls back to the supplied default so a missing translation never leaves a
+     * user staring at a key.
+     *
+     * @param key            message key.
+     * @param defaultMessage message to use when the bundle has no entry.
+     * @return the message.
+     */
+    public static String getMessage(String key, String defaultMessage) {
+
+        try {
+            ResourceBundle bundle = ResourceBundle.getBundle(BreachDetectionConstants.RESOURCE_BUNDLE,
+                    Locale.getDefault(), BreachDetectionUtils.class.getClassLoader());
+            if (bundle.containsKey(key)) {
+                return bundle.getString(key);
+            }
+        } catch (MissingResourceException ignored) {
+            // The bundle is optional; the shipped default is the contract.
+        }
+        return defaultMessage;
+    }
+
+    /**
+     * @param value a configured value.
+     * @param fallback value to use when unset or unparseable.
+     * @return the parsed integer.
+     */
+    public static int parseInt(String value, int fallback) {
+
+        if (value == null || value.trim().isEmpty()) {
+            return fallback;
+        }
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    /**
+     * @param value a configured value.
+     * @param fallback value to use when unset or unparseable.
+     * @return the parsed long.
+     */
+    public static long parseLong(String value, long fallback) {
+
+        if (value == null || value.trim().isEmpty()) {
+            return fallback;
+        }
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    /**
+     * @param value a configured value.
+     * @param fallback value to use when unset.
+     * @return the parsed flag.
+     */
+    public static boolean parseBoolean(String value, boolean fallback) {
+
+        if (value == null || value.trim().isEmpty()) {
+            return fallback;
+        }
+        return Boolean.parseBoolean(value.trim());
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/main/resources/org/wso2/carbon/identity/breach/detection/i18n/Resources.properties
+++ b/components/org.wso2.carbon.identity.breach.detection/src/main/resources/org/wso2/carbon/identity/breach/detection/i18n/Resources.properties
@@ -1,0 +1,10 @@
+# User-facing messages for breached credential detection.
+#
+# These resolve through the same mechanism as the other password-policy messages, so they localize with
+# everything else. No message here contains any part of a submitted password or any source credential.
+
+breach.detection.password.breached=This password has appeared in a known data breach. Choose a different one \
+  - even a small change to it is likely to be found too.
+breach.detection.password.unverifiable=This password could not be checked against the breached password \
+  sources right now. Try again shortly.
+breach.detection.recovery.still.valid=Your reset link is still valid. You can try another password.

--- a/components/org.wso2.carbon.identity.breach.detection/src/test/java/org/wso2/carbon/identity/breach/detection/config/ResolvedSourceConfigurationTest.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/test/java/org/wso2/carbon/identity/breach/detection/config/ResolvedSourceConfigurationTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.config;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.breach.source.PropertyDescriptor;
+import org.wso2.carbon.identity.breach.source.PropertyType;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Resolving a source's declared settings, and the two disciplines that make the declaration mean something:
+ * a path cannot escape the deployment, and a value not declared secret cannot be read as one.
+ */
+public class ResolvedSourceConfigurationTest {
+
+    private static final List<PropertyDescriptor> DESCRIPTORS = Arrays.asList(
+            PropertyDescriptor.builder("path", PropertyType.PATH).required(true).build(),
+            PropertyDescriptor.builder("format", PropertyType.STRING).defaultValue("auto").build(),
+            PropertyDescriptor.builder("read_timeout_ms", PropertyType.DURATION_MS)
+                    .defaultValue("1500").build(),
+            PropertyDescriptor.builder("api_key", PropertyType.STRING).secret(true).build(),
+            PropertyDescriptor.builder("verbose", PropertyType.BOOLEAN).defaultValue("false").build());
+
+    private Path carbonHome;
+
+    @BeforeClass
+    public void setUp() throws IOException {
+
+        carbonHome = Files.createTempDirectory("carbon-home-");
+        carbonHome.toFile().deleteOnExit();
+        System.setProperty("carbon.home", carbonHome.toString());
+    }
+
+    @Test
+    public void anUnsetSettingFallsBackToTheDeclaredDefault() {
+
+        ResolvedSourceConfiguration configuration = resolve(new LinkedHashMap<>());
+        assertEquals(configuration.getString("format").orElse(null), "auto");
+        assertEquals(configuration.getInt("read_timeout_ms", 9999), 1500);
+        assertFalse(configuration.getBoolean("verbose", false));
+    }
+
+    @Test
+    public void aConfiguredValueWins() {
+
+        Map<String, String> values = new LinkedHashMap<>();
+        values.put("format", "sha1");
+        values.put("read_timeout_ms", "400");
+        assertEquals(resolve(values).getString("format").orElse(null), "sha1");
+        assertEquals(resolve(values).getInt("read_timeout_ms", 9999), 400);
+    }
+
+    @Test
+    public void anUnparseableNumberFallsBackRatherThanFailingTheSource() {
+
+        Map<String, String> values = new LinkedHashMap<>();
+        values.put("read_timeout_ms", "soon");
+        assertEquals(resolve(values).getInt("read_timeout_ms", 777), 777);
+    }
+
+    @Test
+    public void aSecretIsReadableOnlyWhereItWasDeclaredSecret() {
+
+        Map<String, String> values = new LinkedHashMap<>();
+        values.put("api_key", "s3cr3t");
+        values.put("format", "sha1");
+        ResolvedSourceConfiguration configuration = resolve(values);
+
+        assertEquals(new String(configuration.getSecret("api_key").orElse(new char[0])), "s3cr3t");
+        assertFalse(configuration.getSecret("format").isPresent(),
+                "A value not declared secret must not be reachable as one.");
+        assertFalse(configuration.getSecret("unknown").isPresent());
+    }
+
+    @Test
+    public void aPathInsideTheDeploymentResolves() {
+
+        Map<String, String> values = new LinkedHashMap<>();
+        values.put("path", "${carbon.home}/repository/resources/security/breached-passwords.txt");
+        String resolved = resolve(values).getPath("path").orElse(null);
+        assertTrue(resolved != null && resolved.startsWith(carbonHome.toString()));
+    }
+
+    @Test
+    public void aPathOutsideTheDeploymentIsRefused() {
+
+        Map<String, String> values = new LinkedHashMap<>();
+        values.put("path", "/etc/shadow");
+        assertFalse(resolve(values).getPath("path").isPresent());
+    }
+
+    @Test
+    public void aTraversalOutOfTheDeploymentIsRefused() {
+
+        Map<String, String> values = new LinkedHashMap<>();
+        values.put("path", "${carbon.home}/../../../../etc/passwd");
+        assertFalse(resolve(values).getPath("path").isPresent());
+    }
+
+    private ResolvedSourceConfiguration resolve(Map<String, String> values) {
+
+        return new ResolvedSourceConfiguration("test",
+                DESCRIPTORS, new SourceNamespace("test", values, new LinkedHashMap<>()));
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/test/java/org/wso2/carbon/identity/breach/detection/engine/BreachEvaluationEngineTest.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/test/java/org/wso2/carbon/identity/breach/detection/engine/BreachEvaluationEngineTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.engine;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.breach.detection.mgt.EnforcementStatus;
+import org.wso2.carbon.identity.breach.detection.metrics.BreachMetrics;
+import org.wso2.carbon.identity.breach.detection.policy.BreachPolicy;
+import org.wso2.carbon.identity.breach.detection.policy.FailurePolicy;
+import org.wso2.carbon.identity.breach.source.BreachContext;
+import org.wso2.carbon.identity.breach.source.BreachVerdict;
+import org.wso2.carbon.identity.breach.source.Credential;
+import org.wso2.carbon.identity.breach.source.Operation;
+import org.wso2.carbon.identity.breach.source.Subject;
+import org.wso2.carbon.identity.breach.source.UnavailableCause;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * The verdict resolution table, row by row.
+ * <p>
+ * This is the behavioural contract an administrator is shown and an operator alerts on, so every row is pinned
+ * here rather than inferred from the implementation.
+ */
+public class BreachEvaluationEngineTest {
+
+    private static final String TENANT = "carbon.super";
+
+    private SourceRegistry registry;
+    private BreachEvaluationEngine engine;
+
+    @BeforeMethod
+    public void setUp() {
+
+        registry = new SourceRegistry();
+        engine = new BreachEvaluationEngine(registry, new BreachMetrics(), 4, 500);
+    }
+
+    @Test
+    public void aDisabledPolicyEvaluatesNothing() {
+
+        StubBreachSource local = StubBreachSource.offline("localList", 100, c -> BreachVerdict.found("localList"));
+        registry.bind(local);
+        EvaluationResult result = engine.evaluate(context(), BreachPolicy.disabled());
+        assertEquals(result.getDecision(), Decision.ACCEPT);
+        assertEquals(result.getStatus(), EnforcementStatus.OFF);
+        assertEquals(local.getCalls(), 0);
+    }
+
+    @Test
+    public void enabledWithNoNamedSourceIsNotEnforcing() {
+
+        EvaluationResult result = engine.evaluate(context(), policy());
+        assertEquals(result.getDecision(), Decision.ACCEPT);
+        assertEquals(result.getStatus(), EnforcementStatus.NOT_ENFORCING);
+    }
+
+    @Test
+    public void anyFoundRefusesAsBreached() {
+
+        registry.bind(StubBreachSource.offline("localList", 100, c -> BreachVerdict.notFound("localList")));
+        registry.bind(StubBreachSource.remote("hibp", 500, c -> BreachVerdict.found("hibp", 612953)));
+        EvaluationResult result = engine.evaluate(context(), policy("localList", "hibp"));
+        assertEquals(result.getDecision(), Decision.REFUSE_BREACHED);
+        assertEquals(result.getStatus(), EnforcementStatus.ENFORCING);
+        assertEquals(result.getDecidingSourceId(), "hibp");
+    }
+
+    @Test
+    public void allNotFoundAccepts() {
+
+        registry.bind(StubBreachSource.offline("localList", 100, c -> BreachVerdict.notFound("localList")));
+        registry.bind(StubBreachSource.remote("hibp", 500, c -> BreachVerdict.notFound("hibp")));
+        EvaluationResult result = engine.evaluate(context(), policy("localList", "hibp"));
+        assertEquals(result.getDecision(), Decision.ACCEPT);
+        assertEquals(result.getStatus(), EnforcementStatus.ENFORCING);
+    }
+
+    @Test
+    public void someUnavailableWithAllowAcceptsAndReportsDegraded() {
+
+        registry.bind(StubBreachSource.offline("localList", 100, c -> BreachVerdict.notFound("localList")));
+        registry.bind(StubBreachSource.remote("hibp", 500,
+                c -> BreachVerdict.unavailable("hibp", UnavailableCause.TRANSPORT, "down")));
+        EvaluationResult result = engine.evaluate(context(),
+                policy(Arrays.asList("localList", "hibp"), failure("hibp", FailurePolicy.ALLOW)));
+        assertEquals(result.getDecision(), Decision.ACCEPT);
+        assertEquals(result.getStatus(), EnforcementStatus.DEGRADED);
+    }
+
+    @Test
+    public void someUnavailableWithDenyRefusesAsUnverified() {
+
+        registry.bind(StubBreachSource.offline("localList", 100, c -> BreachVerdict.notFound("localList")));
+        registry.bind(StubBreachSource.remote("hibp", 500,
+                c -> BreachVerdict.unavailable("hibp", UnavailableCause.TRANSPORT, "down")));
+        EvaluationResult result = engine.evaluate(context(),
+                policy(Arrays.asList("localList", "hibp"), failure("hibp", FailurePolicy.DENY)));
+        assertEquals(result.getDecision(), Decision.REFUSE_UNVERIFIED);
+        assertEquals(result.getStatus(), EnforcementStatus.DEGRADED);
+        assertEquals(result.getDecidingSourceId(), "hibp");
+    }
+
+    @Test
+    public void everySourceUnavailableWithAllowAcceptsButIsNotEnforcing() {
+
+        registry.bind(StubBreachSource.remote("hibp", 500,
+                c -> BreachVerdict.unavailable("hibp", UnavailableCause.TIMEOUT, "slow")));
+        EvaluationResult result = engine.evaluate(context(),
+                policy(Arrays.asList("hibp"), failure("hibp", FailurePolicy.ALLOW)));
+        assertEquals(result.getDecision(), Decision.ACCEPT);
+        assertEquals(result.getStatus(), EnforcementStatus.NOT_ENFORCING);
+    }
+
+    @Test
+    public void aSourceNamedInPolicyWithNothingBoundIsUnavailableNotSkipped() {
+
+        registry.bind(StubBreachSource.offline("localList", 100, c -> BreachVerdict.notFound("localList")));
+        EvaluationResult result = engine.evaluate(context(),
+                policy(Arrays.asList("localList", "spycloud"), failure("spycloud", FailurePolicy.ALLOW)));
+        assertEquals(result.getDecision(), Decision.ACCEPT);
+        assertEquals(result.getStatus(), EnforcementStatus.DEGRADED);
+        assertTrue(result.getVerdicts().stream().anyMatch(
+                v -> v.getCause().orElse(null) == UnavailableCause.SOURCE_NOT_REGISTERED));
+    }
+
+    @Test
+    public void aSourceNamedInPolicyWithNothingBoundCanRefuse() {
+
+        registry.bind(StubBreachSource.offline("localList", 100, c -> BreachVerdict.notFound("localList")));
+        EvaluationResult result = engine.evaluate(context(),
+                policy(Arrays.asList("localList", "spycloud"), failure("spycloud", FailurePolicy.DENY)));
+        assertEquals(result.getDecision(), Decision.REFUSE_UNVERIFIED);
+        assertEquals(result.getDecidingSourceId(), "spycloud");
+    }
+
+    @Test
+    public void aSourceThatIsNotSetUpIsUnavailableRatherThanClean() {
+
+        registry.bind(StubBreachSource.remote("hibp", 500, c -> BreachVerdict.notFound("hibp"))
+                .notConfigured());
+        EvaluationResult result = engine.evaluate(context(),
+                policy(Arrays.asList("hibp"), failure("hibp", FailurePolicy.DENY)));
+        assertEquals(result.getDecision(), Decision.REFUSE_UNVERIFIED);
+        assertTrue(result.getVerdicts().stream().anyMatch(
+                v -> v.getCause().orElse(null) == UnavailableCause.MISCONFIGURED));
+    }
+
+    @Test
+    public void theCheapSourceRunsFirstAndAMatchStopsTheRest() {
+
+        StubBreachSource local = StubBreachSource.offline("localList", 100,
+                c -> BreachVerdict.found("localList"));
+        StubBreachSource remote = StubBreachSource.remote("hibp", 500, c -> BreachVerdict.notFound("hibp"));
+        // Named in the expensive-first order on purpose: ordering must come from the declared priority.
+        registry.bind(remote);
+        registry.bind(local);
+        EvaluationResult result = engine.evaluate(context(), policy("hibp", "localList"));
+        assertEquals(result.getDecision(), Decision.REFUSE_BREACHED);
+        assertEquals(local.getCalls(), 1);
+        assertEquals(remote.getCalls(), 0, "A match must end the evaluation before any network call.");
+    }
+
+    @Test
+    public void anErrorInsideOneSourceIsContainedToThatSource() {
+
+        StubBreachSource broken = StubBreachSource.offline("broken", 100, c -> BreachVerdict.notFound("broken"))
+                .throwing(new IllegalStateException("connector defect"));
+        StubBreachSource healthy = StubBreachSource.offline("healthy", 200,
+                c -> BreachVerdict.found("healthy"));
+        registry.bind(broken);
+        registry.bind(healthy);
+        EvaluationResult result = engine.evaluate(context(),
+                policy(Arrays.asList("broken", "healthy"), failure("broken", FailurePolicy.ALLOW)));
+        assertEquals(result.getDecision(), Decision.REFUSE_BREACHED);
+        assertEquals(healthy.getCalls(), 1);
+    }
+
+    @Test
+    public void aRemoteSourceThatOverrunsItsBudgetIsUnavailableNotClean() {
+
+        registry.bind(StubBreachSource.remote("slow", 500, c -> BreachVerdict.notFound("slow")).slow(2000));
+        long started = System.currentTimeMillis();
+        EvaluationResult result = engine.evaluate(context(),
+                policy(Arrays.asList("slow"), failure("slow", FailurePolicy.DENY)));
+        long elapsed = System.currentTimeMillis() - started;
+        assertEquals(result.getDecision(), Decision.REFUSE_UNVERIFIED);
+        assertTrue(result.getVerdicts().get(0).getCause().orElse(null) == UnavailableCause.TIMEOUT);
+        assertTrue(elapsed < 1500, "The call must be bounded by the timeout, not by the source. Took " + elapsed);
+    }
+
+    @Test
+    public void theCredentialIsClearedOnceEverySourceHasAnswered() {
+
+        registry.bind(StubBreachSource.offline("localList", 100, c -> BreachVerdict.notFound("localList")));
+        BreachContext context = context();
+        engine.evaluate(context, policy("localList"));
+        assertTrue(context.getCredential().isCleared());
+    }
+
+    @Test
+    public void aTimedOutCallLeavesTheCredentialAloneRatherThanCorruptingIt() {
+
+        registry.bind(StubBreachSource.remote("slow", 500, c -> BreachVerdict.notFound("slow")).slow(2000));
+        BreachContext context = context();
+        engine.evaluate(context, policy("slow"));
+        // The worker may still be reading it; clearing underneath a call in flight is worse than waiting.
+        assertTrue(!context.getCredential().isCleared());
+    }
+
+    private BreachContext context() {
+
+        return BreachContext.builder()
+                .credential(new Credential("Password@1".toCharArray()))
+                .subject(Subject.builder("alice").build())
+                .tenantDomain(TENANT)
+                .operation(Operation.REGISTER)
+                .build();
+    }
+
+    private BreachPolicy policy(String... sourceIds) {
+
+        return policy(Arrays.asList(sourceIds), new LinkedHashMap<>());
+    }
+
+    private BreachPolicy policy(List<String> sourceIds, Map<String, FailurePolicy> failurePolicies) {
+
+        return new BreachPolicy(true, new ArrayList<>(sourceIds), failurePolicies);
+    }
+
+    private Map<String, FailurePolicy> failure(String sourceId, FailurePolicy policy) {
+
+        Map<String, FailurePolicy> map = new LinkedHashMap<>();
+        map.put(sourceId, policy);
+        return map;
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/test/java/org/wso2/carbon/identity/breach/detection/engine/StubBreachSource.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/test/java/org/wso2/carbon/identity/breach/detection/engine/StubBreachSource.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.engine;
+
+import org.wso2.carbon.identity.breach.source.BreachContext;
+import org.wso2.carbon.identity.breach.source.BreachSource;
+import org.wso2.carbon.identity.breach.source.BreachSourceException;
+import org.wso2.carbon.identity.breach.source.BreachVerdict;
+import org.wso2.carbon.identity.breach.source.Capability;
+import org.wso2.carbon.identity.breach.source.Descriptor;
+
+import java.util.EnumSet;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+/**
+ * A source the engine has never seen, which is the only kind it ever gets.
+ */
+class StubBreachSource implements BreachSource {
+
+    private final String id;
+    private final int priority;
+    private final EnumSet<Capability> capabilities;
+    private final Function<BreachContext, BreachVerdict> answer;
+    private final AtomicInteger calls = new AtomicInteger();
+
+    private boolean configured = true;
+    private RuntimeException failure;
+    private long delayMillis;
+
+    StubBreachSource(String id, int priority, EnumSet<Capability> capabilities,
+                     Function<BreachContext, BreachVerdict> answer) {
+
+        this.id = id;
+        this.priority = priority;
+        this.capabilities = capabilities;
+        this.answer = answer;
+    }
+
+    static StubBreachSource offline(String id, int priority, Function<BreachContext, BreachVerdict> answer) {
+
+        return new StubBreachSource(id, priority, EnumSet.of(Capability.OFFLINE, Capability.PASSWORD_ONLY),
+                answer);
+    }
+
+    static StubBreachSource remote(String id, int priority, Function<BreachContext, BreachVerdict> answer) {
+
+        return new StubBreachSource(id, priority, EnumSet.of(Capability.REMOTE, Capability.PASSWORD_ONLY),
+                answer);
+    }
+
+    StubBreachSource notConfigured() {
+
+        this.configured = false;
+        return this;
+    }
+
+    StubBreachSource throwing(RuntimeException failure) {
+
+        this.failure = failure;
+        return this;
+    }
+
+    StubBreachSource slow(long delayMillis) {
+
+        this.delayMillis = delayMillis;
+        return this;
+    }
+
+    int getCalls() {
+
+        return calls.get();
+    }
+
+    @Override
+    public String getId() {
+
+        return id;
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+
+        return Descriptor.builder(id).description(id).build();
+    }
+
+    @Override
+    public int getPriority() {
+
+        return priority;
+    }
+
+    @Override
+    public EnumSet<Capability> getCapabilities() {
+
+        return capabilities;
+    }
+
+    @Override
+    public boolean isConfigured(String tenantDomain) {
+
+        return configured;
+    }
+
+    @Override
+    public BreachVerdict evaluate(BreachContext context) throws BreachSourceException {
+
+        calls.incrementAndGet();
+        if (delayMillis > 0) {
+            // Deliberately ignores interruption: a connector that does not cooperate with cancellation is
+            // exactly the case the engine has to survive without corrupting a call in flight.
+            long until = System.currentTimeMillis() + delayMillis;
+            while (System.currentTimeMillis() < until) {
+                try {
+                    Thread.sleep(10);
+                } catch (InterruptedException ignored) {
+                    // Swallowed on purpose.
+                }
+            }
+        }
+        if (failure != null) {
+            throw failure;
+        }
+        return answer.apply(context);
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/test/java/org/wso2/carbon/identity/breach/detection/source/BlocklistLoaderTest.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/test/java/org/wso2/carbon/identity/breach/detection/source/BlocklistLoaderTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.source;
+
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.breach.source.Credential;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Loading the operator's file: the formats accepted, what counts as malformed, and the normalization that has
+ * to agree exactly with how a candidate password is hashed.
+ */
+public class BlocklistLoaderTest {
+
+    @Test
+    public void loadsAHashedSha1File() throws IOException {
+
+        Path file = write("sha1", Arrays.asList(
+                "# a comment",
+                "",
+                sha("SHA-1", "Password@1"),
+                sha("SHA-1", "Qwerty@123") + ":922923"));
+        BlocklistSnapshot snapshot = BlocklistLoader.load(file, BlocklistFormat.SHA1, Long.MAX_VALUE, 1000);
+
+        assertEquals(snapshot.getEntries(), 2);
+        assertEquals(snapshot.getSkipped(), 0, "Comments and blank lines are not entries and are not skipped.");
+        assertTrue(snapshot.getIndex().contains(digestOf("Password@1", "SHA-1")));
+        assertTrue(snapshot.getIndex().contains(digestOf("Qwerty@123", "SHA-1")),
+                "The optional occurrence-count suffix must be ignored.");
+        assertFalse(snapshot.getIndex().contains(digestOf("Zx9q!Kt7#Lm2vRb4", "SHA-1")));
+    }
+
+    @Test
+    public void loadsAHashedSha256File() throws IOException {
+
+        Path file = write("sha256", Arrays.asList(sha("SHA-256", "Password@1")));
+        BlocklistSnapshot snapshot = BlocklistLoader.load(file, BlocklistFormat.SHA256, Long.MAX_VALUE, 1000);
+        assertTrue(snapshot.getIndex().contains(digestOf("Password@1", "SHA-256")));
+    }
+
+    @Test
+    public void hashesAPlaintextFileAtLoadSoItNeverPersistsInThatFormInside() throws IOException {
+
+        Path file = write("plain", Arrays.asList("Password@1", "correct horse battery staple"));
+        BlocklistSnapshot snapshot = BlocklistLoader.load(file, BlocklistFormat.PLAINTEXT, Long.MAX_VALUE, 1000);
+
+        assertEquals(snapshot.getEntries(), 2);
+        // The candidate is hashed by the credential; the entry was hashed at load. They must agree exactly.
+        assertTrue(snapshot.getIndex().contains(
+                new Credential("correct horse battery staple".toCharArray()).digestHex("SHA-256")));
+    }
+
+    @Test
+    public void detectsTheFormatWhenTheOperatorDoesNotDeclareOne() throws IOException {
+
+        assertEquals(BlocklistLoader.load(write("d1", Arrays.asList(sha("SHA-1", "a"))),
+                BlocklistFormat.AUTO, Long.MAX_VALUE, 10).getFormat(), BlocklistFormat.SHA1);
+        assertEquals(BlocklistLoader.load(write("d2", Arrays.asList(sha("SHA-256", "a"))),
+                BlocklistFormat.AUTO, Long.MAX_VALUE, 10).getFormat(), BlocklistFormat.SHA256);
+        assertEquals(BlocklistLoader.load(write("d3", Arrays.asList("hunter2")),
+                BlocklistFormat.AUTO, Long.MAX_VALUE, 10).getFormat(), BlocklistFormat.PLAINTEXT);
+    }
+
+    @Test
+    public void malformedEntriesAreIgnoredCountedAndTheRestAreHonoured() throws IOException {
+
+        Path file = write("mixed", Arrays.asList(
+                sha("SHA-1", "Password@1"),
+                "NOTAHASH",
+                "ZZZZ61E4C9B93F3F0682250B6CF8331B7EE68FD8",
+                "5BAA61E4C9B93F3F0682250B6CF8331B7EE68",
+                sha("SHA-1", "Qwerty@123")));
+        BlocklistSnapshot snapshot = BlocklistLoader.load(file, BlocklistFormat.SHA1, Long.MAX_VALUE, 1000);
+
+        assertEquals(snapshot.getEntries(), 2);
+        assertEquals(snapshot.getSkipped(), 3);
+        assertTrue(snapshot.getIndex().contains(digestOf("Qwerty@123", "SHA-1")));
+    }
+
+    @Test
+    public void plaintextEntriesAreCaseAndWhitespaceSignificant() throws IOException {
+
+        Path file = write("ws", Arrays.asList("  Padded  ", "MixedCase"));
+        BlocklistSnapshot snapshot = BlocklistLoader.load(file, BlocklistFormat.PLAINTEXT, Long.MAX_VALUE, 100);
+
+        assertTrue(snapshot.getIndex().contains(new Credential("  Padded  ".toCharArray()).digestHex("SHA-256")));
+        assertFalse(snapshot.getIndex().contains(new Credential("Padded".toCharArray()).digestHex("SHA-256")),
+                "Trimming would refuse a credential the operator never listed.");
+        assertFalse(snapshot.getIndex().contains(new Credential("mixedcase".toCharArray()).digestHex("SHA-256")),
+                "Case folding would do the same.");
+    }
+
+    @Test
+    public void aFileBeyondTheHeapCeilingIsReportedAsTruncatedRatherThanSilentlyShortened() throws IOException {
+
+        List<String> lines = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            lines.add(sha("SHA-1", "password" + i));
+        }
+        BlocklistSnapshot snapshot =
+                BlocklistLoader.load(write("big", lines), BlocklistFormat.SHA1, Long.MAX_VALUE, 10);
+        assertTrue(snapshot.isTruncated());
+        assertEquals(snapshot.getEntries(), 10);
+    }
+
+    @Test
+    public void aLargeHashedFileIsSearchedInPlaceRatherThanReadIntoHeap() throws IOException {
+
+        List<String> digests = new ArrayList<>();
+        for (int i = 0; i < 500; i++) {
+            digests.add(sha("SHA-1", "entry" + i));
+        }
+        digests.sort(String::compareTo);
+        Path file = write("mapped", digests);
+
+        // A threshold of zero forces the memory-mapped regime regardless of the file's actual size.
+        BlocklistSnapshot snapshot = BlocklistLoader.load(file, BlocklistFormat.SHA1, 0, 1000);
+        assertEquals(snapshot.getIndex().getRegime(), "memory-mapped sorted hash file");
+        assertTrue(snapshot.isEntriesEstimated());
+
+        assertTrue(snapshot.getIndex().contains(digests.get(0)), "first entry");
+        assertTrue(snapshot.getIndex().contains(digests.get(250)), "middle entry");
+        assertTrue(snapshot.getIndex().contains(digests.get(digests.size() - 1)), "last entry");
+        assertFalse(snapshot.getIndex().contains(digestOf("absent-from-the-corpus", "SHA-1")));
+        assertFalse(snapshot.getIndex().contains("0000000000000000000000000000000000000000"),
+                "a key ordered before every entry");
+        assertFalse(snapshot.getIndex().contains("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"),
+                "a key ordered after every entry");
+        snapshot.getIndex().close();
+    }
+
+    @Test
+    public void aLowercaseSortedCorpusStillMatches() throws IOException {
+
+        List<String> digests = new ArrayList<>();
+        for (int i = 0; i < 200; i++) {
+            digests.add(sha("SHA-1", "lower" + i).toLowerCase(Locale.ROOT));
+        }
+        digests.sort(String::compareTo);
+        BlocklistSnapshot snapshot =
+                BlocklistLoader.load(write("lower", digests), BlocklistFormat.SHA1, 0, 1000);
+        assertTrue(snapshot.getIndex().contains(digestOf("lower42", "SHA-1")));
+        snapshot.getIndex().close();
+    }
+
+    private static String digestOf(String password, String algorithm) {
+
+        return new Credential(password.toCharArray()).digestHex(algorithm);
+    }
+
+    private static Path write(String name, List<String> lines) throws IOException {
+
+        Path file = Files.createTempFile("blocklist-" + name + "-", ".txt");
+        file.toFile().deleteOnExit();
+        Files.write(file, String.join("\n", lines).concat("\n").getBytes(StandardCharsets.UTF_8));
+        return file;
+    }
+
+    private static String sha(String algorithm, String value) {
+
+        try {
+            byte[] out = MessageDigest.getInstance(algorithm).digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder();
+            for (byte b : out) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString().toUpperCase(Locale.ROOT);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/test/java/org/wso2/carbon/identity/breach/detection/source/LocalBlocklistSourceTest.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/test/java/org/wso2/carbon/identity/breach/detection/source/LocalBlocklistSourceTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.source;
+
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.breach.source.BreachContext;
+import org.wso2.carbon.identity.breach.source.Capability;
+import org.wso2.carbon.identity.breach.source.Credential;
+import org.wso2.carbon.identity.breach.source.Operation;
+import org.wso2.carbon.identity.breach.source.Outcome;
+import org.wso2.carbon.identity.breach.source.SourceStatus;
+import org.wso2.carbon.identity.breach.source.UnavailableCause;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * The offline source as the engine and the administrator surface see it.
+ */
+public class LocalBlocklistSourceTest {
+
+    private static final String TENANT = "carbon.super";
+
+    @Test
+    public void declaresItselfAsOfflineAndCheapSoTheEngineConsultsItFirst() {
+
+        LocalBlocklistSource source = new LocalBlocklistSource();
+        assertTrue(source.getCapabilities().contains(Capability.OFFLINE));
+        assertTrue(source.getPriority() < 500);
+        source.shutdown();
+    }
+
+    @Test
+    public void refusesAListedPasswordAndAcceptsAnUnlistedOne() throws IOException {
+
+        Path file = write(Arrays.asList("Password@1", "Qwerty@123"));
+        LocalBlocklistSource source = configured(file, "plaintext");
+
+        assertEquals(source.evaluate(context("Password@1")).getOutcome(), Outcome.FOUND);
+        assertEquals(source.evaluate(context("Zx9q!Kt7#Lm2vRb4")).getOutcome(), Outcome.NOT_FOUND);
+        source.shutdown();
+    }
+
+    @Test
+    public void withNoFileConfiguredItIsUnavailableRatherThanReportingEveryPasswordClean() {
+
+        LocalBlocklistSource source = new LocalBlocklistSource();
+        source.configure(new MapSourceConfiguration());
+
+        assertFalse(source.isConfigured(TENANT));
+        assertEquals(source.evaluate(context("Password@1")).getOutcome(), Outcome.UNAVAILABLE);
+        assertEquals(source.evaluate(context("Password@1")).getCause().orElse(null),
+                UnavailableCause.MISCONFIGURED);
+        assertEquals(source.getStatus(TENANT).getState(), SourceStatus.State.NOT_CONFIGURED);
+        source.shutdown();
+    }
+
+    @Test
+    public void itProvesItLoadedRatherThanAssertingIt() throws IOException {
+
+        Path file = write(Arrays.asList("Password@1", "NOTAHASH-but-a-valid-plaintext-entry"));
+        LocalBlocklistSource source = configured(file, "plaintext");
+
+        SourceStatus status = source.getStatus(TENANT);
+        assertEquals(status.getState(), SourceStatus.State.READY);
+        assertEquals(status.getFacts().get("ENTRIES"), "2");
+        assertEquals(status.getFacts().get("SKIPPED"), "0 malformed lines");
+        assertTrue(status.getFacts().containsKey("LAST LOADED"));
+        assertTrue(status.getLastSuccessEpochMillis().isPresent());
+        source.shutdown();
+    }
+
+    @Test
+    public void aReplacedFileTakesEffectWithoutARestart() throws IOException {
+
+        Path file = write(Arrays.asList("Password@1"));
+        LocalBlocklistSource source = configured(file, "plaintext");
+        assertEquals(source.evaluate(context("Summer2023!")).getOutcome(), Outcome.NOT_FOUND);
+
+        Files.write(file, "Password@1\nSummer2023!\n".getBytes(StandardCharsets.UTF_8));
+        source.reload();
+
+        assertEquals(source.evaluate(context("Summer2023!")).getOutcome(), Outcome.FOUND);
+        source.shutdown();
+    }
+
+    @Test
+    public void aFileThatCannotBeReadLeavesThePreviouslyLoadedListInEffect() throws IOException {
+
+        Path file = write(Arrays.asList("Password@1"));
+        LocalBlocklistSource source = configured(file, "plaintext");
+        assertEquals(source.evaluate(context("Password@1")).getOutcome(), Outcome.FOUND);
+
+        Files.delete(file);
+        String outcome = source.reload();
+
+        assertTrue(outcome.toLowerCase().contains("not readable"));
+        assertEquals(source.evaluate(context("Password@1")).getOutcome(), Outcome.FOUND,
+                "The previous list must stay in effect rather than emptying itself.");
+        source.shutdown();
+    }
+
+    @Test
+    public void reconfiguringWithTheSameSettingsDoesNotRebuildTheIndex() throws IOException {
+
+        Path file = write(Arrays.asList("Password@1"));
+        LocalBlocklistSource source = configured(file, "plaintext");
+        Long firstLoad = source.getStatus(TENANT).getLastSuccessEpochMillis().orElse(0L);
+
+        source.configure(new MapSourceConfiguration()
+                .set(LocalBlocklistSource.PROPERTY_PATH, file.toString())
+                .set(LocalBlocklistSource.PROPERTY_FORMAT, "plaintext")
+                .set(LocalBlocklistSource.PROPERTY_REFRESH_SECONDS, 0));
+
+        assertEquals(source.getStatus(TENANT).getLastSuccessEpochMillis().orElse(0L), (Long) firstLoad);
+        source.shutdown();
+    }
+
+    private LocalBlocklistSource configured(Path file, String format) {
+
+        LocalBlocklistSource source = new LocalBlocklistSource();
+        source.configure(new MapSourceConfiguration()
+                .set(LocalBlocklistSource.PROPERTY_PATH, file.toString())
+                .set(LocalBlocklistSource.PROPERTY_FORMAT, format)
+                .set(LocalBlocklistSource.PROPERTY_REFRESH_SECONDS, 0));
+        return source;
+    }
+
+    private BreachContext context(String password) {
+
+        return BreachContext.builder()
+                .credential(new Credential(password.toCharArray()))
+                .tenantDomain(TENANT)
+                .operation(Operation.REGISTER)
+                .build();
+    }
+
+    private static Path write(List<String> lines) throws IOException {
+
+        Path file = Files.createTempFile("local-blocklist-", ".txt");
+        file.toFile().deleteOnExit();
+        Files.write(file, String.join("\n", lines).concat("\n").getBytes(StandardCharsets.UTF_8));
+        return file;
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/test/java/org/wso2/carbon/identity/breach/detection/source/MapSourceConfiguration.java
+++ b/components/org.wso2.carbon.identity.breach.detection/src/test/java/org/wso2/carbon/identity/breach/detection/source/MapSourceConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.breach.detection.source;
+
+import org.wso2.carbon.identity.breach.source.SourceConfiguration;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * The settings a source would have been handed, without the deployment configuration layer in the way.
+ */
+class MapSourceConfiguration implements SourceConfiguration {
+
+    private final Map<String, String> values = new HashMap<>();
+
+    MapSourceConfiguration set(String name, Object value) {
+
+        values.put(name, value == null ? null : String.valueOf(value));
+        return this;
+    }
+
+    @Override
+    public Optional<String> getString(String name) {
+
+        return Optional.ofNullable(values.get(name));
+    }
+
+    @Override
+    public int getInt(String name, int defaultValue) {
+
+        return getString(name).map(Integer::parseInt).orElse(defaultValue);
+    }
+
+    @Override
+    public long getLong(String name, long defaultValue) {
+
+        return getString(name).map(Long::parseLong).orElse(defaultValue);
+    }
+
+    @Override
+    public boolean getBoolean(String name, boolean defaultValue) {
+
+        return getString(name).map(Boolean::parseBoolean).orElse(defaultValue);
+    }
+
+    @Override
+    public Optional<char[]> getSecret(String name) {
+
+        return getString(name).map(String::toCharArray);
+    }
+
+    @Override
+    public Optional<String> getPath(String name) {
+
+        return getString(name);
+    }
+}

--- a/components/org.wso2.carbon.identity.breach.detection/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.breach.detection/src/test/resources/testng.xml
@@ -1,0 +1,10 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="breach-detection">
+    <test name="breach-detection-tests">
+        <packages>
+            <package name="org.wso2.carbon.identity.breach.detection.engine"/>
+            <package name="org.wso2.carbon.identity.breach.detection.source"/>
+            <package name="org.wso2.carbon.identity.breach.detection.config"/>
+        </packages>
+    </test>
+</suite>

--- a/features/org.wso2.carbon.identity.breach.detection.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.breach.detection.server.feature/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.governance</groupId>
+        <artifactId>identity-governance</artifactId>
+        <relativePath>../../pom.xml</relativePath>
+        <version>1.16.36-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.breach.detection.server.feature</artifactId>
+    <packaging>pom</packaging>
+    <name>WSO2 Carbon - Breached Credential Detection Feature</name>
+    <url>http://wso2.org</url>
+    <description>This feature contains the bundles required for breached credential detection</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.breach.detection.api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.breach.detection</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>carbon-p2-plugin</artifactId>
+                <version>${carbon.p2.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>p2-feature-generation</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>p2-feature-gen</goal>
+                        </goals>
+                        <configuration>
+                            <id>org.wso2.carbon.identity.breach.detection.server</id>
+                            <propertiesFile>../../etc/feature.properties</propertiesFile>
+                            <adviceFile>
+                                <properties>
+                                    <propertyDef>org.wso2.carbon.p2.category.type:server</propertyDef>
+                                </properties>
+                            </adviceFile>
+                            <bundles>
+                                <bundleDef>org.wso2.carbon.identity.governance:org.wso2.carbon.identity.breach.detection.api</bundleDef>
+                                <bundleDef>org.wso2.carbon.identity.governance:org.wso2.carbon.identity.breach.detection</bundleDef>
+                            </bundles>
+                            <importFeatures>
+                            </importFeatures>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,8 @@
         <module>components/org.wso2.carbon.identity.password.expiry</module>
         <module>components/org.wso2.carbon.identity.idle.account.identification</module>
         <module>components/org.wso2.carbon.identity.user.onboard.core.service</module>
+        <module>components/org.wso2.carbon.identity.breach.detection.api</module>
+        <module>components/org.wso2.carbon.identity.breach.detection</module>
 
         <module>features/org.wso2.carbon.identity.recovery.server.feature</module>
         <module>features/org.wso2.carbon.identity.user.server.feature</module>
@@ -78,6 +80,7 @@
         <module>features/org.wso2.carbon.identity.auth.attribute.handler.server.feature</module>
         <module>features/org.wso2.carbon.identity.password.expiry.server.feature</module>
         <module>features/org.wso2.carbon.identity.user.onboard.core.service.feature</module>
+        <module>features/org.wso2.carbon.identity.breach.detection.server.feature</module>
     </modules>
 
     <dependencyManagement>
@@ -328,7 +331,17 @@
                 <artifactId>org.wso2.carbon.identity.governance.stub</artifactId>
                 <version>${project.version}</version>
             </dependency>
+    
             <dependency>
+                <groupId>org.wso2.carbon.identity.governance</groupId>
+                <artifactId>org.wso2.carbon.identity.breach.detection.api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.governance</groupId>
+                <artifactId>org.wso2.carbon.identity.breach.detection</artifactId>
+                <version>${project.version}</version>
+            </dependency>        <dependency>
                 <groupId>org.wso2.carbon.identity.governance</groupId>
                 <artifactId>org.wso2.carbon.identity.governance</artifactId>
                 <version>${project.version}</version>
@@ -696,6 +709,16 @@
         <!--Carbon Identity Governance Version-->
         <identity.governance.exp.pkg.version>${project.version}</identity.governance.exp.pkg.version>
         <identity.governance.imp.pkg.version.range>[1.3.0, 2.0.0)</identity.governance.imp.pkg.version.range>
+
+        <!--
+          The breach source SPI is versioned on the contract's own compatibility rather than on this
+          repository's release number, so a connector built outside this repository keeps resolving across
+          releases that do not change the contract.
+        -->
+        <breach.spi.package.version>1.0.0</breach.spi.package.version>
+        <breach.spi.imp.pkg.version.range>[1.0.0, 2.0.0)</breach.spi.imp.pkg.version.range>
+        <axiom.osgi.version.range>[1.2.11, 2.0.0)</axiom.osgi.version.range>
+        <securevault.version.range>[1.0.0, 2.0.0)</securevault.version.range>
 
         <equinox.javax.servlet.version>3.0.0.v201112011016</equinox.javax.servlet.version>
 


### PR DESCRIPTION
## Purpose

Identity Server cannot currently refuse a password that is already circulating in a credential breach. The
Password Policies category offers history and expiry, and composition is governed separately by input
validation — none of them can recognise a password as previously exposed. On an unmodified distribution,
`Password@1` (612,953 breach records) is accepted by every password-setting path, including administrative
user creation.

This adds the enforcement and the source model behind it. It ships **off by default**: upgrading with no
configuration change produces password-setting behaviour identical to before.

## What this adds

| Module | Contains |
|---|---|
| `org.wso2.carbon.identity.breach.detection.api` | The `BreachSource` SPI — the contract a source implements. |
| `org.wso2.carbon.identity.breach.detection` | Listener, policy resolver, evaluation engine, the offline blocklist source, the governance connector, telemetry, and the management service. |
| `org.wso2.carbon.identity.breach.detection.server.feature` | p2 feature packaging both bundles. |

## Design notes for review

**Enforcement is a user-operation listener at order 420.** Every password-setting path converges on
`AbstractUserStoreManager`'s listener chain, so one interception point covers portals, management APIs,
recovery and invitation acceptance, and any path added later. 420 sits after input validation at 3 — so a
password failing composition never reaches a breach source — and before the service extension at 10000, so
in-product policy resolves before any customer extension runs.

This deliberately does **not** go in `input.validation.mgt`. A `ValidationContext` carries no subject identity
and no indication of which operation is running, which is sufficient for a password-only corpus and
structurally insufficient for credential-pair intelligence. `BreachContext` carries both, so a source keyed on
the identity as well as the secret can be added later without redesign.

**A verdict is tri-state.** `UNAVAILABLE` is not `NOT_FOUND`. A source that times out, exhausts a quota, fails
to parse, is not configured, or is named in policy with nothing bound behind it returns `UNAVAILABLE` with a
cause, and the per-source failure policy decides what that means. Collapsing the two is how a breach check
silently stops enforcing while still reporting itself as enabled.

**The SPI's exported package version is `1.0.0`, not `${identity.governance.exp.pkg.version}`.** This is the
one place the PR departs from the repository convention, and it is intentional. Connectors are built outside
this repository and compile against that package. Versioning it on this repository's release number would
invalidate every connector in the field on a release that never touched the contract — which is exactly how
the existing `identity-password-validator-hibp` extension came to import a framework package at
`[5.15.28,6.0.0)` against a `7.10.156` export and fail to resolve. The contract gains default methods rather
than abstract ones, so an existing connector keeps compiling across additive revisions.

**Only the offline blocklist ships here.** Remote sources are connectors, released on their own clock — the
core owns the contract and the enforcement, not anyone's API client. The offline list registers through the
same registry as any connector and gets no privileged path; it is also what keeps the control enforcing when a
remote source is down, which is what makes `allow` a defensible default failure policy.

## Configuration

Operator concerns in `deployment.toml`, per-organization policy in the governance store:

```toml
[event.default_listener.breach_detection]
enable = true

[breach_detection.sources.localList]
path = "${carbon.home}/repository/resources/security/breached-passwords.txt"
format = "sha1"
mmap_threshold_mb = 32
```

Source settings are namespaced on the source id, and the keys under a namespace are whatever that source
declares through `getProperties()` — so a connector this repository has never seen needs no change here to be
configured. A property marked `secret` is vault-resolved, never written to the tenant store, and never
returned by any API.

Tenant policy is a governance connector, `breachDetection`, under Password Policies. Its property list is
built from the sources bound at the time, so installing a connector adds its failure-policy setting with no
core change. Default is disabled with no sources named.

## Testing

52 unit tests across the two modules.

- The verdict resolution table row by row, plus priority ordering, short-circuiting on the first match, error
  containment per source, timeout bounding, and credential clearing.
- Blocklist loading in every accepted format, auto-detection, malformed-entry counting, case and whitespace
  significance, and the memory-mapped binary search across first/middle/last/out-of-range keys.
- Configuration resolution: declared defaults, path confinement inside the deployment, traversal refusal, and
  refusal to read a non-secret property as a secret.
- Credential handling: NFC agreement between composed and decomposed forms, masking, clearing, and refusal to
  answer once cleared.

Verified at runtime on a 7.3.0 pack across self-registration, administrative creation, administrative reset
(SCIM2 PATCH and PUT), and password recovery — including that a refusal during recovery leaves the recovery
credential valid for another attempt. With the capability off, behaviour is unchanged. No candidate password,
fragment, or digest appears in the log at INFO or DEBUG.

## Not in this PR

- **The configuration template.** The listener declaration and the `<BreachDetection>` element belong in
  `product-is`; without that change the capability cannot be switched on. A PR follows.
- **The HIBP connector**, which lives in its own repository. A PR follows there, and depends on this one for
  the SPI.
- **The Console screen.** The backend it renders from is here and published as an OSGi service —
  `BreachDetectionService.getStatus(tenantDomain)` reports installed and enabled sources as separate sets, each
  source's state, its declared settings and its counters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added breach detection for user registration, password updates, administrative resets, invitations, and recovery flows.
  * Added support for configurable local blocklists using plaintext, SHA-1, or SHA-256 formats.
  * Added source configuration, prioritization, failure policies, status reporting, and tenant-specific enforcement.
  * Added administrator-visible metrics, source health details, and reload controls.
  * Added secure credential handling and localized messages for breached or unverifiable passwords.
* **Tests**
  * Added coverage for configuration, evaluation, blocklist loading, reloading, timeouts, and credential protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->