### PR TITLE
Add EmailVerification.DisableNotifyUnlockState as a connector property

### DIFF
--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/IdentityRecoveryConstants.java
@@ -768,6 +768,8 @@ public class IdentityRecoveryConstants {
         public static final String EMAIL_VERIFICATION_NOTIFICATION_INTERNALLY_MANAGE = "EmailVerification.Notification.InternallyManage";
         public static final String EMAIL_VERIFICATION_NOTIFICATION_ACCOUNT_ACTIVATION = "EmailVerification.AskPassword" +
                 ".AccountActivation";
+        public static final String EMAIL_VERIFICATION_DISABLE_NOTIFY_UNLOCK_STATE =
+                "EmailVerification.DisableNotifyUnlockState";
 
         public static final String TENANT_ADMIN_ASK_PASSWORD_EXPIRY_TIME = "TenantRegistrationVerification." +
                 "AskPassword.ExpiryTime";

--- a/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImpl.java
+++ b/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImpl.java
@@ -108,6 +108,8 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
                 "Manage notifications sending internally");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_ACCOUNT_ACTIVATION,
                 "Send account activation email");
+        nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_DISABLE_NOTIFY_UNLOCK_STATE,
+                "Disable account unlock email on email verification");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_EXPIRY_TIME,
                 "Email verification code expiry time");
         nameMapping.put(IdentityRecoveryConstants.ConnectorConfig.ASK_PASSWORD_EXPIRY_TIME,
@@ -148,6 +150,8 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
                 "Disable if the client application handles notification sending.");
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_ACCOUNT_ACTIVATION,
                 "Disable if account activation confirmation email is not required.");
+        descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_DISABLE_NOTIFY_UNLOCK_STATE,
+                "Disable the account unlock email that is sent when the user confirms the email verification.");
         descriptionMapping.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_EXPIRY_TIME,
                 "Set the time span that the verification e-mail would be valid, in minutes. (For infinite validity " +
                         "period, set -1)");
@@ -177,6 +181,7 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
         properties.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_ACCOUNT_LOCK_ON_CREATION);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_INTERNALLY_MANAGE);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_ACCOUNT_ACTIVATION);
+        properties.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_DISABLE_NOTIFY_UNLOCK_STATE);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_EXPIRY_TIME);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.ASK_PASSWORD_EXPIRY_TIME);
         properties.add(IdentityRecoveryConstants.ConnectorConfig.ASK_PASSWORD_TEMP_PASSWORD_GENERATOR);
@@ -198,6 +203,7 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
         String useNumbersInOTP = "true";
         String otpLength = "6";
         String enableEmailAccountLockOnCreation = "true";
+        String disableNotifyUnlockState = "false";
         String enableNotificationInternallyManage = "true";
         String sentNotificationOnAccountActivation = "true";
         String emailVerificationCodeExpiry = "1440";
@@ -234,6 +240,8 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
                 IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_INTERNALLY_MANAGE);
         String notificationOnAccountActivationProperty = IdentityUtil.getProperty(
                 IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_ACCOUNT_ACTIVATION);
+        String disableNotifyUnlockStateProperty = IdentityUtil.getProperty(
+                IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_DISABLE_NOTIFY_UNLOCK_STATE);
 
         if (StringUtils.isNotEmpty(emailVerificationProperty)) {
             enableEmailVerification = emailVerificationProperty;
@@ -270,6 +278,9 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
         }
         if (StringUtils.isNotEmpty(notificationOnAccountActivationProperty)) {
             sentNotificationOnAccountActivation = notificationOnAccountActivationProperty;
+        }
+        if (StringUtils.isNotEmpty(disableNotifyUnlockStateProperty)) {
+            disableNotifyUnlockState = disableNotifyUnlockStateProperty;
         }
         if (StringUtils.isNotEmpty(emailVerificationCodeExpiryProperty)) {
             emailVerificationCodeExpiry = emailVerificationCodeExpiryProperty;
@@ -310,6 +321,8 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
                 enableNotificationInternallyManage);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_ACCOUNT_ACTIVATION,
                 sentNotificationOnAccountActivation);
