### PR TITLE
Require email claim only for internally-managed email password recovery

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManager.java
@@ -147,7 +147,9 @@ public class NotificationPasswordRecoveryManager {
                             user.getUserName());
                 }
                 return new NotificationResponseBean(user);
-            } else if (isExistingUser(user) && StringUtils.isEmpty(Utils.getUserClaim(user,
+            } else if (isNotificationInternallyManage &&
+                    NotificationChannels.EMAIL_CHANNEL.getChannelType().equals(notificationChannel) &&
+                    StringUtils.isEmpty(Utils.getUserClaim(user,
                     IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM))) {
 
             /* If the email is not found for the user, Check for NOTIFY_RECOVERY_EMAIL_EXISTENCE property.

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManagerTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/password/NotificationPasswordRecoveryManagerTest.java
@@ -39,6 +39,7 @@ import org.wso2.carbon.identity.recovery.IdentityRecoveryClientException;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.RecoveryScenarios;
+import org.wso2.carbon.identity.recovery.RecoverySteps;
 import org.wso2.carbon.identity.recovery.bean.NotificationResponseBean;
 import org.wso2.carbon.identity.recovery.internal.IdentityRecoveryServiceDataHolder;
 import org.wso2.carbon.identity.recovery.model.UserRecoveryData;
@@ -70,6 +71,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ConnectorConfig.NOTIFICATION_BASED_PW_RECOVERY;
@@ -396,6 +398,84 @@ public class NotificationPasswordRecoveryManagerTest {
             } catch (IdentityRecoveryClientException e) {
                 assertEquals(e.getErrorCode(), IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_LOCKED_ACCOUNT.getCode());
             }
+        }
+    }
+
+    @Test
+    public void testSendRecoveryNotification_EmailLessUser_ExternallyManaged_ReturnsRecoveryKey() throws Exception {
+
+        User user = createTestUser();
+        UserRecoveryData existingRecoveryData = new UserRecoveryData(user, "test-secret-key",
+                RecoveryScenarios.NOTIFICATION_BASED_PW_RECOVERY, RecoverySteps.UPDATE_PASSWORD);
+
+        try (MockedStatic<IdentityTenantUtil> tenantUtilMock = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<IdentityUtil> identityUtilMock = mockStatic(IdentityUtil.class);
+             MockedStatic<Utils> utilsMock = mockStatic(Utils.class);
+             MockedStatic<JDBCRecoveryDataStore> jdbcRecoveryDataStoreMock = mockStatic(JDBCRecoveryDataStore.class);
+             MockedStatic<OrganizationManagementUtil> organizationManagementUtilMock = mockStatic(OrganizationManagementUtil.class)) {
+
+            jdbcRecoveryDataStoreMock.when(JDBCRecoveryDataStore::getInstance).thenReturn(userRecoveryDataStore);
+            organizationManagementUtilMock.when(() -> OrganizationManagementUtil.isOrganization(anyString()))
+                    .thenReturn(false);
+
+            setupCommonMocks(user, tenantUtilMock, identityUtilMock, utilsMock);
+
+            // Override: the user has no email claim. This is the reported bug scenario.
+            utilsMock.when(() -> Utils.getUserClaim(any(User.class),
+                    ArgumentMatchers.eq(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM))).thenReturn("");
+            utilsMock.when(() -> Utils.reIssueExistingConfirmationCode(any(), anyString())).thenReturn(true);
+            when(userRecoveryDataStore.loadWithoutCodeExpiryValidation(ArgumentMatchers.eq(user),
+                    ArgumentMatchers.eq(RecoveryScenarios.NOTIFICATION_BASED_PW_RECOVERY),
+                    ArgumentMatchers.eq(RecoverySteps.UPDATE_PASSWORD))).thenReturn(existingRecoveryData);
+
+            NotificationPasswordRecoveryManager notificationPasswordRecoveryManager =
+                    NotificationPasswordRecoveryManager.getInstance();
+
+            // notify=false: notifications are managed externally by the caller, not delivered by
+            // the server over email, so the missing email claim must not block the recovery code.
+            NotificationResponseBean result = notificationPasswordRecoveryManager.sendRecoveryNotification(
+                    user, null, false, new org.wso2.carbon.identity.recovery.model.Property[0]);
+
+            assertEquals(result.getKey(), "test-secret-key",
+                    "An email-less user with externally managed notifications should still receive the " +
+                            "recovery key.");
+        }
+    }
+
+    @Test
+    public void testSendRecoveryNotification_EmailLessUser_InternallyManagedEmailChannel_ReturnsEmptyResponse()
+            throws Exception {
+
+        User user = createTestUser();
+
+        try (MockedStatic<IdentityTenantUtil> tenantUtilMock = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<IdentityUtil> identityUtilMock = mockStatic(IdentityUtil.class);
+             MockedStatic<Utils> utilsMock = mockStatic(Utils.class);
+             MockedStatic<JDBCRecoveryDataStore> jdbcRecoveryDataStoreMock = mockStatic(JDBCRecoveryDataStore.class);
+             MockedStatic<OrganizationManagementUtil> organizationManagementUtilMock = mockStatic(OrganizationManagementUtil.class)) {
+
+            jdbcRecoveryDataStoreMock.when(JDBCRecoveryDataStore::getInstance).thenReturn(userRecoveryDataStore);
+            organizationManagementUtilMock.when(() -> OrganizationManagementUtil.isOrganization(anyString()))
+                    .thenReturn(false);
+
+            setupCommonMocks(user, tenantUtilMock, identityUtilMock, utilsMock);
+
+            // Override: the user has no email claim.
+            utilsMock.when(() -> Utils.getUserClaim(any(User.class),
+                    ArgumentMatchers.eq(IdentityRecoveryConstants.EMAIL_ADDRESS_CLAIM))).thenReturn("");
+
+            NotificationPasswordRecoveryManager notificationPasswordRecoveryManager =
+                    NotificationPasswordRecoveryManager.getInstance();
+
+            // notify=true with the default (EMAIL) channel: notifications are managed internally
+            // over email, so the missing email claim must still block recovery, exactly as before
+            // this fix. Regression guard for the fix in sendRecoveryNotification.
+            NotificationResponseBean result = notificationPasswordRecoveryManager.sendRecoveryNotification(
+                    user, NOTIFICATION_CHANNEL_EMAIL, true, new org.wso2.carbon.identity.recovery.model.Property[0]);
+
+            assertNull(result.getKey(), "An email-less user with internally managed email recovery must " +
+                    "not receive a recovery key.");
+            Mockito.verifyNoInteractions(userRecoveryDataStore);
         }
     }
 


### PR DESCRIPTION
## Summary

The v0.9 password recovery API (`POST /api/identity/recovery/v0.9/recover-password`) returns an empty `202 Accepted` instead of the recovery code when the target user has no email address, even when notifications are managed externally (`notify=false`) or sent over SMS. The email-claim requirement was applied unconditionally, without checking whether the server itself was actually about to deliver the notification over email.

## Root Cause

`NotificationPasswordRecoveryManager#sendRecoveryNotification` requires the email claim to be present whenever a user exists, regardless of the resolved notification channel or whether notifications are internally or externally managed. This means:

- Callers managing their own notifications (`notify=false`) never receive the recovery code for an email-less user, even though no email was ever going to be sent.
- Internally-managed SMS-only recovery for an email-less user silently returns an empty response instead of sending an SMS.

## Change

The email-claim check now only applies when the server is actually about to deliver the notification over email internally (`isNotificationInternallyManage && notificationChannel == EMAIL`). When notifications are externally managed, or the channel is SMS/external, the email claim is no longer required. The redundant `isExistingUser` check in the same condition was also dropped (already guaranteed by the enclosing `else` branch).

This restores the original intent of the commit that introduced the check, which was about suppressing an error page in the email-link recovery portal, not about blocking non-email recovery flows.

## Verification

- Build: succeeds cleanly against `master`.
- Existing unit tests (`NotificationPasswordRecoveryManagerTest`): 9/9 pass, unaffected.
- This is the same code change already verified at runtime against a running IS 7.3.0 server: mobile-only users calling with `notify=false` now receive the recovery code instead of an empty response; the internally-managed email path is confirmed unchanged; a user with neither email nor mobile on the SMS channel now gets a clear "mobile number not found" error instead of a silent empty success.

---
Ref: https://github.com/wso2/product-is/issues/28310


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password recovery notifications for externally managed and non-email notification channels.
  * Users are no longer shown an “email not found” error when email validation is not applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->