+        defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_DISABLE_NOTIFY_UNLOCK_STATE,
+                disableNotifyUnlockState);
         defaultProperties.put(IdentityRecoveryConstants.ConnectorConfig.ASK_PASSWORD_TEMP_PASSWORD_GENERATOR,
                 askPasswordTempPassExtension);
         try {
@@ -373,6 +386,9 @@ public class UserEmailVerificationConfigImpl implements IdentityConnectorConfig 
                 getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_INTERNALLY_MANAGE,
+                getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
+
+        meta.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_DISABLE_NOTIFY_UNLOCK_STATE,
                 getPropertyObject(IdentityMgtConstants.DataTypes.BOOLEAN.getValue()));
 
         meta.put(IdentityRecoveryConstants.ConnectorConfig.ASK_PASSWORD_TEMP_PASSWORD_GENERATOR,

--- a/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImplTest.java
+++ b/components/org.wso2.carbon.identity.recovery/src/test/java/org/wso2/carbon/identity/recovery/connector/UserEmailVerificationConfigImplTest.java
@@ -114,6 +114,8 @@ public class UserEmailVerificationConfigImplTest {
                 "Manage notifications sending internally");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_ACCOUNT_ACTIVATION,
                 "Send account activation email");
+        nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_DISABLE_NOTIFY_UNLOCK_STATE,
+                "Disable account unlock email on email verification");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_EXPIRY_TIME,
                 "Email verification code expiry time");
         nameMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.ASK_PASSWORD_EXPIRY_TIME,
@@ -158,6 +160,8 @@ public class UserEmailVerificationConfigImplTest {
         descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.
                         EMAIL_VERIFICATION_NOTIFICATION_ACCOUNT_ACTIVATION,
                 "Disable if account activation confirmation email is not required.");
+        descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_DISABLE_NOTIFY_UNLOCK_STATE,
+                "Disable the account unlock email that is sent when the user confirms the email verification.");
         descriptionMappingExpected.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_EXPIRY_TIME,
                 "Set the time span that the verification e-mail would be valid, in minutes. (For infinite validity " +
                         "period, set -1)");
@@ -190,6 +194,7 @@ public class UserEmailVerificationConfigImplTest {
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_ACCOUNT_LOCK_ON_CREATION);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_INTERNALLY_MANAGE);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_ACCOUNT_ACTIVATION);
+        propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_DISABLE_NOTIFY_UNLOCK_STATE);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_EXPIRY_TIME);
         propertiesExpected.add(IdentityRecoveryConstants.ConnectorConfig.ASK_PASSWORD_EXPIRY_TIME);
         String[] propertiesArrayExpected = propertiesExpected.toArray(new String[0]);
@@ -217,6 +222,7 @@ public class UserEmailVerificationConfigImplTest {
         String testEnableEmailAccountLockOnCreation = "true";
         String testEnableNotificationInternallyManage = "true";
         String testSentNotificationOnAccountActivation = "true";
+        String testDisableNotifyUnlockState = "false";
         String testEmailVerificationCodeExpiry = "1440";
         String testAskPasswordCodeExpiry = "1440";
         String testAskPasswordTempPassExtension = "org.wso2.carbon.user.mgt.common.DefaultPasswordGenerator";
@@ -250,6 +256,8 @@ public class UserEmailVerificationConfigImplTest {
                 testEnableNotificationInternallyManage);
         defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_ACCOUNT_ACTIVATION,
                 testSentNotificationOnAccountActivation);
+        defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_DISABLE_NOTIFY_UNLOCK_STATE,
+                testDisableNotifyUnlockState);
         defaultPropertiesExpected.put(IdentityRecoveryConstants.ConnectorConfig.ASK_PASSWORD_TEMP_PASSWORD_GENERATOR,
                 testAskPasswordTempPassExtension);
         try {


### PR DESCRIPTION
## Issue

`EmailVerification.DisableNotifyUnlockState` suppresses the account unlock email sent when a user confirms email verification, but it is only readable from the server level `identity.xml`. It cannot be configured per tenant.

## Fix

Register the property on the email verification connector so it resolves through `IdentityGovernanceService` per tenant. The `identity.xml` value seeds the connector default, so deployments that only set the server level property keep their current behaviour.

The consumer of this property is in the account lock handler; that change is sent separately.

## Testing

`org.wso2.carbon.identity.recovery` suite: 526 tests, 0 failures. `UserEmailVerificationConfigImplTest` updated for the new property.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to disable the account unlock email sent after email verification.
  * The option is available in the user email verification connector and defaults to disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->